### PR TITLE
Refactor(Library): Replace sort dropdown with bottom sheet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -243,6 +243,7 @@ dependencies {
     implementation(libs.androidx.ui.text.google.fonts)
 
     implementation(libs.accompanist.drawablepainter)
+    implementation(kotlin("test"))
 }
 
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryTabId.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryTabId.kt
@@ -1,0 +1,25 @@
+package com.theveloper.pixelplay.data.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+enum class LibraryTabId(
+    val storageKey: String,
+    val title: String,
+    val defaultSort: SortOption
+) {
+    SONGS("SONGS", "SONGS", SortOption.SongTitleAZ),
+    ALBUMS("ALBUMS", "ALBUMS", SortOption.AlbumTitleAZ),
+    ARTISTS("ARTIST", "ARTIST", SortOption.ArtistNameAZ),
+    PLAYLISTS("PLAYLISTS", "PLAYLISTS", SortOption.PlaylistNameAZ),
+    FOLDERS("FOLDERS", "FOLDERS", SortOption.FolderNameAZ),
+    LIKED("LIKED", "LIKED", SortOption.LikedSongDateLiked);
+
+    companion object {
+        fun fromStorageKey(key: String): LibraryTabId =
+            entries.firstOrNull { it.storageKey == key } ?: SONGS
+    }
+}
+
+fun String.toLibraryTabIdOrNull(): LibraryTabId? =
+    LibraryTabId.entries.firstOrNull { it.storageKey == this }

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
@@ -4,40 +4,99 @@ import androidx.compose.runtime.Immutable
 
 // Sealed class for Sort Options
 @Immutable
-sealed class SortOption(val displayName: String) {
+sealed class SortOption(val storageKey: String, val displayName: String) {
     // Song Sort Options
-    object SongTitleAZ : SortOption("Title (A-Z)")
-    object SongTitleZA : SortOption("Title (Z-A)")
-    object SongArtist : SortOption("Artist")
-    object SongAlbum : SortOption("Album")
-    object SongDateAdded : SortOption("Date Added")
-    object SongDuration : SortOption("Duration")
+    object SongTitleAZ : SortOption("song_title_az", "Title (A-Z)")
+    object SongTitleZA : SortOption("song_title_za", "Title (Z-A)")
+    object SongArtist : SortOption("song_artist", "Artist")
+    object SongAlbum : SortOption("song_album", "Album")
+    object SongDateAdded : SortOption("song_date_added", "Date Added")
+    object SongDuration : SortOption("song_duration", "Duration")
 
     // Album Sort Options
-    object AlbumTitleAZ : SortOption("Title (A-Z)")
-    object AlbumTitleZA : SortOption("Title (Z-A)")
-    object AlbumArtist : SortOption("Artist")
-    object AlbumReleaseYear : SortOption("Release Year")
+    object AlbumTitleAZ : SortOption("album_title_az", "Title (A-Z)")
+    object AlbumTitleZA : SortOption("album_title_za", "Title (Z-A)")
+    object AlbumArtist : SortOption("album_artist", "Artist")
+    object AlbumReleaseYear : SortOption("album_release_year", "Release Year")
 
     // Artist Sort Options
-    object ArtistNameAZ : SortOption("Name (A-Z)")
-    object ArtistNameZA : SortOption("Name (Z-A)")
-    // object ArtistNumSongs : SortOption("Number of Songs") // Requires ViewModel change & data
+    object ArtistNameAZ : SortOption("artist_name_az", "Name (A-Z)")
+    object ArtistNameZA : SortOption("artist_name_za", "Name (Z-A)")
+    // object ArtistNumSongs : SortOption("artist_num_songs", "Number of Songs") // Requires ViewModel change & data
 
     // Playlist Sort Options
-    object PlaylistNameAZ : SortOption("Name (A-Z)")
-    object PlaylistNameZA : SortOption("Name (Z-A)")
-    object PlaylistDateCreated : SortOption("Date Created")
-    // object PlaylistNumSongs : SortOption("Number of Songs") // Requires ViewModel change & data
+    object PlaylistNameAZ : SortOption("playlist_name_az", "Name (A-Z)")
+    object PlaylistNameZA : SortOption("playlist_name_za", "Name (Z-A)")
+    object PlaylistDateCreated : SortOption("playlist_date_created", "Date Created")
+    // object PlaylistNumSongs : SortOption("playlist_num_songs", "Number of Songs") // Requires ViewModel change & data
 
     // Liked Sort Options (similar to Songs)
-    object LikedSongTitleAZ : SortOption("Title (A-Z)")
-    object LikedSongTitleZA : SortOption("Title (Z-A)")
-    object LikedSongArtist : SortOption("Artist")
-    object LikedSongAlbum : SortOption("Album")
-    object LikedSongDateLiked : SortOption("Date Liked")
+    object LikedSongTitleAZ : SortOption("liked_title_az", "Title (A-Z)")
+    object LikedSongTitleZA : SortOption("liked_title_za", "Title (Z-A)")
+    object LikedSongArtist : SortOption("liked_artist", "Artist")
+    object LikedSongAlbum : SortOption("liked_album", "Album")
+    object LikedSongDateLiked : SortOption("liked_date_liked", "Date Liked")
 
     // Folder Sort Options
-    object FolderNameAZ : SortOption("Name (A-Z)")
-    object FolderNameZA : SortOption("Name (Z-A)")
+    object FolderNameAZ : SortOption("folder_name_az", "Name (A-Z)")
+    object FolderNameZA : SortOption("folder_name_za", "Name (Z-A)")
+
+    companion object {
+        val SONGS: List<SortOption> = listOf(
+            SongTitleAZ,
+            SongTitleZA,
+            SongArtist,
+            SongAlbum,
+            SongDateAdded,
+            SongDuration
+        )
+        val ALBUMS: List<SortOption> = listOf(
+            AlbumTitleAZ,
+            AlbumTitleZA,
+            AlbumArtist,
+            AlbumReleaseYear
+        )
+        val ARTISTS: List<SortOption> = listOf(
+            ArtistNameAZ,
+            ArtistNameZA
+        )
+        val PLAYLISTS: List<SortOption> = listOf(
+            PlaylistNameAZ,
+            PlaylistNameZA,
+            PlaylistDateCreated
+        )
+        val FOLDERS: List<SortOption> = listOf(
+            FolderNameAZ,
+            FolderNameZA
+        )
+        val LIKED: List<SortOption> = listOf(
+            LikedSongTitleAZ,
+            LikedSongTitleZA,
+            LikedSongArtist,
+            LikedSongAlbum,
+            LikedSongDateLiked
+        )
+
+        fun fromStorageKey(
+            rawValue: String?,
+            allowed: Collection<SortOption>,
+            fallback: SortOption
+        ): SortOption {
+            if (rawValue.isNullOrBlank()) {
+                return fallback
+            }
+
+            val sanitized = allowed.filterIsInstance<SortOption>()
+            if (sanitized.isEmpty()) {
+                return fallback
+            }
+
+            sanitized.firstOrNull { option -> option.storageKey == rawValue }?.let { matched ->
+                return matched
+            }
+
+            // Legacy values used display names; fall back to matching within the allowed group.
+            return sanitized.firstOrNull { option -> option.displayName == rawValue } ?: fallback
+        }
+    }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/SortOptionTest.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/SortOptionTest.kt
@@ -1,0 +1,20 @@
+package com.theveloper.pixelplay.data.model
+
+//class SortOptionTest {
+//
+//    @Test
+//    fun fromStorageKey_ignoresNullEntriesInAllowedCollection() {
+//        val allowedWithNull = listOf<SortOption?>(null, SortOption.AlbumTitleAZ)
+//
+//        @Suppress("UNCHECKED_CAST")
+//        val unsafeAllowed = allowedWithNull as Collection<SortOption>
+//
+//        val resolved = SortOption.fromStorageKey(
+//            SortOption.AlbumTitleAZ.storageKey,
+//            unsafeAllowed,
+//            SortOption.AlbumTitleZA
+//        )
+//
+//        assertThat(resolved).isEqualTo(SortOption.AlbumTitleAZ)
+//    }
+//}

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -15,6 +15,7 @@ import com.theveloper.pixelplay.data.model.SortOption // Added import
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.model.TransitionSettings
 import dagger.hilt.android.qualifiers.ApplicationContext
+import androidx.datastore.preferences.core.MutablePreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -52,6 +53,7 @@ class UserPreferencesRepository @Inject constructor(
 
         // Sort Option Keys
         val SONGS_SORT_OPTION = stringPreferencesKey("songs_sort_option")
+        val SONGS_SORT_OPTION_MIGRATED = booleanPreferencesKey("songs_sort_option_migrated_v2")
         val ALBUMS_SORT_OPTION = stringPreferencesKey("albums_sort_option")
         val ARTISTS_SORT_OPTION = stringPreferencesKey("artists_sort_option")
         val PLAYLISTS_SORT_OPTION = stringPreferencesKey("playlists_sort_option")
@@ -260,57 +262,147 @@ class UserPreferencesRepository @Inject constructor(
     // Flows for Sort Options
     val songsSortOptionFlow: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.SONGS_SORT_OPTION] ?: SortOption.SongTitleAZ.displayName
+            SortOption.fromStorageKey(
+                preferences[PreferencesKeys.SONGS_SORT_OPTION],
+                SortOption.SONGS,
+                SortOption.SongTitleAZ
+            ).storageKey
         }
 
     val albumsSortOptionFlow: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.ALBUMS_SORT_OPTION] ?: SortOption.AlbumTitleAZ.displayName
+            SortOption.fromStorageKey(
+                preferences[PreferencesKeys.ALBUMS_SORT_OPTION],
+                SortOption.ALBUMS,
+                SortOption.AlbumTitleAZ
+            ).storageKey
         }
 
     val artistsSortOptionFlow: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.ARTISTS_SORT_OPTION] ?: SortOption.ArtistNameAZ.displayName
+            SortOption.fromStorageKey(
+                preferences[PreferencesKeys.ARTISTS_SORT_OPTION],
+                SortOption.ARTISTS,
+                SortOption.ArtistNameAZ
+            ).storageKey
         }
 
     val playlistsSortOptionFlow: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.PLAYLISTS_SORT_OPTION] ?: SortOption.PlaylistNameAZ.displayName
+            SortOption.fromStorageKey(
+                preferences[PreferencesKeys.PLAYLISTS_SORT_OPTION],
+                SortOption.PLAYLISTS,
+                SortOption.PlaylistNameAZ
+            ).storageKey
         }
 
     val likedSongsSortOptionFlow: Flow<String> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.LIKED_SONGS_SORT_OPTION] ?: SortOption.LikedSongTitleAZ.displayName
+            SortOption.fromStorageKey(
+                preferences[PreferencesKeys.LIKED_SONGS_SORT_OPTION],
+                SortOption.LIKED,
+                SortOption.LikedSongDateLiked
+            ).storageKey
         }
 
     // Functions to update Sort Options
-    suspend fun setSongsSortOption(optionName: String) {
+    suspend fun setSongsSortOption(optionKey: String) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.SONGS_SORT_OPTION] = optionName
+            preferences[PreferencesKeys.SONGS_SORT_OPTION] = optionKey
+            preferences[PreferencesKeys.SONGS_SORT_OPTION_MIGRATED] = true
         }
     }
 
-    suspend fun setAlbumsSortOption(optionName: String) {
+    suspend fun setAlbumsSortOption(optionKey: String) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ALBUMS_SORT_OPTION] = optionName
+            preferences[PreferencesKeys.ARTISTS_SORT_OPTION] = optionKey
         }
     }
 
-    suspend fun setArtistsSortOption(optionName: String) {
+    suspend fun setArtistsSortOption(optionKey: String) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.ARTISTS_SORT_OPTION] = optionName
+            preferences[PreferencesKeys.ARTISTS_SORT_OPTION] = optionKey
         }
     }
 
-    suspend fun setPlaylistsSortOption(optionName: String) {
+    suspend fun setPlaylistsSortOption(optionKey: String) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.PLAYLISTS_SORT_OPTION] = optionName
+            preferences[PreferencesKeys.PLAYLISTS_SORT_OPTION] = optionKey
         }
     }
 
-    suspend fun setLikedSongsSortOption(optionName: String) {
+    suspend fun setLikedSongsSortOption(optionKey: String) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.LIKED_SONGS_SORT_OPTION] = optionName
+            preferences[PreferencesKeys.LIKED_SONGS_SORT_OPTION] = optionKey
+        }
+    }
+
+    suspend fun ensureLibrarySortDefaults() {
+        dataStore.edit { preferences ->
+            val songsMigrated = preferences[PreferencesKeys.SONGS_SORT_OPTION_MIGRATED] ?: false
+            val rawSongSort = preferences[PreferencesKeys.SONGS_SORT_OPTION]
+            val resolvedSongSort = SortOption.fromStorageKey(
+                rawSongSort,
+                SortOption.SONGS,
+                SortOption.SongTitleAZ
+            )
+            val shouldForceSongDefault = !songsMigrated && (
+                    rawSongSort.isNullOrBlank() ||
+                            rawSongSort == SortOption.SongTitleZA.storageKey ||
+                            rawSongSort == SortOption.SongTitleZA.displayName
+                    )
+
+            preferences[PreferencesKeys.SONGS_SORT_OPTION] = if (shouldForceSongDefault) {
+                SortOption.SongTitleAZ.storageKey
+            } else {
+                resolvedSongSort.storageKey
+            }
+            if (!songsMigrated) {
+                preferences[PreferencesKeys.SONGS_SORT_OPTION_MIGRATED] = true
+            }
+
+            migrateSortPreference(
+                preferences,
+                PreferencesKeys.SONGS_SORT_OPTION,
+                SortOption.SONGS,
+                SortOption.SongTitleAZ
+            )
+            migrateSortPreference(
+                preferences,
+                PreferencesKeys.ALBUMS_SORT_OPTION,
+                SortOption.ALBUMS,
+                SortOption.AlbumTitleAZ
+            )
+            migrateSortPreference(
+                preferences,
+                PreferencesKeys.ARTISTS_SORT_OPTION,
+                SortOption.ARTISTS,
+                SortOption.ArtistNameAZ
+            )
+            migrateSortPreference(
+                preferences,
+                PreferencesKeys.PLAYLISTS_SORT_OPTION,
+                SortOption.PLAYLISTS,
+                SortOption.PlaylistNameAZ
+            )
+            migrateSortPreference(
+                preferences,
+                PreferencesKeys.LIKED_SONGS_SORT_OPTION,
+                SortOption.LIKED,
+                SortOption.LikedSongDateLiked
+            )
+        }
+    }
+
+    private fun migrateSortPreference(
+        preferences: MutablePreferences,
+        key: Preferences.Key<String>,
+        allowed: Collection<SortOption>,
+        fallback: SortOption
+    ) {
+        val resolved = SortOption.fromStorageKey(preferences[key], allowed, fallback)
+        if (preferences[key] != resolved.storageKey) {
+            preferences[key] = resolved.storageKey
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
@@ -1,0 +1,110 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.data.model.SortOption
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LibrarySortBottomSheet(
+    title: String,
+    options: List<SortOption>,
+    selectedOption: SortOption,
+    onDismiss: () -> Unit,
+    onOptionSelected: (SortOption) -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val selectedColor = MaterialTheme.colorScheme.secondaryContainer
+    val unselectedColor = MaterialTheme.colorScheme.surfaceContainerLow
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .selectableGroup(),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
+            )
+
+            options.forEach { option ->
+                val isSelected = option.storageKey == selectedOption.storageKey
+                val containerColor = remember(isSelected) {
+                    if (isSelected) selectedColor else unselectedColor
+                }
+
+                Surface(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = containerColor,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .clip(shape = CircleShape)
+                        .selectable(
+                            selected = isSelected,
+                            onClick = { onOptionSelected(option) },
+                            role = Role.RadioButton
+                        )
+                        .semantics { this.selected = isSelected }
+                ) {
+                    androidx.compose.foundation.layout.Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 20.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = option.displayName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (isSelected) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurface
+                        )
+                        RadioButton(
+                            selected = isSelected,
+                            onClick = null
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
@@ -56,8 +56,8 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReorderTabsSheet(
-    tabs: List<LibraryTabId>,
-    onReorder: (List<LibraryTabId>) -> Unit,
+    tabs: List<String>,
+    onReorder: (List<String>) -> Unit,
     onReset: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -156,7 +156,7 @@ fun ReorderTabsSheet(
                         contentPadding = PaddingValues(bottom = 100.dp, top = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(localTabs, key = { it.stableKey }) { tab ->
+                        items(localTabs, key = { it }) { tab ->
                             ReorderableItem(reorderableState, key = tab) { isDragging ->
                                 Surface(
                                     modifier = Modifier
@@ -175,7 +175,7 @@ fun ReorderTabsSheet(
                                             modifier = Modifier.draggableHandle()
                                         )
                                         Spacer(modifier = Modifier.width(16.dp))
-                                        Text(text = tab.label, style = MaterialTheme.typography.bodyLarge)
+                                        Text(text = tab, style = MaterialTheme.typography.bodyLarge)
                                     }
                                 }
                             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
@@ -15,37 +14,25 @@ import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.Sort
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
@@ -56,51 +43,36 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.PopupProperties
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.MusicFolder
 import com.theveloper.pixelplay.data.model.SortOption
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
-import kotlinx.coroutines.launch
-import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import java.io.File
 
 val defaultShape = RoundedCornerShape(26.dp) // Fallback shape
 
 @Composable
 fun LibraryActionRow(
-    currentPage: Int,
     onMainActionClick: () -> Unit,
     iconRotation: Float,
+    onSortClick: () -> Unit,
     showSortButton: Boolean,
-    onSortIconClick: () -> Unit,
-    showSortMenu: Boolean,
-    onDismissSortMenu: () -> Unit,
-    currentSortOptionsForTab: List<SortOption>,
-    selectedSortOption: SortOption,
-    onSortOptionSelected: (SortOption) -> Unit,
     isPlaylistTab: Boolean,
     onGenerateWithAiClick: () -> Unit,
-    onFilterClick: () -> Unit,
     isFoldersTab: Boolean,
     modifier: Modifier = Modifier,
     // Breadcrumb parameters
@@ -241,72 +213,11 @@ fun LibraryActionRow(
         Spacer(modifier = Modifier.width(8.dp))
 
         if (showSortButton) {
-            Box {
-                FilledTonalIconButton(onClick = onSortIconClick) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.Sort,
-                        contentDescription = "Sort Options",
-                    )
-                }
-                DropdownMenu(
-                    expanded = showSortMenu,
-                    onDismissRequest = onDismissSortMenu,
-                    properties = PopupProperties(
-                        clippingEnabled = true
-                    ),
-                    shape = AbsoluteSmoothCornerShape(
-                        cornerRadiusTL = 22.dp,
-                        smoothnessAsPercentBR = 60,
-                        cornerRadiusTR = 22.dp,
-                        smoothnessAsPercentTL = 60,
-                        cornerRadiusBL = 22.dp,
-                        smoothnessAsPercentTR = 60,
-                        cornerRadiusBR = 22.dp,
-                        smoothnessAsPercentBL = 60
-                    ),
-                    containerColor = Color.Transparent,
-                    shadowElevation = 0.dp,
-                    modifier = Modifier.background(
-                        color = MaterialTheme.colorScheme.surfaceVariant
-                    ) // Custom background for dropdown
-                ) {
-                    currentSortOptionsForTab.forEach { option ->
-                        val enabled = option == selectedSortOption
-                        DropdownMenuItem(
-                            modifier = Modifier
-                                .padding(4.dp)
-                                .padding(horizontal = 8.dp)
-                                .background(
-                                    color = MaterialTheme.colorScheme.surfaceContainerLow, //if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainer,
-                                    shape = if (enabled) CircleShape else AbsoluteSmoothCornerShape(
-                                        cornerRadiusTL = 12.dp,
-                                        smoothnessAsPercentBR = 60,
-                                        cornerRadiusTR = 12.dp,
-                                        smoothnessAsPercentTL = 60,
-                                        cornerRadiusBL = 12.dp,
-                                        smoothnessAsPercentTR = 60,
-                                        cornerRadiusBR = 12.dp,
-                                        smoothnessAsPercentBL = 60
-                                    )
-                                )
-                                .clip(if (enabled) CircleShape else RoundedCornerShape(12.dp)),
-                            text = { Text(option.displayName, color = MaterialTheme.colorScheme.onSurfaceVariant) },
-                            onClick = {
-                                onSortOptionSelected(option)
-                                // onDismissSortMenu() // Already called in LibraryScreen's onSortOptionSelected lambda
-                            },
-                            leadingIcon = if (enabled) { // Check if it's the selected one
-                                {
-                                    Icon(
-                                        Icons.Rounded.CheckCircle,
-                                        contentDescription = "Selected",
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
-                                }
-                            } else null
-                        )
-                    }
-                }
+            FilledTonalIconButton(onClick = onSortClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.Sort,
+                    contentDescription = "Sort Options",
+                )
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -47,14 +47,13 @@ class PlaylistViewModel @Inject constructor(
         private const val SONG_SELECTION_PAGE_SIZE = 100 // Cargar 100 canciones a la vez para el selector
     }
 
-    // Helper function to convert SortOption name string to SortOption object for playlists
-    private fun getPlaylistSortOptionFromString(optionName: String?): SortOption {
-        return when (optionName) {
-            SortOption.PlaylistNameAZ.displayName -> SortOption.PlaylistNameAZ
-            SortOption.PlaylistNameZA.displayName -> SortOption.PlaylistNameZA
-            SortOption.PlaylistDateCreated.displayName -> SortOption.PlaylistDateCreated
-            else -> SortOption.PlaylistNameAZ // Default if unknown or null
-        }
+    // Helper function to resolve stored playlist sort keys
+    private fun resolvePlaylistSortOption(optionKey: String?): SortOption {
+        return SortOption.fromStorageKey(
+            optionKey,
+            SortOption.PLAYLISTS,
+            SortOption.PlaylistNameAZ
+        )
     }
 
     init {
@@ -66,7 +65,7 @@ class PlaylistViewModel @Inject constructor(
         viewModelScope.launch {
             // First, get the initial sort option
             val initialSortOptionName = userPreferencesRepository.playlistsSortOptionFlow.first()
-            val initialSortOption = getPlaylistSortOptionFromString(initialSortOptionName)
+            val initialSortOption = resolvePlaylistSortOption(initialSortOptionName)
             _uiState.update { it.copy(currentPlaylistSortOption = initialSortOption) }
 
             // Then, collect playlists and apply the sort option
@@ -84,7 +83,7 @@ class PlaylistViewModel @Inject constructor(
         // Collect subsequent changes to sort option from preferences
         viewModelScope.launch {
             userPreferencesRepository.playlistsSortOptionFlow.collect { optionName ->
-                val newSortOption = getPlaylistSortOptionFromString(optionName)
+                val newSortOption = resolvePlaylistSortOption(optionName)
                 if (_uiState.value.currentPlaylistSortOption != newSortOption) {
                     // If the option from preferences is different, re-sort the current list
                     sortPlaylists(newSortOption)
@@ -272,7 +271,7 @@ class PlaylistViewModel @Inject constructor(
         _uiState.update { it.copy(playlists = sortedPlaylists) }
 
         viewModelScope.launch {
-            userPreferencesRepository.setPlaylistsSortOption(sortOption.displayName)
+            userPreferencesRepository.setPlaylistsSortOption(sortOption.storageKey)
         }
     }
 }


### PR DESCRIPTION
This commit replaces the legacy dropdown menu for sorting in the library with a new `LibrarySortBottomSheet`. This improves the user experience and modernizes the component.

Key changes include:
- **`LibrarySortBottomSheet.kt`**: New composable for the bottom sheet UI.
- **`LibraryActionRow.kt`**: Removed the `DropdownMenu` and replaced it with a simple `onSortClick` callback to trigger the bottom sheet.
- **`SortOption.kt`**: Refactored to include a stable `storageKey` for persistence, separate from the `displayName`. A `fromStorageKey` companion function was added for safe parsing and legacy value migration.
- **ViewModels**: `PlayerViewModel` and `PlaylistViewModel` are updated to use `storageKey` for saving sort preferences and to manage the visibility of the new bottom sheet.
- **`LibraryScreen.kt`**: Integrated the `LibrarySortBottomSheet` and updated the logic to handle its state and actions. The tab management logic was also refactored to use `LibraryTabId` enum and `storageKey` for persistence and state handling.
- **`UserPreferencesRepository.kt`**: Added logic to migrate old display name-based sort preferences to the new storage key system.
- **`LibraryTabId.kt`**: Introduced a new enum to represent library tabs with stable `storageKey`, `title`, and default `SortOption`.