### PR TITLE
Handle ImageVector models in SmartImage

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
@@ -1,28 +1,23 @@
 package com.theveloper.pixelplay.presentation.components
 
-import android.graphics.drawable.BitmapDrawable
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import coil.annotation.ExperimentalCoilApi
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
 import coil.request.CachePolicy
 import coil.request.ImageRequest
 import com.theveloper.pixelplay.R
-import kotlinx.coroutines.Dispatchers
 import coil.size.Size // Import Coil's Size
 
 @Composable
@@ -44,6 +39,32 @@ fun SmartImage(
     onState: ((AsyncImagePainter.State) -> Unit)? = null
 ) {
     val context = LocalContext.current
+    val clippedModifier = modifier.clip(shape)
+
+    when (model) {
+        is ImageVector -> {
+            Image(
+                imageVector = model,
+                contentDescription = contentDescription,
+                modifier = clippedModifier,
+                contentScale = contentScale,
+                colorFilter = colorFilter,
+                alpha = alpha
+            )
+            return
+        }
+        is Painter -> {
+            Image(
+                painter = model,
+                contentDescription = contentDescription,
+                modifier = clippedModifier,
+                contentScale = contentScale,
+                colorFilter = colorFilter,
+                alpha = alpha
+            )
+            return
+        }
+    }
 
     val requestBuilder = ImageRequest.Builder(context)
         .data(model)
@@ -63,7 +84,7 @@ fun SmartImage(
     AsyncImage(
         model = requestBuilder.build(),
         contentDescription = contentDescription,
-        modifier = modifier.clip(shape),
+        modifier = clippedModifier,
         contentScale = contentScale,
         colorFilter = colorFilter,
         alpha = alpha,


### PR DESCRIPTION
## Summary
- render ImageVector and Painter models directly in SmartImage instead of passing them to Coil
- reuse the clipped modifier for all rendering paths to prevent crashes when falling back to vector assets

## Testing
- :app:compileDebugKotlin *(fails: missing Android SDK path in local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_690390f0b89c832fae5b82b608c272d8