### PR TITLE
Fix bottom bars layout with navigation insets

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -96,6 +96,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -123,6 +124,7 @@ import com.theveloper.pixelplay.presentation.components.NavBarContentHeight
 import com.theveloper.pixelplay.presentation.components.NavBarContentHeightFullWidth
 import kotlin.math.pow
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.NavigationBarDefaults
 import androidx.compose.ui.platform.LocalWindowInfo

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -459,46 +459,45 @@ fun LyricsSheet(
                 }
             }
 
-                val bottomPadding = paddingValues.calculateBottomPadding() + 10.dp
-                val footerBaseHeight = 76.dp
+            val bottomPadding = paddingValues.calculateBottomPadding() + 10.dp
+            val footerBaseHeight = 76.dp
 
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .heightIn(min = footerBaseHeight + bottomPadding)
-                        .background(
-                            brush = Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    containerColor
-                                )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .heightIn(min = footerBaseHeight + bottomPadding)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                containerColor
                             )
                         )
-                ) {
-
-                }
-
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                        .padding(bottom = bottomPadding)
-                        .padding(horizontal = 24.dp)
-                ) {
-                    PlayerSeekBar(
-                        backgroundColor = backgroundColor,
-                        onBackgroundColor = onBackgroundColor,
-                        primaryColor = accentColor,
-                        currentPosition = playerUiState.currentPosition,
-                        totalDuration = stablePlayerState.totalDuration,
-                        onSeek = onSeekTo,
-                        isPlaying = isPlaying,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(70.dp)
                     )
-                }
+            ) {
+
+            }
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(bottom = bottomPadding)
+                    .padding(horizontal = 24.dp)
+            ) {
+                PlayerSeekBar(
+                    backgroundColor = backgroundColor,
+                    onBackgroundColor = onBackgroundColor,
+                    primaryColor = accentColor,
+                    currentPosition = playerUiState.currentPosition,
+                    totalDuration = stablePlayerState.totalDuration,
+                    onSeek = onSeekTo,
+                    isPlaying = isPlaying,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(50.dp)
+                )
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayerInternalNavigationBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayerInternalNavigationBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars


### PR DESCRIPTION
## Summary
- keep the player navigation bar height constant and offset it with navigation bar padding instead of height inflation
- fix the lyrics sheet seek bar layout by applying insets as outer padding while retaining its fixed height
- simplify navigation bar item padding so it no longer depends on system navigation insets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc3e0f724832faccfa3747de0855e)