### PR TITLE
fix(player): Restart progress updates when player is ready

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1557,6 +1557,7 @@ class PlayerViewModel @Inject constructor(
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (playbackState == Player.STATE_READY) {
                     _stablePlayerState.update { it.copy(totalDuration = playerCtrl.duration.coerceAtLeast(0L)) }
+                    startProgressUpdates()
                 }
                 if (playbackState == Player.STATE_IDLE && playerCtrl.mediaItemCount == 0) {
                     _stablePlayerState.update { it.copy(currentSong = null, isPlaying = false) }


### PR DESCRIPTION
The player's progress slider would get stuck at 0:00 when connecting to a Bluetooth device. This was because the progress update polling was not being restarted after the audio route change caused a player state transition.

This change fixes the issue by calling `startProgressUpdates()` within the `onPlaybackStateChanged` listener whenever the `playbackState` becomes `Player.STATE_READY`. This ensures that the UI progress polling is reliably restarted after any event that makes the player ready, including connecting to a new audio output like a Bluetooth device.