### PR TITLE
feat: Re-enable AI metadata generation button

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
@@ -172,30 +172,30 @@ fun EditSongSheet(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-//                    Box(
-//                        modifier = Modifier
-//                            .size(40.dp)
-//                            .clip(CircleShape)
-//                            .background(
-//                                brush = Brush.horizontalGradient(
-//                                    colors = listOf(
-//                                        MaterialTheme.colorScheme.primary,
-//                                        MaterialTheme.colorScheme.secondary,
-//                                        MaterialTheme.colorScheme.tertiary
-//                                    )
-//                                )
-//                            )
-//                    ) {
-//                        IconButton(onClick = { showAiDialog = true }) {
-//                            Icon(
-//                                modifier = Modifier
-//                                    .size(20.dp),
-//                                painter = painterResource(id = R.drawable.gemini_ai),
-//                                contentDescription = "Use Gemini AI",
-//                                tint = MaterialTheme.colorScheme.onPrimary
-//                            )
-//                        }
-//                    }
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(
+                                brush = Brush.horizontalGradient(
+                                    colors = listOf(
+                                        MaterialTheme.colorScheme.primary,
+                                        MaterialTheme.colorScheme.secondary,
+                                        MaterialTheme.colorScheme.tertiary
+                                    )
+                                )
+                            )
+                    ) {
+                        IconButton(onClick = { showAiDialog = true }) {
+                            Icon(
+                                modifier = Modifier
+                                    .size(20.dp),
+                                painter = painterResource(id = R.drawable.gemini_ai),
+                                contentDescription = "Use Gemini AI",
+                                tint = MaterialTheme.colorScheme.onPrimary
+                            )
+                        }
+                    }
                     FilledTonalIconButton(
                         onClick = { showInfoDialog = true },
                         shape = CircleShape


### PR DESCRIPTION
This commit re-enables the "Use Gemini AI" button in the `EditSongSheet`.

The button, which was previously commented out, allows users to trigger AI-powered metadata generation for the song. It is styled with a circular background using a horizontal gradient of primary, secondary, and tertiary colors, and displays the Gemini AI icon. Clicking the button now sets `showAiDialog` to true, presumably to open a dialog for AI interaction.