### PR TITLE
Fixes UI and player visibility on Navbar Corner Radius Screen.

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -359,7 +359,7 @@ fun UnifiedPlayerSheet(
         miniPlayerAndSpacerHeightPx,
         navBarHeightPx
     ) {
-        val playerSlotHeightContribution = if (isPlayerSlotOccupied) miniPlayerAndSpacerHeightPx else 0f
+        val playerSlotHeightContribution = if (isPlayerSlotOccupied && !hideNavBar) miniPlayerAndSpacerHeightPx else 0f
         val navHeight = if (hideNavBar) 0f else navBarHeightPx
         playerSlotHeightContribution + navHeight
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/NavBarCornerRadiusScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/NavBarCornerRadiusScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -42,12 +41,12 @@ fun NavBarCornerRadiusScreen(
                     }
                 }
             )
-        },
-        containerColor = Color.LightGray.copy(alpha = 0.9f)
+        }
     ) { paddingValues ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
                 .padding(top = paddingValues.calculateTopPadding())
                 .padding(bottom = paddingValues.calculateBottomPadding())
         ) {
@@ -55,7 +54,7 @@ fun NavBarCornerRadiusScreen(
                 text = "Match the black area's corners with your device's corners",
                 style = MaterialTheme.typography.headlineSmall,
                 textAlign = TextAlign.Center,
-                color = Color.Black,
+                color = MaterialTheme.colorScheme.onBackground,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(16.dp)
@@ -72,9 +71,9 @@ fun NavBarCornerRadiusScreen(
                     onValueChange = { sliderValue = it },
                     valueRange = 0f..50f,
                     colors = SliderDefaults.colors(
-                        thumbColor = Color.Black,
-                        activeTrackColor = Color.Black,
-                        inactiveTrackColor = Color.LightGray
+                        thumbColor = MaterialTheme.colorScheme.primary,
+                        activeTrackColor = MaterialTheme.colorScheme.primary,
+                        inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
                     ),
                     modifier = Modifier
                         .fillMaxWidth()
@@ -87,7 +86,7 @@ fun NavBarCornerRadiusScreen(
                         .fillMaxWidth()
                         .height(80.dp)
                         .padding(horizontal = paddingValues.calculateBottomPadding()),
-                    color = Color.Black,
+                    color = MaterialTheme.colorScheme.onBackground,
                     shape = AbsoluteSmoothCornerShape(
                         cornerRadiusTL = 10.dp,
                         smoothnessAsPercentBL = 60,


### PR DESCRIPTION
This commit addresses two issues on the Navbar Corner Radius screen:
1.  The mini-player is now correctly hidden when the screen is active. This was fixed by adjusting the height calculation in `UnifiedPlayerSheet.kt` to ensure its height collapses to zero when the `hideNavBar` flag is true.
2.  The screen's UI has been updated from a hardcoded black and white theme to use Material 3 colors from the application's theme, ensuring high contrast and a consistent look and feel.

Testing:
Unit tests could not be run due to the execution environment lacking an Android SDK configuration. The changes were purely in the UI layer and were validated through a successful code review.