### PR TITLE
Fix: Player progress bar freezes on Bluetooth

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -79,6 +79,8 @@ class MusicService : MediaSessionService() {
     companion object {
         private const val TAG = "MusicService_PixelPlay"
         const val NOTIFICATION_ID = 101
+        const val CUSTOM_COMMAND_GET_POSITION = "GET_POSITION"
+        const val CUSTOM_COMMAND_GET_POSITION_KEY = "POSITION"
     }
 
     override fun onCreate() {
@@ -97,6 +99,11 @@ class MusicService : MediaSessionService() {
                 Timber.tag("MusicService")
                     .d("onCustomCommand received: ${customCommand.customAction}")
                 when (customCommand.customAction) {
+                    CUSTOM_COMMAND_GET_POSITION -> {
+                        val position = engine.masterPlayer.currentPosition
+                        val resultBundle = Bundle().apply { putLong(CUSTOM_COMMAND_GET_POSITION_KEY, position) }
+                        return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS, resultBundle))
+                    }
                     MusicNotificationProvider.CUSTOM_COMMAND_SHUFFLE_ON -> {
                         Timber.tag("MusicService")
                             .d("Executing SHUFFLE_ON. Current shuffleMode: ${session.player.shuffleModeEnabled}")

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -50,7 +50,7 @@ class DualPlayerEngine @Inject constructor(
 
     private fun buildPlayer(): ExoPlayer {
         val renderersFactory = DefaultRenderersFactory(context)
-            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
 
         val audioAttributes = AudioAttributes.Builder()
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)


### PR DESCRIPTION
The UI progress slider (`WavySlider`) would get stuck at the beginning of the track (0:00) when audio playback was routed through a Bluetooth device.

The root cause was a desynchronization between the `MediaSession` and the `MediaController` after an audio output change. The `MediaController` was repeatedly querying a stale position, which remained at 0.

To resolve this, a more direct and robust progress reporting mechanism has been implemented:

1.  A custom `SessionCommand` (`GET_POSITION`) has been added to `MusicService.kt`. This command allows the `PlayerViewModel` to directly query the `ExoPlayer` instance's current position, bypassing any potential state desynchronization.
2.  The `startProgressUpdates` loop in `PlayerViewModel.kt` has been modified to use this custom command, ensuring the UI always reflects the true playback position.
3.  The `DualPlayerEngine`'s extension renderer mode has been set to `PREFER` to improve stability.