### PR TITLE
Fix stats screen unknown songs and maintain song selection highlight

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
@@ -230,13 +230,16 @@ class PlaybackStatsRepository @Inject constructor(
         val uniqueSongs = segmentsBySong.keys.size
 
         val allSongs = segmentsBySong
-            .map { (songId, segmentsForSong) ->
-                val song = songMap[songId]
+            .mapNotNull { (songId, segmentsForSong) ->
+                val song = songMap[songId] ?: return@mapNotNull null
+                val title = song.title.takeIf { it.isNotBlank() }
+                    ?: song.path.substringAfterLast('/').ifBlank { return@mapNotNull null }
+                val artist = song.artist.takeIf { it.isNotBlank() } ?: "Unknown Artist"
                 SongPlaybackSummary(
                     songId = songId,
-                    title = song?.title ?: "Unknown Track",
-                    artist = song?.artist ?: "Unknown Artist",
-                    albumArtUri = song?.albumArtUriString,
+                    title = title,
+                    artist = artist,
+                    albumArtUri = song.albumArtUriString,
                     totalDurationMs = segmentsForSong.sumOf { it.durationMs },
                     playCount = segmentsForSong.size
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
@@ -204,7 +204,7 @@ fun AlbumDetailScreen(
                     items(songs, key = { song -> "album_song_${song.id}" }) { song ->
                         EnhancedSongListItem(
                             song = song,
-                            isCurrentSong = songs.isNotEmpty() && stablePlayerState.currentSong == song,
+                            isCurrentSong = stablePlayerState.currentSong?.id == song.id,
                             isPlaying = stablePlayerState.isPlaying,
                             onMoreOptionsClick = {
                                 playerViewModel.selectSongForInfo(song)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -217,7 +217,7 @@ fun ArtistDetailScreen(
                                 EnhancedSongListItem(
                                     modifier = Modifier.padding(horizontal = 16.dp),
                                     song = song,
-                                    isCurrentSong = stablePlayerState.currentSong == song,
+                                    isCurrentSong = stablePlayerState.currentSong?.id == song.id,
                                     isPlaying = stablePlayerState.isPlaying,
                                     onMoreOptionsClick = {
                                         playerViewModel.selectSongForInfo(song)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -278,7 +278,7 @@ fun DailyMixScreen(
                         modifier = Modifier
                             .padding(horizontal = 16.dp),
                         song = song,
-                        isCurrentSong = dailyMixSongs.isNotEmpty() && stablePlayerState.currentSong == song,
+                        isCurrentSong = stablePlayerState.currentSong?.id == song.id,
                         isPlaying = currentSongId == song.id && isPlaying,
                         onClick = { playerViewModel.showAndPlaySong(song, dailyMixSongs, "Daily Mix", isVoluntaryPlay = false) },
                         onMoreOptionsClick = {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -1110,7 +1110,7 @@ fun LibraryFavoritesTab(
                     val isPlayingThisSong = song.id == stablePlayerState.currentSong?.id && stablePlayerState.isPlaying
                     EnhancedSongListItem(
                         song = song,
-                        isCurrentSong = favoriteSongs.isNotEmpty() && stablePlayerState.currentSong == song,
+                        isCurrentSong = stablePlayerState.currentSong?.id == song.id,
                         isPlaying = isPlayingThisSong,
                         onMoreOptionsClick = { onMoreOptionsClick(song) },
                         onClick = { playerViewModel.showAndPlaySong(song, favoriteSongs, "Liked Songs") }
@@ -1263,7 +1263,7 @@ fun LibrarySongsTab(
                             EnhancedSongListItem(
                                 song = song,
                                 isPlaying = isPlayingThisSong,
-                                isCurrentSong = songs.isNotEmpty() && stablePlayerState.currentSong == song,
+                                isCurrentSong = stablePlayerState.currentSong?.id == song.id,
                                 isLoading = false,
                                 onMoreOptionsClick = rememberedOnMoreOptionsClick,
                                 onClick = rememberedOnClick


### PR DESCRIPTION
## Summary
- filter out playback stats entries without backing song metadata to avoid showing broken "Unknown Track" rows
- keep displaying artists for blank metadata using existing fallbacks while still skipping orphaned songs
- compare songs by id in list screens so selection highlight animations continue to work after metadata edits

## Testing
- ./gradlew test *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_6903602b6118832f96dc67631ba97ff2