### PR TITLE
Fix: Prevent carousel from peeking when only one item exists

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
@@ -4,12 +4,10 @@ import androidx.compose.runtime.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.*
-import androidx.compose.ui.util.lerp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import coil.size.Size
 import com.theveloper.pixelplay.data.model.Song
@@ -90,7 +88,7 @@ fun AlbumCarouselSection(
             modifier = Modifier.fillMaxSize(), // Fill the space provided by the parent's modifier
             itemSpacing = itemSpacing,
             itemCornerRadius = corner,
-            carouselStyle = carouselStyle,
+            carouselStyle = if (carouselState.pagerState.pageCount == 1) CarouselStyle.NO_PEEK else carouselStyle, // Handle single-item case
             carouselWidth = availableWidth // Pass the full width for layout calculations
         ) { index ->
             val song = queue[index]


### PR DESCRIPTION
This commit modifies the `AlbumCarouselSelection` to handle cases where there is only one item in the queue.

When the `pagerState.pageCount` is equal to 1, the `carouselStyle` is now forced to `CarouselStyle.NO_PEEK`. This prevents the carousel from showing a "peek" of adjacent (non-existent) items, which could cause visual bugs or an undesirable layout.