### PR TITLE
Fix: Adjust full player layout for tall screens

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -1595,7 +1595,8 @@ private fun FullPlayerContentInternal(
                     horizontal = lerp(8.dp, 24.dp, expansionFraction),
                     vertical = lerp(0.dp, 16.dp, expansionFraction)
                 ),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceAround
         ) {
             // Album Cover section
             val albumArtContainerModifier = Modifier
@@ -1637,38 +1638,38 @@ private fun FullPlayerContentInternal(
                 timeTextColor = LocalMaterialTheme.current.onPrimaryContainer.copy(alpha = 0.7f)
             )
 
-            Spacer(modifier = Modifier.weight(1f))
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                AnimatedPlaybackControls(
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    isPlaying = isPlaying,
+                    onPrevious = onPrevious,
+                    onPlayPause = onPlayPause,
+                    onNext = onNext,
+                    height = 80.dp,
+                    pressAnimationSpec = stableControlAnimationSpec,
+                    releaseDelay = 220L,
+                    colorOtherButtons = controlOtherButtonsColor,
+                    colorPlayPause = controlPlayPauseColor,
+                    tintPlayPauseIcon = controlTintPlayPauseIcon,
+                    tintOtherIcons = controlTintOtherIcons
+                )
 
-            AnimatedPlaybackControls(
-                modifier = Modifier
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
-                isPlaying = isPlaying,
-                onPrevious = onPrevious,
-                onPlayPause = onPlayPause,
-                onNext = onNext,
-                height = 80.dp,
-                pressAnimationSpec = stableControlAnimationSpec,
-                releaseDelay = 220L,
-                colorOtherButtons = controlOtherButtonsColor,
-                colorPlayPause = controlPlayPauseColor,
-                tintPlayPauseIcon = controlTintPlayPauseIcon,
-                tintOtherIcons = controlTintOtherIcons
-            )
+                Spacer(modifier = Modifier.height(14.dp))
 
-            Spacer(modifier = Modifier.height(14.dp))
-
-            BottomToggleRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 58.dp, max = 88.dp)
-                    .padding(horizontal = 26.dp, vertical = 8.dp),
-                isShuffleEnabled = isShuffleEnabled,
-                repeatMode = repeatMode,
-                isFavorite = isFavorite,
-                onShuffleToggle = onShuffleToggle,
-                onRepeatToggle = onRepeatToggle,
-                onFavoriteToggle = onFavoriteToggle
-            )
+                BottomToggleRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 58.dp, max = 88.dp)
+                        .padding(horizontal = 26.dp, vertical = 8.dp),
+                    isShuffleEnabled = isShuffleEnabled,
+                    repeatMode = repeatMode,
+                    isFavorite = isFavorite,
+                    onShuffleToggle = onShuffleToggle,
+                    onRepeatToggle = onRepeatToggle,
+                    onFavoriteToggle = onFavoriteToggle
+                )
+            }
         }
     }
     AnimatedVisibility(


### PR DESCRIPTION
The previous layout used a weighted spacer, which caused large vertical gaps between UI elements on tall aspect-ratio devices.

This commit refactors the layout of the `FullPlayerContentInternal` composable to use `Arrangement.SpaceAround` on the main `Column`. This distributes the available vertical space more evenly among the album art, song info, progress bar, and playback controls.

The playback controls and bottom toggle row have been wrapped in a new `Column` to ensure they remain grouped together at the bottom of the screen.