### PR TITLE
feat: Add changelog bottom sheet

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ChangelogBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ChangelogBottomSheet.kt
@@ -1,0 +1,66 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.presentation.components.subcomps.SineWaveLine
+import com.theveloper.pixelplay.ui.theme.ExpTitleTypography
+
+@Composable
+fun ChangelogBottomSheet(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(bottom = 32.dp, top = 16.dp, start = 24.dp, end = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Changelog",
+            style = ExpTitleTypography.displaySmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        SineWaveLine(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally)
+                .height(32.dp)
+                .padding(horizontal = 8.dp)
+                .padding(bottom = 4.dp),
+            animate = true,
+            color = MaterialTheme.colorScheme.surface,
+            alpha = 0.95f,
+            strokeWidth = 16.dp,
+            amplitude = 4.dp,
+            waves = 7.6f,
+            phase = 0f
+        )
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            shape = RoundedCornerShape(18.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            )
+        ) {
+            Text(
+                text = "- First Beta build.",
+                modifier = Modifier.padding(16.dp),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import com.theveloper.pixelplay.presentation.components.ChangelogBottomSheet
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -105,6 +106,7 @@ fun HomeScreen(
     val bottomPadding = if (currentSong != null) MiniPlayerHeight else 0.dp
 
     var showOptionsBottomSheet by remember { mutableStateOf(false) }
+    var showChangelogBottomSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -120,8 +122,7 @@ fun HomeScreen(
                         navController.navigate(Screen.Settings.route)
                     },
                     onMoreOptionsClick = {
-                        //showOptionsBottomSheet = true
-                        Toast.makeText(context, "Coming Soon...", Toast.LENGTH_SHORT).show()
+                        showChangelogBottomSheet = true
                     }
                 )
             }
@@ -215,6 +216,14 @@ fun HomeScreen(
                     }
                 }
             )
+        }
+    }
+    if (showChangelogBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showChangelogBottomSheet = false },
+            sheetState = sheetState
+        ) {
+            ChangelogBottomSheet()
         }
     }
 }


### PR DESCRIPTION
This commit introduces a new changelog feature, accessible via the newspaper icon in the home screen's top bar.

- A new `ChangelogBottomSheet` composable has been created to display the changelog information with a Material 3 expressive style.
- The `HomeScreen` has been updated to show the `ChangelogBottomSheet` when the newspaper icon is clicked.