### PR TITLE
Fix: Update LibraryActionRow based on tab identity, not index

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
@@ -117,9 +117,9 @@ fun LibraryActionRow(
                 ),
                 contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp) // Standard button padding
             ) {
-                val icon = if (currentPage == 3) Icons.Rounded.PlaylistAdd else Icons.Rounded.Shuffle
-                val text = if (currentPage == 3) "New" else "Shuffle"
-                val contentDesc = if (currentPage == 3) "Create New Playlist" else "Shuffle Play"
+                val icon = if (isPlaylistTab) Icons.Rounded.PlaylistAdd else Icons.Rounded.Shuffle
+                val text = if (isPlaylistTab) "New" else "Shuffle"
+                val contentDesc = if (isPlaylistTab) "Create New Playlist" else "Shuffle Play"
 
                 Row(
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
The action buttons in the Library screen were not updating correctly when the tabs were reordered. This was because the logic in `LibraryActionRow` used a hardcoded page index (`currentPage == 3`) to determine which button to show.

This change corrects the logic to use the `isPlaylistTab` boolean, which is derived from the tab's title. This makes the component robust and ensures the correct actions are displayed for the selected tab, regardless of its position in the tab row.