### PR TITLE
Refactor: Use String for albumArtUri and simplify ViewModel logic

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -49,6 +49,7 @@ class MusicRepositoryImpl @Inject constructor(
     // --- Para getPermittedSongReferences ---
     data class MinimalSongInfo(val songId: String, val albumId: Long, val artistId: Long)
     private var cachedPermittedSongReferences: List<MinimalSongInfo>? = null
+    // ¡¡¡CAMBIO AQUÍ!!! Declara estas propiedades como miembros de la clase
     private var cachedPermittedAlbumSongCounts: Map<Long, Int>? = null
     private var cachedPermittedArtistSongCounts: Map<Long, Int>? = null
     private val permittedSongReferencesMutex = Mutex() // Mutex dedicado
@@ -245,24 +246,6 @@ class MusicRepositoryImpl @Inject constructor(
         if (page == 1) Log.i("MusicRepo/Songs", "getAudioFiles (page 1) took ${System.currentTimeMillis() - getAudioFilesStartTime} ms to return ${songsToReturn.size} songs.")
         return@withContext songsToReturn
     }
-    // Implementación de getAudioFiles con paginación MANUAL
-//    override suspend fun getAudioFiles(page: Int, pageSize: Int): List<Song> = withContext(Dispatchers.IO) {
-//        val offset = (page - 1) * pageSize
-//        if (offset < 0) throw IllegalArgumentException("Page number must be 1 or greater")
-//
-//        // Si la caché de todas las canciones filtradas no existe, la cargamos
-//        if (cachedAllSongs == null) {
-//            val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} >= ?"
-//            val selectionArgs = arrayOf("30000") // Mínimo 30 segundos
-//            val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC" // Ordenar pero SIN paginación en la consulta
-//
-//            // Consulta MediaStore para obtener *todas* las canciones válidas y filtrarlas
-//            cachedAllSongs = queryAndFilterSongs(selection, selectionArgs, sortOrder)
-//        }
-//
-//        // Aplicar Paginación MANUAL a la lista cacheada
-//        return@withContext cachedAllSongs?.drop(offset)?.take(pageSize) ?: emptyList()
-//    }
 
     override suspend fun getAlbums(page: Int, pageSize: Int): List<Album> = withContext(Dispatchers.IO) {
         val getAlbumsStartTime = System.currentTimeMillis()
@@ -371,57 +354,6 @@ class MusicRepositoryImpl @Inject constructor(
         if (page == 1) Log.i("MusicRepo/Albums", "getAlbums (page 1) took ${System.currentTimeMillis() - getAlbumsStartTime} ms to return ${albumsToReturn.size} albums.")
         return@withContext albumsToReturn
     }
-    // Implementación de getAlbums con paginación MANUAL
-//    override suspend fun getAlbums(page: Int, pageSize: Int): List<Album> = withContext(Dispatchers.IO) {
-//        val allAlbums = mutableListOf<Album>()
-//        val offset = (page - 1) * pageSize
-//        if (offset < 0) throw IllegalArgumentException("Page number must be 1 or greater")
-//
-//        val projection = arrayOf(
-//            MediaStore.Audio.Albums._ID,
-//            MediaStore.Audio.Albums.ALBUM,
-//            MediaStore.Audio.Albums.ARTIST,
-//            MediaStore.Audio.Albums.NUMBER_OF_SONGS,
-//            MediaStore.Audio.Albums.ALBUM_ART // Disponible a partir de API 29
-//        )
-//
-//        // Consulta SIN paginación en MediaStore
-//        val sortOrder = "${MediaStore.Audio.Albums.ALBUM} ASC" // Solo ordenar, sin LIMIT/OFFSET
-//
-//        val cursor: Cursor? = context.contentResolver.query(
-//            MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
-//            projection,
-//            null, // Sin selección específica por ahora
-//            null,
-//            sortOrder // Usamos el sortOrder SIN paginación
-//        )
-//        cursor?.use { c ->
-//            val idColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums._ID)
-//            val titleColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.ALBUM)
-//            val artistColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.ARTIST)
-//            val songCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.NUMBER_OF_SONGS)
-//            // val albumArtColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Albums.ALBUM_ART) // API 29+
-//
-//            while (c.moveToNext()) {
-//                val id = c.getLong(idColumn)
-//                val title = c.getString(titleColumn) ?: "Álbum Desconocido"
-//                val artist = c.getString(artistColumn) ?: "Varios Artistas"
-//                val songCount = c.getInt(songCountColumn)
-//                val albumArtUri: Uri? = ContentUris.withAppendedId(
-//                    Uri.parse("content://media/external/audio/albumart"), id
-//                )
-//
-//                if (songCount > 0) { // Solo mostrar álbumes con canciones
-//                    // Añadir *todos* los álbumes válidos a la lista temporal
-//                    allAlbums.add(Album(id, title, artist, albumArtUri, songCount))
-//                }
-//            }
-//        }
-//
-//        // --- Aplicar Paginación MANUAL a la lista completa ---
-//        return@withContext allAlbums.drop(offset).take(pageSize)
-//        // ----------------------------------------------------
-//    }
 
     override suspend fun getArtists(page: Int, pageSize: Int): List<Artist> = withContext(Dispatchers.IO) {
         val getArtistsStartTime = System.currentTimeMillis()
@@ -516,47 +448,6 @@ class MusicRepositoryImpl @Inject constructor(
         if (page == 1) Log.i("MusicRepo/Artists", "getArtists (page 1) took ${System.currentTimeMillis() - getArtistsStartTime} ms to return ${artistsToReturn.size} artists.")
         return@withContext artistsToReturn
     }
-    // Implementación de getArtists con paginación MANUAL
-//    override suspend fun getArtists(page: Int, pageSize: Int): List<Artist> = withContext(Dispatchers.IO) {
-//        val allArtists = mutableListOf<Artist>()
-//        val offset = (page - 1) * pageSize
-//        if (offset < 0) throw IllegalArgumentException("Page number must be 1 or greater")
-//
-//        val projection = arrayOf(
-//            MediaStore.Audio.Artists._ID,
-//            MediaStore.Audio.Artists.ARTIST,
-//            MediaStore.Audio.Artists.NUMBER_OF_TRACKS
-//        )
-//
-//        // Consulta SIN paginación en MediaStore
-//        val sortOrder = "${MediaStore.Audio.Artists.ARTIST} ASC" // Solo ordenar, sin LIMIT/OFFSET
-//
-//        val cursor: Cursor? = context.contentResolver.query(
-//            MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI,
-//            projection,
-//            null,
-//            null,
-//            sortOrder // Usamos el sortOrder SIN paginación
-//        )
-//        cursor?.use { c ->
-//            val idColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists._ID)
-//            val nameColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.ARTIST)
-//            val trackCountColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Artists.NUMBER_OF_TRACKS)
-//            while (c.moveToNext()) {
-//                val id = c.getLong(idColumn)
-//                val name = c.getString(nameColumn) ?: "Artista Desconocido"
-//                val trackCount = c.getInt(trackCountColumn)
-//                if (trackCount > 0) { // Solo mostrar artistas con canciones
-//                    // Añadir *todos* los artistas válidos a la lista temporal
-//                    allArtists.add(Artist(id, name, trackCount))
-//                }
-//            }
-//        }
-//
-//        // --- Aplicar Paginación MANUAL a la lista completa ---
-//        return@withContext allArtists.drop(offset).take(pageSize)
-//        // ---------------------------------------------------
-//    }
 
     // --- Funciones que usan queryAndFilterSongs (sin paginación propia, filtran por directorio) ---
     override suspend fun getSongsForAlbum(albumId: Long): List<Song> = withContext(Dispatchers.IO) {
@@ -602,8 +493,8 @@ class MusicRepositoryImpl @Inject constructor(
                 }
                 // Populate new caches
                 val refs = cachedPermittedSongReferences ?: emptyList()
-                this.cachedPermittedAlbumSongCounts = refs.groupBy { it.albumId }.mapValues { entry -> entry.value.size }
-                this.cachedPermittedArtistSongCounts = refs.groupBy { it.artistId }.mapValues { entry -> entry.value.size }
+                cachedPermittedAlbumSongCounts = refs.groupBy { it.albumId }.mapValues { entry -> entry.value.size }
+                cachedPermittedArtistSongCounts = refs.groupBy { it.artistId }.mapValues { entry -> entry.value.size }
                 Log.i("MusicRepo/Refs", "Populated cachedPermittedSongReferences with ${cachedPermittedSongReferences?.size} items. Album counts: ${cachedPermittedAlbumSongCounts?.size}, Artist counts: ${cachedPermittedArtistSongCounts?.size}. Cold load took ${System.currentTimeMillis() - coldLoadStartTime} ms")
             }
         }
@@ -614,33 +505,15 @@ class MusicRepositoryImpl @Inject constructor(
 // Podrías llamarla desde UserPreferencesRepository o desde un ViewModel que observe los cambios de directorio.
     fun invalidatePermittedSongReferencesCache() {
         Log.d("MusicRepositoryImpl", "Invalidating cachedPermittedSongReferences.")
-        // Considera el scope de la corrutina si no estás en un ViewModel.
-        // Si estás en un ViewModel, usa viewModelScope.launch.
-        // Aquí, como es una función del repositorio, no tiene viewModelScope.
-        // Se puede hacer que el ViewModel llame a esta función dentro de su propio scope.
-        // O, si este repositorio tiene su propio CoroutineScope, usarlo.
-        // Por simplicidad, la invalidación es síncrona respecto al Mutex para la próxima lectura.
-        // kotlinx.coroutines.GlobalScope.launch { // ¡Evitar GlobalScope en producción! Usar un scope gestionado.
-        //     permittedSongReferencesMutex.withLock {
-        //         cachedPermittedSongReferences = null
-        //     }
-        // }
-        // Una forma más simple de invalidar para la próxima lectura:
         this.cachedPermittedSongReferences = null
-        // La próxima llamada a getPermittedSongReferences (con el mutex) lo recargará.
     }
 
-    // Método para invalidar la caché cuando cambian los directorios permitidos.
-    // Llamar desde el ViewModel/lugar apropiado cuando UserPreferencesRepository.allowedDirectoriesFlow emita un nuevo valor.
+    // Méthod para invalidar la caché cuando cambian los directorios permitidos.
     override suspend fun invalidateCachesDependentOnAllowedDirectories() {
         Log.i("MusicRepo", "Invalidating caches dependent on allowed directories (cachedPermittedSongReferences).")
-        // No es necesario GlobalScope aquí, simplemente nulificar para la próxima carga.
-        // El mutex en getPermittedSongReferences manejará la recarga segura.
         this.cachedPermittedSongReferences = null
         this.cachedPermittedAlbumSongCounts = null
         this.cachedPermittedArtistSongCounts = null
-        // Considera si cachedAudioDirectories también necesita invalidarse aquí.
-        // this.cachedAudioDirectories = null; // Si getAllUniqueAudioDirectories debe re-escanear
     }
 
 
@@ -660,10 +533,6 @@ class MusicRepositoryImpl @Inject constructor(
                     File(c.getString(dataColumn)).parent?.let { directories.add(it) }
                 }
             }
-            // La lógica de actualizar UserPreferencesRepository si !initialSetupDone está bien aquí.
-            // Asegúrate que UserPreferencesRepository.updateAllowedDirectories también llame a
-            // UserPreferencesRepository.setInitialSetupDone(true) o que lo hagas explícitamente.
-            // También, considera llamar a invalidatePermittedSongReferencesCache() si los directorios cambian.
             val initialSetupDone = userPreferencesRepository.initialSetupDoneFlow.first()
             if (!initialSetupDone && directories.isNotEmpty()) {
                 Log.i("MusicRepo", "Initial setup: saving all found audio directories (${directories.size}) as allowed.")
@@ -674,49 +543,6 @@ class MusicRepositoryImpl @Inject constructor(
             return@withContext directories
         }
     }
-    // Función para obtener todos los directorios únicos que contienen audio
-    // Usado por SettingsViewModel
-//    override suspend fun getAllUniqueAudioDirectories(): Set<String> = withContext(Dispatchers.IO) {
-//        // Usamos un Mutex para asegurar que solo un escaneo de directorios se ejecute a la vez
-//        directoryScanMutex.withLock {
-//            // Si ya hemos escaneado los directorios recientemente, devolvemos la caché.
-//            cachedAudioDirectories?.let { return@withContext it }
-//
-//            // Si no hay caché, realizamos la consulta a MediaStore para *todos* los directorios.
-//            val directories = mutableSetOf<String>()
-//            val projection = arrayOf(MediaStore.Audio.Media.DATA)
-//            val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
-//
-//            // Consulta SIN paginación para obtener TODOS los directorios
-//            val cursor: Cursor? = context.contentResolver.query(
-//                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-//                projection,
-//                selection,
-//                null,
-//                null // No hay LIMIT/OFFSET ni ORDER BY aquí
-//            )
-//            cursor?.use { c ->
-//                val dataColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
-//                while (c.moveToNext()) {
-//                    val filePath = c.getString(dataColumn)
-//                    File(filePath).parent?.let { directories.add(it) }
-//                }
-//            }
-//
-//            // Si el setup inicial no se ha hecho, guardar todos los directorios encontrados como permitidos.
-//            val initialSetupDone = userPreferencesRepository.initialSetupDoneFlow.first()
-//            if (!initialSetupDone && directories.isNotEmpty()) {
-//                userPreferencesRepository.updateAllowedDirectories(directories) // Esto ya marca el setup como hecho
-//                // La siguiente línea ya no es necesaria si updateAllowedDirectories lo maneja,
-//                // pero si quieres llamarla explícitamente por claridad o en otros escenarios:
-//                // userPreferencesRepository.setInitialSetupDone(true)
-//            }
-//
-//            // Cachear los directorios encontrados en este escaneo completo
-//            cachedAudioDirectories = directories
-//            return@withContext directories
-//        } // Fin del Mutex lock
-//    }
 
     override suspend fun getAllUniqueAlbumArtUris(): List<Uri> = withContext(Dispatchers.IO) {
         val uris = mutableSetOf<Uri>()
@@ -770,30 +596,4 @@ class MusicRepositoryImpl @Inject constructor(
         Log.d("MusicRepo", "getAllUniqueAlbumArtUris returning ${uris.size} URIs.")
         return@withContext uris.toList()
     }
-//    override suspend fun getAllUniqueAlbumArtUris(): List<Uri> = withContext(Dispatchers.IO) {
-//        val uris = mutableSetOf<Uri>() // Usar Set para evitar duplicados
-//        val projection = arrayOf(MediaStore.Audio.Media.ALBUM_ID)
-//        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
-//        val cursor: Cursor? = context.contentResolver.query(
-//            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-//            projection,
-//            selection,
-//            null,
-//            null // No necesitamos orden específico aquí
-//        )
-//        cursor?.use { c ->
-//            val albumIdColumn = c.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
-//            while (c.moveToNext()) {
-//                val albumId = c.getLong(albumIdColumn)
-//                val albumArtUri: Uri = ContentUris.withAppendedId(
-//                    Uri.parse("content://media/external/audio/albumart"),
-//                    albumId
-//                )
-//                // Verificar si la URI es válida o si la carátula existe podría ser una optimización,
-//                // pero Coil ya maneja errores de carga.
-//                uris.add(albumArtUri)
-//            }
-//        }
-//        return@withContext uris.toList()
-//    }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
@@ -58,7 +58,7 @@ import okhttp3.internal.toImmutableList
  */
 @Composable
 fun AlbumArtCollage(
-    albumArts: ImmutableList<Uri?>,
+    albumArts: ImmutableList<String?>,
     modifier: Modifier = Modifier,
     height: Dp = 400.dp,
     padding: Dp = 0.dp

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
@@ -132,7 +132,7 @@ private fun DailyMixHeader(thumbnails: ImmutableList<Song>) {
                             .border(2.dp, MaterialTheme.colorScheme.surface, CircleShape)
                     ) {
                         SmartImage(
-                            model = song.albumArtUri ?: R.drawable.rounded_album_24,
+                            model = song.albumArtUriString ?: R.drawable.rounded_album_24,
                             contentDescription = null,
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ModernSongCard.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ModernSongCard.kt
@@ -65,7 +65,7 @@ fun ModernSongCard(
                     .clip(RoundedCornerShape(12.dp))
             ) {
                 AsyncImage(
-                    model = song.albumArtUri ?: painterResource(R.drawable.rounded_music_note_24),
+                    model = song.albumArtUriString ?: painterResource(R.drawable.rounded_music_note_24),
                     contentDescription = "Album art for ${song.title}",
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.Dispatchers
 @OptIn(ExperimentalCoilApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun OptimizedAlbumArt(
-    uri: Uri,
+    uri: String,
     title: String,
     expansionFraction: Float,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -680,7 +680,7 @@ private fun MiniPlayerContentInternal(
         verticalAlignment = Alignment.CenterVertically
     ) {
         SmartImage(
-            model = song.albumArtUri ?: R.drawable.rounded_album_24,
+            model = song.albumArtUriString ?: R.drawable.rounded_album_24,
             contentDescription = "Carátula de ${song.title}",
             shape = CircleShape,
             modifier = Modifier
@@ -879,7 +879,7 @@ private fun FullPlayerContentInternal(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // Album Cover - Asegurando suficiente espacio
-            song.albumArtUri?.let {
+            song.albumArtUriString?.let {
                 OptimizedAlbumArt(
                     uri = it,
                     title = song.title,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -98,10 +98,10 @@ fun HomeScreen(
         .collectAsState(initial = null)
 
     // 3) Calcular y recordar los URIs para el header
-    val recentUrisForHeader: ImmutableList<Uri?> = remember(allSongs) {
+    val recentUrisForHeader: ImmutableList<String?> = remember(allSongs) {
         allSongs
             .take(6)
-            .map { it.albumArtUri }
+            .map { it.albumArtUriString }
             .toImmutableList() // Convierte la List resultante a ImmutableList
     }
 
@@ -420,7 +420,7 @@ fun SongListItemFavs(
     cardCorners: Dp = 12.dp,
     title: String,
     artist: String,
-    albumArtUrl: Uri?,
+    albumArtUrl: String?,
     isPlaying: Boolean,
     onClick: () -> Unit
 ) {
@@ -608,7 +608,7 @@ fun SongListItemFavsWrapper(
         modifier = modifier, // El modifier se aplica a la Card
         title = song.title,
         artist = song.artist, // Usamos song.artist
-        albumArtUrl = song.albumArtUri.toString(), // Usamos song.albumArtUri
+        albumArtUrl = song.albumArtUriString, // Usamos song.albumArtUri
         isPlaying = isThisSongPlaying,
         onClick = onClick,
         itemWidth = itemWidth // Pasamos el ancho al composable de la tarjeta
@@ -645,32 +645,8 @@ fun SongListItemFavsWrapper(
         cardCorners = 0.dp,
         title         = song.title,
         artist        = song.artist,
-        albumArtUrl   = song.albumArtUri,
+        albumArtUrl   = song.albumArtUriString,
         isPlaying     = isThisSongPlaying,
         onClick       = onClick
     )
 }
-
-//@Composable
-//fun SongListItemFavsWrapper(
-//    song: Song,
-//    playerViewModel: PlayerViewModel,
-//    onClick: () -> Unit,
-//    modifier: Modifier = Modifier
-//) {
-//    // Observe only the necessary parts of playerUiState for *this specific song*
-//    val currentPlayingSongId by playerViewModel.playerUiState.map { it.currentSong?.id }.collectAsState(initial = null)
-//    val isGlobalPlaying by playerViewModel.playerUiState.map { it.isPlaying }.collectAsState(initial = false)
-//
-//    val isThisSongPlaying = song.id == currentPlayingSongId && isGlobalPlaying
-//
-//    // Call the presentational Composable with the derived state
-//    SongListItemFavs(
-//        modifier = modifier,
-//        title = song.title,
-//        artist = song.artist,
-//        albumArtUrl = song.albumArtUri,
-//        isPlaying = isThisSongPlaying,
-//        onClick = onClick
-//    )
-//}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -525,7 +525,7 @@ fun LibraryFavoritesTab(
                 SongListItemFavs(
                     title = song.title,
                     artist = song.artist,
-                    albumArtUrl = song.albumArtUri,
+                    albumArtUrl = song.albumArtUriString,
                     isPlaying = isPlayingThisSong,
                     onClick = { playerViewModel.showAndPlaySong(song) }
                 )
@@ -646,7 +646,7 @@ fun EnhancedSongListItem(
                     .background(MaterialTheme.colorScheme.surfaceVariant)
             ) {
                 SmartImage(
-                    model = song.albumArtUri ?: R.drawable.rounded_album_24,
+                    model = song.albumArtUriString ?: R.drawable.rounded_album_24,
                     contentDescription = song.title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxSize()
@@ -763,7 +763,7 @@ fun LibraryAlbumsTab(uiState: PlayerUiState, playerViewModel: PlayerViewModel, b
                     Spacer(Modifier.height(8.dp))
                 }
                 items(uiState.albums, key = { "album_${it.id}" }) { album ->
-                    val albumSpecificColorSchemeFlow = playerViewModel.getAlbumColorSchemeFlow(album.albumArtUri)
+                    val albumSpecificColorSchemeFlow = playerViewModel.getAlbumColorSchemeFlow(album.albumArtUriString)
                     AlbumGridItemRedesigned( // Usar el nuevo Composable
                         album = album,
                         albumColorSchemePairFlow = albumSpecificColorSchemeFlow,
@@ -849,7 +849,7 @@ fun AlbumGridItemRedesigned(
         ) {
             Box(contentAlignment = Alignment.BottomStart) {
                 SmartImage(
-                    model = album.albumArtUri ?: R.drawable.rounded_album_24,
+                    model = album.albumArtUriString ?: R.drawable.rounded_album_24,
                     contentDescription = "Carátula de ${album.title}",
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.aspectRatio(3f/2f).fillMaxSize()
@@ -888,34 +888,6 @@ fun AlbumGridItemRedesigned(
     }
 }
 
-//@Composable
-//fun LibraryAlbumsTab(uiState: PlayerUiState, playerViewModel: PlayerViewModel) {
-//    val gridState = rememberLazyGridState()
-//    if (uiState.isLoadingLibraryCategories && uiState.albums.isEmpty()) { /* ... Loading ... */ }
-//    else if (uiState.albums.isEmpty() && !uiState.canLoadMoreAlbums) { /* ... No albums ... */ }
-//    else {
-//        LazyVerticalGrid(
-//            state = gridState,
-//            columns = GridCells.Fixed(2),
-//            contentPadding = PaddingValues(16.dp),
-//            verticalArrangement = Arrangement.spacedBy(16.dp),
-//            horizontalArrangement = Arrangement.spacedBy(16.dp)
-//        ) {
-//            items(uiState.albums, key = { it.id }) { album -> AlbumGridItem(album = album) { playerViewModel.playAlbum(album) } }
-//            if (uiState.isLoadingLibraryCategories && uiState.albums.isNotEmpty()) { // Mostrar loader al final si está cargando más
-//                item { Box(Modifier
-//                    .fillMaxWidth()
-//                    .padding(8.dp), Alignment.Center) { CircularProgressIndicator() } }
-//            }
-//        }
-//        InfiniteGridHandler(gridState = gridState) {
-//            if (uiState.canLoadMoreAlbums && !uiState.isLoadingLibraryCategories) {
-//                playerViewModel.loadMoreAlbums()
-//            }
-//        }
-//    }
-//}
-
 @Composable
 fun LibraryArtistsTab(uiState: PlayerUiState, playerViewModel: PlayerViewModel) {
     val listState = rememberLazyListState() // Artistas en una lista por ahora
@@ -951,7 +923,7 @@ fun AlbumGridItem(album: Album, onClick: () -> Unit) {
     ) {
         Column {
             SmartImage(
-                model = album.albumArtUri ?: R.drawable.rounded_album_24,
+                model = album.albumArtUriString ?: R.drawable.rounded_album_24,
                 contentDescription = "Carátula de ${album.title}",
                 contentScale = ContentScale.Crop,
             )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -397,7 +397,7 @@ fun PlaylistSongItem(
                 modifier = Modifier.padding(end = 12.dp)
             )
             SmartImage(
-                model = song.albumArtUri,
+                model = song.albumArtUriString,
                 shape = RoundedCornerShape(8.dp),
                 contentDescription = "Carátula",
                 modifier = Modifier.size(48.dp).clip(RoundedCornerShape(8.dp)),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -399,7 +399,7 @@ fun ExpressiveSongListItem(
                     )
             ) {
                 SmartImage(
-                    model = song.albumArtUri,
+                    model = song.albumArtUriString,
                     contentDescription = "Album Art",
                     contentScale = ContentScale.Crop,
                     shape = RoundedCornerShape(18.dp),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -29,15 +29,6 @@ data class PlaylistUiState(
     val canLoadMoreSongsForSelection: Boolean = true // Nuevo: para saber si hay más canciones para cargar
 )
 
-//data class PlaylistUiState(
-//    val playlists: List<Playlist> = emptyList(),
-//    val currentPlaylistSongs: List<Song> = emptyList(),
-//    val currentPlaylistDetails: Playlist? = null,
-//    val isLoading: Boolean = false,
-//    val songSelectionForPlaylist: List<Song> = emptyList(), // Para el diálogo de selección
-//    val isLoadingSongSelection: Boolean = false
-//)
-
 @HiltViewModel
 class PlaylistViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -98,21 +98,6 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-//    fun toggleDirectoryAllowed(directoryItem: DirectoryItem) {
-//        viewModelScope.launch {
-//            val currentAllowed = userPreferencesRepository.allowedDirectoriesFlow.first().toMutableSet()
-//            if (directoryItem.isAllowed) {
-//                currentAllowed.remove(directoryItem.path)
-//            } else {
-//                currentAllowed.add(directoryItem.path)
-//            }
-//            // Guardar el conjunto actualizado en preferencias
-//            userPreferencesRepository.updateAllowedDirectories(currentAllowed)
-//            // El flujo allowedDirectoriesFlow en loadDirectoryPreferences() detectará el cambio
-//            // y regenerará la lista directoryItems automáticamente.
-//        }
-//    }
-
     // Método para guardar la preferencia de tema global
     fun setGlobalThemePreference(preference: String) {
         viewModelScope.launch {


### PR DESCRIPTION
This commit introduces the following changes:

- Replaced `Uri` with `String` for `albumArtUri` and `albumArtUriString` throughout the codebase. This simplifies handling and potential nullability issues.
- Removed unused and commented-out code from `MusicRepositoryImpl.kt`, `LibraryScreen.kt`, `PlayerViewModel.kt`, `PlaylistViewModel.kt`, and `SettingsViewModel.kt` for improved readability and maintenance.
- In `PlayerViewModel.kt`:
    - Simplified `favoriteSongs` flow initialization.
    - Updated `resetAndLoadInitialData` to use `toImmutableList()` for empty lists.
    - Adjusted `getAlbumColorSchemeFlow` and `getOrGenerateColorSchemeForUri` to accept `String` for `albumArtUri`.
- In `HomeScreen.kt`:
    - Updated `recentUrisForHeader` to use `String?` and `map { it.albumArtUriString }`.
- In `AlbumArtCollage.kt`:
    - Modified `AlbumArtCollage` to accept `ImmutableList<String?>` for `albumArts`.
- Updated various composables (`ModernSongCard.kt`, `LibraryScreen.kt`, `SearchScreen.kt`, `UnifiedPlayerSheet.kt`, `DailyMixSection.kt`, `OptimizedAlbumArt.kt`, `PlaylistDetailScreen.kt`) to use the new `String` type for album art URIs.