### PR TITLE
Fix: Handle float duration in lyrics API response

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/network/lyrics/LrcLibResponse.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/lyrics/LrcLibResponse.kt
@@ -11,7 +11,7 @@ data class LrcLibResponse(
     val name: String,
     val artistName: String,
     val albumName: String,
-    val duration: Int,
+    val duration: Double,
     @SerializedName("plainLyrics")
     val plainLyrics: String?,
     @SerializedName("syncedLyrics")


### PR DESCRIPTION
The `duration` field in the `LrcLibResponse` data class was changed from `Int` to `Double` to prevent a `JsonSyntaxException` when the lrclib.net API returns a floating-point number for the song duration. This fixes a crash when fetching lyrics for certain songs.