### PR TITLE
Ensure player exposes position command and resilient polling

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -90,6 +90,26 @@ class MusicService : MediaSessionService() {
         controller.initialize()
 
         val callback = object : MediaSession.Callback {
+            override fun onConnect(
+                session: MediaSession,
+                controller: MediaSession.ControllerInfo
+            ): MediaSession.ConnectionResult {
+                val sessionCommandsBuilder = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS
+                    .buildUpon()
+                    .add(SessionCommand(CUSTOM_COMMAND_GET_POSITION, Bundle.EMPTY))
+                    .add(SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_SHUFFLE_ON, Bundle.EMPTY))
+                    .add(SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_SHUFFLE_OFF, Bundle.EMPTY))
+                    .add(SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_CYCLE_REPEAT_MODE, Bundle.EMPTY))
+                    .add(SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_LIKE, Bundle.EMPTY))
+
+                val playerCommands = MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS
+
+                return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+                    .setAvailableSessionCommands(sessionCommandsBuilder.build())
+                    .setAvailablePlayerCommands(playerCommands)
+                    .build()
+            }
+
             override fun onCustomCommand(
                 session: MediaSession,
                 controller: MediaSession.ControllerInfo,


### PR DESCRIPTION
## Summary
- allow controllers to invoke the player position custom command by advertising it during session connection
- add a fallback to the media controller position when the custom command result is unavailable so progress keeps updating

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f9a1247994832f9709f35f97ed673c