### PR TITLE
feat(compose): Add keys to all LazyColumn and LazyVerticalGrid instances

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AiMetadataDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AiMetadataDialog.kt
@@ -35,7 +35,10 @@ fun AiMetadataDialog(
                 Text("Select the fields you want to generate:")
                 Spacer(modifier = Modifier.height(16.dp))
                 LazyColumn {
-                    items(missingFields) { field ->
+                    items(
+                        items = missingFields,
+                        key = { it }
+                    ) { field ->
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -165,7 +165,10 @@ fun CastBottomSheet(
                     LazyColumn(
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        items(routes.toList(), key = { it.id }) { route ->
+                        items(
+                            items = routes.toList(),
+                            key = { it.id }
+                        ) { route ->
                             if (!route.isDefault) {
                                 DeviceItem(
                                     route = route,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -366,7 +366,7 @@ fun LyricsSheet(
                             }
 
                             if (lyrics!!.areFromRemote) {
-                                item {
+                                item(key = "provider_text") {
                                     ProviderText(
                                         providerText = context.resources.getString(R.string.lyrics_provided_by),
                                         uri = context.resources.getString(R.string.lrclib_uri),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
@@ -245,7 +245,7 @@ fun AboutScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // App info section
-            item {
+            item(key = "app_info_header") {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.padding(top = 32.dp, bottom = 24.dp)
@@ -287,7 +287,7 @@ fun AboutScreen(
             }
 
             // Greeting section
-            item {
+            item(key = "greeting_card") {
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -316,7 +316,7 @@ fun AboutScreen(
             }
 
             // Author section
-            item {
+            item(key = "author_header") {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -331,16 +331,16 @@ fun AboutScreen(
                 }
             }
 
-            item{
+            item(key = authors[0].name) {
                 ContributorCard(authors[0])
             }
 
-            item {
+            item(key = "author_contributor_spacer") {
                 Spacer(modifier = Modifier.height(12.dp))
             }
 
             // Contributors section
-            item {
+            item(key = "contributors_header") {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -355,7 +355,10 @@ fun AboutScreen(
                 }
             }
 
-            items(contributors) { contributor ->
+            items(
+                items = contributors,
+                key = { it.name }
+            ) { contributor ->
                 ContributorCard(contributor)
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -203,7 +203,7 @@ fun ArtistDetailScreen(
                             )
                         }
 
-                        item { Spacer(modifier = Modifier.height(MiniPlayerHeight + 16.dp)) }
+                        item(key = "bottom_spacer") { Spacer(modifier = Modifier.height(MiniPlayerHeight + 16.dp)) }
                     }
 
                     CustomCollapsingTopBar(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -208,7 +208,7 @@ fun DailyMixScreen(
                 contentPadding = PaddingValues(bottom = MiniPlayerHeight + 38.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                item {
+                item(key = "daily_mix_header") {
                     ExpressiveDailyMixHeader(
                         songs = dailyMixSongs,
                         scrollState = lazyListState,
@@ -216,7 +216,7 @@ fun DailyMixScreen(
                     )
                 }
 
-                item {
+                item(key = "play_shuffle_buttons") {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
@@ -224,7 +224,7 @@ fun GenreDetailScreen(
                             }
                         }
 
-                        item { Spacer(modifier = Modifier.height(MiniPlayerHeight + 36.dp)) }
+                        item(key = "bottom_spacer") { Spacer(modifier = Modifier.height(MiniPlayerHeight + 36.dp)) }
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -140,7 +140,7 @@ fun HomeScreen(
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
                 // Your Mix
-                item {
+                item(key = "your_mix_header") {
                     YourMixHeader(
                         song = yourMixSong,
                         onPlayRandomSong = {
@@ -153,7 +153,7 @@ fun HomeScreen(
 
                 // Collage
                 if (yourMixSongs.isNotEmpty()) {
-                    item {
+                    item(key = "album_art_collage") {
                         AlbumArtCollage(
                             modifier = Modifier.fillMaxWidth(),
                             songs = yourMixSongs,
@@ -168,7 +168,7 @@ fun HomeScreen(
 
                 // Daily Mix
                 if (dailyMixSongs.isNotEmpty()) {
-                    item {
+                    item(key = "daily_mix_section") {
                         DailyMixSection(
                             songs = dailyMixSongs.take(4).toImmutableList(),
                             onClickOpen = {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -907,7 +907,7 @@ fun LibrarySongsTab(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(bottom = bottomBarHeight + MiniPlayerHeight + 30.dp)
                     ) {
-                        item { Spacer(Modifier.height(0.dp)) }
+                        item(key = "songs_top_spacer") { Spacer(Modifier.height(0.dp)) }
                         items(songs, key = { "song_${it.id}" }) { song ->
                             val isPlayingThisSong =
                                 song.id == stablePlayerState.currentSong?.id && stablePlayerState.isPlaying
@@ -1231,7 +1231,7 @@ fun LibraryAlbumsTab(
                 verticalArrangement = Arrangement.spacedBy(14.dp),
                 horizontalArrangement = Arrangement.spacedBy(14.dp)
             ) {
-                item(span = { GridItemSpan(maxLineSpan) }) {
+                item(key = "albums_top_spacer", span = { GridItemSpan(maxLineSpan) }) {
                     Spacer(Modifier.height(4.dp))
                 }
                 items(albums, key = { "album_${it.id}" }) { album ->
@@ -1435,7 +1435,7 @@ fun LibraryArtistsTab(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 contentPadding = PaddingValues(bottom = bottomBarHeight + MiniPlayerHeight + ListExtraBottomGap)
             ) {
-                item {
+                item(key = "artists_top_spacer") {
                     Spacer(Modifier.height(4.dp))
                 }
                 items(artists, key = { "artist_${it.id}" }) { artist ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/MashupScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/MashupScreen.kt
@@ -315,7 +315,7 @@ private fun SongPickerSheet(songs: List<Song>, onSongSelected: (Song) -> Unit) {
         LazyColumn(modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp)) {
-            items(songs) { song ->
+            items(songs, key = { it.id }) { song ->
                 SongPickerItem(song = song, onClick = { onSongSelected(song) })
                 Divider()
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -562,7 +562,7 @@ fun SearchResultsList(
             val itemsForSection = groupedResults[filterType] ?: emptyList()
 
             if (itemsForSection.isNotEmpty()) {
-                item {
+                item(key = "header_${filterType.name}") {
                     SearchResultSectionHeader(
                         title = when (filterType) {
                             SearchFilterType.SONGS -> "Songs"

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
@@ -295,7 +295,7 @@ fun SettingsScreen(
             contentPadding = PaddingValues(top = currentTopBarHeightDp),
             modifier = Modifier.fillMaxSize()
         ) {
-            item {
+            item(key = "music_management_section") {
                 // Sección de gestión de música
                 SettingsSection(
                     title = "Music Management",
@@ -344,9 +344,9 @@ fun SettingsScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item(key = "spacer_1") { Spacer(modifier = Modifier.height(16.dp)) }
 
-            item {
+            item(key = "appearance_section") {
                 // Sección de apariencia
                 SettingsSection(
                     title = "Appearance",
@@ -443,9 +443,9 @@ fun SettingsScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item(key = "spacer_2") { Spacer(modifier = Modifier.height(16.dp)) }
 
-            item {
+            item(key = "ai_section") {
                 SettingsSection(
                     title = "AI Integration (Beta)",
                     icon = {
@@ -465,9 +465,9 @@ fun SettingsScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item(key = "spacer_3") { Spacer(modifier = Modifier.height(16.dp)) }
 
-            item {
+            item(key = "dev_options_section") {
                 // Sección de Opciones de Desarrollador
                 SettingsSection(
                     title = "Developer Options",
@@ -500,9 +500,9 @@ fun SettingsScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(16.dp)) }
+            item(key = "spacer_4") { Spacer(modifier = Modifier.height(16.dp)) }
 
-            item {
+            item(key = "about_section") {
                 // About section
                 SettingsSection(
                     title = "About",
@@ -542,7 +542,7 @@ fun SettingsScreen(
                 }
             }
 
-            item { Spacer(modifier = Modifier.height(MiniPlayerHeight + 36.dp)) }
+            item(key = "bottom_spacer") { Spacer(modifier = Modifier.height(MiniPlayerHeight + 36.dp)) }
         }
         SettingsTopBar(
             collapseFraction = collapseFraction,


### PR DESCRIPTION
This change improves UI performance and stability by providing a unique and stable `key` for every item in all `LazyColumn` and `LazyVerticalGrid` components throughout the application.

Following Jetpack Compose best practices, this helps the recomposer efficiently identify and manage list items, preventing unnecessary recompositions and state loss during list updates.

- For dynamic lists of data (songs, albums, artists, etc.), a unique identifier from the data model (e.g., `item.id`) is used as the key.
- For static items like headers, footers, or spacers, a descriptive and unique string literal is used as the key.