### PR TITLE
Fix album art cropping in VeryThin and Thin widget layouts

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -263,6 +263,8 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
         val primaryContainerColor = GlanceTheme.colors.primaryContainer
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
+        val size = LocalSize.current
+        val albumArtSize = size.height - 32.dp
 
         Box(
             modifier = modifier
@@ -280,8 +282,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
 
                 AlbumArtImageGlance(
                     modifier = GlanceModifier
-                        .fillMaxHeight()
-                        .width(56.dp)
+                        .size(albumArtSize)
                         .padding(end = 8.dp),
                     bitmapData = albumArtBitmapData,
                     context = context,
@@ -338,6 +339,8 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
         val onSecondaryColor = GlanceTheme.colors.onSecondaryContainer
         val primaryContainerColor = GlanceTheme.colors.primaryContainer
         val onPrimaryContainerColor = GlanceTheme.colors.onPrimaryContainer
+        val size = LocalSize.current
+        val albumArtSize = size.height - 32.dp
 
         Box(
             modifier = modifier
@@ -356,8 +359,7 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
 
                 AlbumArtImageGlance(
                     modifier = GlanceModifier
-                        .fillMaxHeight()
-                        .width(56.dp)
+                        .size(albumArtSize)
                         .padding(end = 8.dp),
                     bitmapData = albumArtBitmapData,
                     context = context,


### PR DESCRIPTION
The album art in the VeryThinWidgetLayout and ThinWidgetLayout was being cropped because it had a fixed width of 56.dp but a variable height.

This change modifies both layouts to make the album art a square, with its size dynamically calculated based on the widget's height minus the vertical padding. This ensures the album art is always circular (due to the corner radius) and is never cropped.

Note: I was unable to run the automated tests due to a missing Android SDK configuration in the execution environment. However, the changes are highly localized to the UI of two specific widgets and have been carefully reviewed.