### PR TITLE
Fix NullPointerException crash when lyrics end

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -124,7 +124,7 @@ fun LyricsSheet(
             onDismiss = {
                 showFetchLyricsDialog = false
                 onDismissLyricsSearch()
-             },
+            },
             onImport = onImportLyrics
         )
     }
@@ -244,7 +244,12 @@ fun LyricsSheet(
                                     onDismissRequest = { expanded = false }
                                 ) {
                                     DropdownMenuItem(
-                                        leadingIcon = { Icon(painter = painterResource(R.drawable.outline_restart_alt_24), contentDescription = null) },
+                                        leadingIcon = {
+                                            Icon(
+                                                painter = painterResource(R.drawable.outline_restart_alt_24),
+                                                contentDescription = null
+                                            )
+                                        },
                                         text = { Text(text = "Reset imported lyrics") },
                                         onClick = {
                                             expanded = false
@@ -253,8 +258,7 @@ fun LyricsSheet(
                                     )
                                 }
                             }
-                        }
-                        ,
+                        },
                         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                             containerColor = Color.Transparent
                         )
@@ -394,6 +398,7 @@ fun LyricsSheet(
                         }
                     }
                 }
+
                 true -> {
                     lyrics?.synced?.let { synced ->
                         SyncedLyricsList(
@@ -415,7 +420,7 @@ fun LyricsSheet(
                             highlightOffsetDp = highlightOffsetDp,
                             autoscrollAnimationSpec = autoscrollAnimationSpec,
                             footer = {
-                                if (lyrics!!.areFromRemote) {
+                                if (lyrics?.areFromRemote == true) {
                                     item(key = "provider_text") {
                                         ProviderText(
                                             providerText = context.resources.getString(R.string.lyrics_provided_by),
@@ -431,6 +436,7 @@ fun LyricsSheet(
                         )
                     }
                 }
+
                 false -> {
                     lyrics?.plain?.let { plain ->
                         LazyColumn(


### PR DESCRIPTION
### Problem
App was crashing with `NullPointerException` when lyrics finished playing. The crash occurred in `LyricsSheet.kt` at line 418 where `lyrics!!.areFromRemote` was being accessed.

### Cause
The `footer` lambda passed to `SyncedLyricsList` was being called by `LazyColumn` after the `lyrics` state had already become null (when song ends or changes).

### Solution
Replaced unsafe `lyrics!!.areFromRemote` with safe null check `lyrics?.areFromRemote == true`.
Reverted my codex pr since its making it way worse.
