### PR TITLE
Improve cast queue display and add cast connecting state

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -94,6 +95,7 @@ fun CastBottomSheet(
     val isWifiEnabled by playerViewModel.isWifiEnabled.collectAsState()
     val isBluetoothEnabled by playerViewModel.isBluetoothEnabled.collectAsState()
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsState()
+    val isCastConnecting by playerViewModel.isCastConnecting.collectAsState()
     val trackVolume by playerViewModel.trackVolume.collectAsState()
 
     val activeRoute = selectedRoute?.takeUnless { it.isDefault }
@@ -136,6 +138,7 @@ fun CastBottomSheet(
             item {
                 CastStatusHeader(
                     isRemote = isRemoteSession,
+                    isConnecting = isCastConnecting,
                     routeName = activeRoute?.name ?: "This device",
                     isPlaying = playerViewModel.stablePlayerState.collectAsState().value.isPlaying,
                     onDisconnect = { playerViewModel.disconnect() },
@@ -218,7 +221,11 @@ private fun CastStatusHeader(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = if (isRemote) "Casting on" else "Playing on",
+                    text = when {
+                        isConnecting -> "Connecting to"
+                        isRemote -> "Casting on"
+                        else -> "Playing on"
+                    },
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer
                 )
@@ -260,6 +267,13 @@ private fun CastStatusHeader(
             }
 
             Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (isConnecting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(28.dp),
+                        strokeWidth = 3.dp,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                }
                 FilledIconButton(
                     onClick = onRefresh,
                     colors = IconButtonDefaults.filledIconButtonColors(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -329,6 +330,7 @@ fun FullPlayerContent(
                         horizontalArrangement = Arrangement.spacedBy(6.dp)
                     ) {
                         val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsState()
+                        val isCastConnecting by playerViewModel.isCastConnecting.collectAsState()
                         val selectedRouteName by playerViewModel.selectedRoute.map { it?.name }.collectAsState(initial = null)
                         Box(
                             modifier = Modifier
@@ -353,7 +355,22 @@ fun FullPlayerContent(
                                     contentDescription = "Cast",
                                     tint = if (isRemotePlaybackActive) LocalMaterialTheme.current.onPrimaryContainer else LocalMaterialTheme.current.primary
                                 )
-                                AnimatedVisibility(visible = isRemotePlaybackActive && selectedRouteName != null) {
+                                AnimatedVisibility(visible = isCastConnecting) {
+                                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(12.dp),
+                                            strokeWidth = 2.dp,
+                                            color = LocalMaterialTheme.current.onPrimaryContainer
+                                        )
+                                        Text(
+                                            text = "Connecting…",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = LocalMaterialTheme.current.onPrimaryContainer,
+                                            maxLines = 1
+                                        )
+                                    }
+                                }
+                                AnimatedVisibility(visible = !isCastConnecting && isRemotePlaybackActive && selectedRouteName != null) {
                                     Text(
                                         text = selectedRouteName ?: "",
                                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -381,6 +381,8 @@ class PlayerViewModel @Inject constructor(
     private var castPlayer: CastPlayer? = null
     private val _isRemotePlaybackActive = MutableStateFlow(false)
     val isRemotePlaybackActive: StateFlow<Boolean> = _isRemotePlaybackActive.asStateFlow()
+    private val _isCastConnecting = MutableStateFlow(false)
+    val isCastConnecting: StateFlow<Boolean> = _isCastConnecting.asStateFlow()
     private val _remotePosition = MutableStateFlow(0L)
     val remotePosition: StateFlow<Long> = _remotePosition.asStateFlow()
     private val _trackVolume = MutableStateFlow(1.0f)
@@ -1047,8 +1049,20 @@ class PlayerViewModel @Inject constructor(
                         }
                     }
                 }
-                _playerUiState.update {
-                    it.copy(currentPlaybackQueue = newQueue)
+                val previousQueue = _playerUiState.value.currentPlaybackQueue
+                val isSubsetOfPrevious =
+                    previousQueue.isNotEmpty() && newQueue.isNotEmpty() && newQueue.all { song ->
+                        previousQueue.any { it.id == song.id }
+                    }
+                val queueForUi = when {
+                    newQueue.isEmpty() -> previousQueue
+                    isSubsetOfPrevious && newQueue.size < previousQueue.size -> previousQueue
+                    else -> newQueue
+                }
+                if (queueForUi.isNotEmpty() || previousQueue.isNotEmpty()) {
+                    _playerUiState.update {
+                        it.copy(currentPlaybackQueue = queueForUi)
+                    }
                 }
                 val isPlaying = mediaStatus.playerState == MediaStatus.PLAYER_STATE_PLAYING
                 lastKnownRemoteIsPlaying = isPlaying
@@ -1082,16 +1096,23 @@ class PlayerViewModel @Inject constructor(
         castSessionManagerListener = object : SessionManagerListener<CastSession> {
             private fun transferPlayback(session: CastSession) {
                 viewModelScope.launch {
+                    _isCastConnecting.value = true
                     if (!ensureHttpServerRunning()) {
                         sendToast("Could not start cast server. Check connection.")
+                        _isCastConnecting.value = false
                         disconnect()
                         return@launch
                     }
 
-                    val serverAddress = MediaFileHttpServerService.serverAddress ?: return@launch
-                    val localPlayer = mediaController ?: return@launch
+                    val serverAddress = MediaFileHttpServerService.serverAddress
+                    val localPlayer = mediaController
                     val currentQueue = _playerUiState.value.currentPlaybackQueue
-                    if (currentQueue.isEmpty()) return@launch
+                    if (serverAddress == null || localPlayer == null || currentQueue.isEmpty()) {
+                        _isCastConnecting.value = false
+                        return@launch
+                    }
+
+                    _isSheetVisible.value = true
 
                     val wasPlaying = localPlayer.isPlaying
                     val currentSongIndex = localPlayer.currentMediaItemIndex
@@ -1112,7 +1133,7 @@ class PlayerViewModel @Inject constructor(
 
                     castPlayer = CastPlayer(session)
                     _castSession.value = session
-                    _isRemotePlaybackActive.value = true
+                    _isRemotePlaybackActive.value = false
 
                     castPlayer?.loadQueue(
                         songs = currentQueue,
@@ -1125,7 +1146,10 @@ class PlayerViewModel @Inject constructor(
                             if (!success) {
                                 sendToast("Failed to load media on cast device.")
                                 disconnect()
+                                _isCastConnecting.value = false
                             }
+                            _isRemotePlaybackActive.value = success
+                            _isCastConnecting.value = false
                         }
                     )
 
@@ -1164,6 +1188,7 @@ class PlayerViewModel @Inject constructor(
                 castPlayer = null
                 _castSession.value = null
                 _isRemotePlaybackActive.value = false
+                _isCastConnecting.value = false
                 context.stopService(Intent(context, MediaFileHttpServerService::class.java))
                 disconnect()
                 val localPlayer = mediaController ?: return
@@ -1218,11 +1243,21 @@ class PlayerViewModel @Inject constructor(
             }
 
             // Other listener methods can be overridden if needed
-            override fun onSessionStarting(session: CastSession) {}
-            override fun onSessionStartFailed(session: CastSession, error: Int) {}
-            override fun onSessionEnding(session: CastSession) {}
-            override fun onSessionResuming(session: CastSession, sessionId: String) {}
-            override fun onSessionResumeFailed(session: CastSession, error: Int) {}
+            override fun onSessionStarting(session: CastSession) {
+                _isCastConnecting.value = true
+            }
+            override fun onSessionStartFailed(session: CastSession, error: Int) {
+                _isCastConnecting.value = false
+            }
+            override fun onSessionEnding(session: CastSession) {
+                _isCastConnecting.value = false
+            }
+            override fun onSessionResuming(session: CastSession, sessionId: String) {
+                _isCastConnecting.value = true
+            }
+            override fun onSessionResumeFailed(session: CastSession, error: Int) {
+                _isCastConnecting.value = false
+            }
         }
         sessionManager.addSessionManagerListener(castSessionManagerListener as SessionManagerListener<CastSession>, CastSession::class.java)
         _castSession.value = sessionManager.currentCastSession
@@ -3511,6 +3546,7 @@ class PlayerViewModel @Inject constructor(
     fun disconnect() {
         mediaRouter.selectRoute(mediaRouter.defaultRoute)
         _isRemotePlaybackActive.value = false
+        _isCastConnecting.value = false
     }
 
     fun setRouteVolume(volume: Int) {


### PR DESCRIPTION
## Summary
- keep the queue UI using the full playlist during cast sessions instead of truncating to current and next items
- add cast connection state management so the player stays visible while establishing remote playback
- surface "connecting" indicators in the cast controls while sessions are being set up

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934bae366c0832faea4a5af9fd127cb)