### PR TITLE
fix: sorting albums by release year

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
@@ -20,7 +20,8 @@ data class AlbumEntity(
     @ColumnInfo(name = "artist_name") val artistName: String, // Nombre del artista del álbum
     @ColumnInfo(name = "artist_id") val artistId: Long, // ID del artista principal del álbum (si aplica)
     @ColumnInfo(name = "album_art_uri_string") val albumArtUriString: String?,
-    @ColumnInfo(name = "song_count") val songCount: Int
+    @ColumnInfo(name = "song_count") val songCount: Int,
+    @ColumnInfo(name = "year") val year: Int
 )
 
 fun AlbumEntity.toAlbum(): Album {
@@ -29,7 +30,8 @@ fun AlbumEntity.toAlbum(): Album {
         title = this.title,
         artist = this.artistName,
         albumArtUriString = this.albumArtUriString, // El modelo Album usa albumArtUrl
-        songCount = this.songCount
+        songCount = this.songCount,
+        year = this.year
     )
 }
 
@@ -44,6 +46,7 @@ fun Album.toEntity(artistIdForAlbum: Long): AlbumEntity { // Necesitamos pasar e
         artistName = this.artist,
         artistId = artistIdForAlbum, // Asignar el ID del artista
         albumArtUriString = this.albumArtUriString,
-        songCount = this.songCount
+        songCount = this.songCount,
+        year = this.year
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -15,7 +15,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         ArtistEntity::class,
         TransitionRuleEntity::class
     ],
-    version = 7, // Incremented version for dateAdded column
+    version = 8, // Incremented version for year column
     exportSchema = false
 )
 abstract class PixelPlayDatabase : RoomDatabase() {

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
@@ -50,6 +50,7 @@ data class SongEntity(
     @ColumnInfo(name = "is_favorite", defaultValue = "0") val isFavorite: Boolean = false,
     @ColumnInfo(name = "lyrics", defaultValue = "null") val lyrics: String? = null,
     @ColumnInfo(name = "track_number", defaultValue = "0") val trackNumber: Int = 0,
+    @ColumnInfo(name = "year", defaultValue = "0") val year: Int = 0,
     @ColumnInfo(name = "date_added", defaultValue = "0") val dateAdded: Long = System.currentTimeMillis()
 )
 
@@ -68,7 +69,8 @@ fun SongEntity.toSong(): Song {
         lyrics = this.lyrics,
         isFavorite = this.isFavorite,
         trackNumber = this.trackNumber,
-        dateAdded = this.dateAdded
+        dateAdded = this.dateAdded,
+        year = this.year
         // filePath no está en el modelo Song, se usa internamente en el repo o SSoT
     )
 }
@@ -95,7 +97,8 @@ fun Song.toEntity(filePathFromMediaStore: String, parentDirFromMediaStore: Strin
         lyrics = this.lyrics,
         filePath = filePathFromMediaStore,
         parentDirectoryPath = parentDirFromMediaStore,
-        dateAdded = this.dateAdded
+        dateAdded = this.dateAdded,
+        year = this.year
     )
 }
 
@@ -116,6 +119,7 @@ fun Song.toEntityWithoutPaths(): SongEntity {
         lyrics = this.lyrics,
         filePath = "", // Default o manejar como no disponible
         parentDirectoryPath = "", // Default o manejar como no disponible
-        dateAdded = this.dateAdded
+        dateAdded = this.dateAdded,
+        year = this.year
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
@@ -8,6 +8,7 @@ data class Album(
     val id: Long, // MediaStore.Audio.Albums._ID
     val title: String,
     val artist: String,
+    val year: Int,
     val albumArtUriString: String?,
     val songCount: Int
 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/Song.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/Song.kt
@@ -18,6 +18,7 @@ data class Song(
     val lyrics: String? = null,
     val isFavorite: Boolean = false,
     val trackNumber: Int = 0,
+    val year: Int = 0,
     val dateAdded: Long = 0
 ) {
     companion object {
@@ -36,6 +37,7 @@ data class Song(
                 lyrics = null,
                 isFavorite = false,
                 trackNumber = 0,
+                year = 0,
                 dateAdded = 0
             )
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -120,7 +120,8 @@ class SyncWorker @AssistedInject constructor(
                 artistName = firstSong.artistName,
                 artistId = firstSong.artistId,
                 albumArtUriString = firstSong.albumArtUriString,
-                songCount = songsInAlbum.size
+                songCount = songsInAlbum.size,
+                year = firstSong.year
             )
         }
 
@@ -153,7 +154,8 @@ class SyncWorker @AssistedInject constructor(
             MediaStore.Audio.Media.DURATION,
             MediaStore.Audio.Media.DATA,
             MediaStore.Audio.Media.GENRE,
-            MediaStore.Audio.Media.TRACK
+            MediaStore.Audio.Media.TRACK,
+            MediaStore.Audio.Media.YEAR
         )
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} >= ?"
         val selectionArgs = arrayOf("10000")
@@ -176,6 +178,7 @@ class SyncWorker @AssistedInject constructor(
             val dataCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
             val genreCol = cursor.getColumnIndex(MediaStore.Audio.Media.GENRE)
             val trackCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
+            val yearCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
 
 
             while (cursor.moveToNext()) {
@@ -215,7 +218,8 @@ class SyncWorker @AssistedInject constructor(
                         genre = if (genreCol != -1) cursor.getString(genreCol) else null,
                         filePath = filePath,
                         parentDirectoryPath = parentDir,
-                        trackNumber = cursor.getInt(trackCol)
+                        trackNumber = cursor.getInt(trackCol),
+                        year = cursor.getInt(yearCol)
                     )
                 )
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2160,7 +2160,7 @@ class PlayerViewModel @Inject constructor(
             SortOption.AlbumTitleAZ -> _playerUiState.value.albums.sortedBy { it.title }
             SortOption.AlbumTitleZA -> _playerUiState.value.albums.sortedByDescending { it.title }
             SortOption.AlbumArtist -> _playerUiState.value.albums.sortedBy { it.artist }
-            SortOption.AlbumReleaseYear -> _playerUiState.value.albums.sortedByDescending { it.id } //need to implement album release date
+            SortOption.AlbumReleaseYear -> _playerUiState.value.albums.sortedByDescending { it.year }
             else -> _playerUiState.value.albums
         }.toImmutableList()
         _playerUiState.update {


### PR DESCRIPTION
Fixes #224

Previously, the "Release Date" sort option was sorting by the album ID.

| Before  | After | Booming Music |
| ------------- | ------------- | ------------- | 
| <img width="227" height="720" alt="Screenshot_20251012_200114" src="https://github.com/user-attachments/assets/18441bc9-23e0-468d-a1c2-0eff35dc5468" />  | <img width="227" height="720" alt="Screenshot_20251012_195902" src="https://github.com/user-attachments/assets/a14216a1-0549-4b73-83e5-5f976b04e0f6" />  | <img width="227" height="720" alt="Screenshot_20251012_200154" src="https://github.com/user-attachments/assets/7fd5a392-e673-4037-963d-42dc15e7bdd4" /> |