### PR TITLE
Fix: Prevent crash in SearchScreen due to duplicate genre keys

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -412,9 +412,13 @@ class PlayerViewModel @Inject constructor(
                 }
             }
 
-            genreMap.toList().mapIndexed { index, (genreName, songs) ->
+            genreMap.toList().mapIndexedNotNull { index, (genreName, songs) ->
                 if (songs.isNotEmpty()) {
-                    val id = if (genreName.equals(unknownGenreName, ignoreCase = true)) "unknown" else genreName.lowercase().replace(" ", "_")
+                    val id = if (genreName.equals(unknownGenreName, ignoreCase = true)) {
+                        "unknown"
+                    } else {
+                        genreName.lowercase().replace(" ", "_").replace("/", "_")
+                    }
                     val color = GenreColors.colors[index % GenreColors.colors.size]
                     Genre(
                         id = id,
@@ -427,7 +431,8 @@ class PlayerViewModel @Inject constructor(
                 } else {
                     null
                 }
-            }.filterNotNull()
+            }
+                .distinctBy { it.id }
                 .sortedBy { it.name }
                 .toImmutableList()
         }


### PR DESCRIPTION
The SearchScreen was crashing when the list of music genres contained duplicates, as this resulted in non-unique keys being passed to the `LazyVerticalGrid`.

This commit fixes the issue by ensuring the genre list is always unique. In `PlayerViewModel`, the `genres` `StateFlow` now uses `.distinctBy { it.id }` to filter out any genres that have the same ID. This guarantees that the UI receives a list with unique keys, preventing the crash.