### PR TITLE
fix(player): Show lyrics dialog when song without lyrics starts

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -1817,10 +1817,15 @@ private fun FullPlayerContentInternal(
         LyricsSheet(
             stablePlayerStateFlow = playerViewModel.stablePlayerState,
             playerUiStateFlow = playerViewModel.playerUiState,
+            lyricsSearchUiState = lyricsSearchUiState,
             resetLyricsForCurrentSong = {
                 showLyricsSheet = false
                 playerViewModel.resetLyricsForCurrentSong()
             },
+            onSearchLyrics = { playerViewModel.fetchLyricsForCurrentSong() },
+            onPickResult = { playerViewModel.acceptLyricsSearchResultForCurrentSong(it) },
+            onImportLyrics = { filePickerLauncher.launch("*/*") },
+            onDismissLyricsSearch = { playerViewModel.resetLyricsSearchState() },
             lyricsTextStyle = MaterialTheme.typography.titleLarge,
             backgroundColor = LocalMaterialTheme.current.background,
             onBackgroundColor = LocalMaterialTheme.current.onBackground,


### PR DESCRIPTION
When the LyricsSheet is open and the song changes to one that does not have lyrics, the sheet would previously just go blank.

This change modifies the `LyricsSheet` to observe the current song. If the new song has no lyrics and lyrics are not currently being fetched, it now displays the `FetchLyricsDialog`. This allows the user to immediately search for or import lyrics for the new song, improving the user experience.