### PR TITLE
Fix(UI): Apply Google Sans font to bottom sheet title

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.data.model.SortOption
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -60,8 +61,10 @@ fun LibrarySortBottomSheet(
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineSmall,
+                fontFamily = GoogleSansRounded,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
+                modifier = Modifier
+                    .padding(start = 2.dp, top = 8.dp, bottom = 16.dp)
             )
 
             options.forEach { option ->


### PR DESCRIPTION
This commit updates the `LibrarySortBottomSheet` component to use the `GoogleSansRounded` font for its title, aligning it with the application's typography.

A minor padding adjustment is also included to refine the title's alignment.