### PR TITLE
Implement hierarchical file explorer for directory selection

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/FileExplorerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/FileExplorerBottomSheet.kt
@@ -1,0 +1,288 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.FolderOff
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import java.io.File
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
+@Composable
+fun FileExplorerBottomSheet(
+    currentPath: File,
+    children: List<File>,
+    allowedDirectories: Set<String>,
+    isLoading: Boolean,
+    canNavigateUp: Boolean,
+    onNavigateUp: () -> Unit,
+    onDirectoryClick: (File) -> Unit,
+    onToggleAllowed: (File) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight(0.92f)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            FileExplorerNavigationHeader(
+                currentPath = currentPath,
+                canNavigateUp = canNavigateUp,
+                onNavigateUp = onNavigateUp,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            AnimatedContent(
+                targetState = currentPath.absolutePath,
+                transitionSpec = {
+                    slideInHorizontally(animationSpec = tween(300)) { it } togetherWith
+                        slideOutHorizontally(animationSpec = tween(250)) { -it } using
+                        SizeTransform(clip = false)
+                },
+                label = "DirectoryTransition"
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(AbsoluteSmoothCornerShape(18.dp, 70))
+                        .background(MaterialTheme.colorScheme.surface)
+                ) {
+                    when {
+                        isLoading -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                androidx.compose.material3.CircularProgressIndicator(
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                            }
+                        }
+
+                        children.isEmpty() -> {
+                            EmptyDirectoryState()
+                        }
+
+                        else -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.spacedBy(10.dp),
+                                contentPadding = BottomSheetDefaults.windowInsets.asPaddingValues()
+                            ) {
+                                items(children, key = { it.absolutePath }) { child ->
+                                    val isAllowed = allowedDirectories.contains(child.absolutePath)
+                                    FileExplorerItem(
+                                        file = child,
+                                        isAllowed = isAllowed,
+                                        onNavigate = onDirectoryClick,
+                                        onToggle = onToggleAllowed
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FileExplorerNavigationHeader(
+    currentPath: File,
+    canNavigateUp: Boolean,
+    onNavigateUp: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        IconButton(
+            onClick = onNavigateUp,
+            enabled = canNavigateUp,
+            colors = IconButtonDefaults.filledIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+            ),
+            modifier = Modifier.clip(CircleShape)
+        ) {
+            Icon(imageVector = Icons.Rounded.ArrowBack, contentDescription = "Navigate up")
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            val name = currentPath.name.ifEmpty { currentPath.absolutePath }
+            Text(
+                text = name,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = currentPath.absolutePath,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+fun FileExplorerItem(
+    file: File,
+    isAllowed: Boolean,
+    onNavigate: (File) -> Unit,
+    onToggle: (File) -> Unit,
+) {
+    val containerColor = if (isAllowed) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val contentColor = if (isAllowed) {
+        MaterialTheme.colorScheme.onPrimaryContainer
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    val shape = AbsoluteSmoothCornerShape(20.dp, 65)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(containerColor)
+            .clickable { onNavigate(file) }
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Surface(
+            color = contentColor.copy(alpha = 0.16f),
+            contentColor = contentColor,
+            shape = AbsoluteSmoothCornerShape(14.dp, 70),
+            modifier = Modifier.size(46.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(imageVector = Icons.Rounded.Folder, contentDescription = null)
+            }
+        }
+
+        Column(modifier = Modifier.weight(1f)) {
+            val name = file.name.ifEmpty { file.absolutePath }
+            Text(
+                text = name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = contentColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = file.absolutePath,
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor.copy(alpha = 0.8f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Switch(
+            checked = isAllowed,
+            onCheckedChange = { onToggle(file) },
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                checkedTrackColor = MaterialTheme.colorScheme.primary,
+            )
+        )
+    }
+}
+
+@Composable
+private fun EmptyDirectoryState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Surface(
+            shape = AbsoluteSmoothCornerShape(26.dp, 70),
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+            modifier = Modifier.size(96.dp),
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                Icon(imageVector = Icons.Rounded.FolderOff, contentDescription = null, modifier = Modifier.size(48.dp))
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "No subfolders found here",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = "Try a different folder or create one to continue",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/FileExplorerStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/FileExplorerStateHolder.kt
@@ -1,0 +1,89 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import android.os.Environment
+import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
+import java.io.File
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class FileExplorerStateHolder @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val scope: CoroutineScope,
+) {
+
+    private val explorerRoot: File = Environment.getExternalStorageDirectory().absoluteFile
+
+    private val _currentPath = MutableStateFlow(explorerRoot)
+    val currentPath: StateFlow<File> = _currentPath.asStateFlow()
+
+    private val _currentDirectoryChildren = MutableStateFlow<List<File>>(emptyList())
+    val currentDirectoryChildren: StateFlow<List<File>> = _currentDirectoryChildren.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    val allowedDirectories: StateFlow<Set<String>> = userPreferencesRepository.allowedDirectoriesFlow
+        .stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
+    init {
+        loadDirectory(explorerRoot)
+    }
+
+    fun loadDirectory(file: File) {
+        scope.launch {
+            val target = file.takeIf { it.exists() && it.isDirectory } ?: explorerRoot
+            _isLoading.value = true
+            _currentPath.value = target
+            val children = withContext(Dispatchers.IO) {
+                runCatching {
+                    target.listFiles()
+                        ?.filter { it.isDirectory && !it.isHidden }
+                        ?.sortedBy { it.name.lowercase() }
+                }.getOrNull().orEmpty()
+            }
+            _currentDirectoryChildren.value = children
+            _isLoading.value = false
+        }
+    }
+
+    fun navigateUp(): Boolean {
+        val parent = _currentPath.value.parentFile ?: return false
+        val isAboveRoot = !parent.absolutePath.startsWith(explorerRoot.absolutePath)
+        return if (!isAboveRoot) {
+            loadDirectory(parent)
+            true
+        } else {
+            false
+        }
+    }
+
+    fun resetToRoot() {
+        loadDirectory(explorerRoot)
+    }
+
+    fun toggleDirectoryAllowed(file: File) {
+        scope.launch {
+            val currentAllowed = allowedDirectories.value.toMutableSet()
+            val path = file.absolutePath
+            if (currentAllowed.contains(path)) {
+                currentAllowed.remove(path)
+            } else {
+                currentAllowed.add(path)
+            }
+            userPreferencesRepository.updateAllowedDirectories(currentAllowed)
+        }
+    }
+
+    fun canNavigateUp(): Boolean = _currentPath.value.absolutePath != explorerRoot.absolutePath
+
+    val rootPath: File
+        get() = explorerRoot
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -2,7 +2,6 @@ package com.theveloper.pixelplay.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.theveloper.pixelplay.data.model.DirectoryItem
 import com.theveloper.pixelplay.data.preferences.AppThemeMode
 import com.theveloper.pixelplay.data.preferences.CarouselStyle
 import com.theveloper.pixelplay.data.preferences.ThemePreference
@@ -18,10 +17,9 @@ import com.theveloper.pixelplay.data.preferences.NavBarStyle
 import com.theveloper.pixelplay.data.ai.GeminiModelService
 import com.theveloper.pixelplay.data.ai.GeminiModel
 import com.theveloper.pixelplay.data.preferences.LaunchTab
+import java.io.File
 
 data class SettingsUiState(
-    val directoryItems: List<DirectoryItem> = emptyList(),
-    val isLoadingDirectories: Boolean = true,
     val appThemeMode: String = AppThemeMode.FOLLOW_SYSTEM,
     val playerThemePreference: String = ThemePreference.ALBUM_ART,
     val mockGenresEnabled: Boolean = false,
@@ -57,6 +55,13 @@ class SettingsViewModel @Inject constructor(
 
     val geminiSystemPrompt: StateFlow<String> = userPreferencesRepository.geminiSystemPrompt
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), UserPreferencesRepository.DEFAULT_SYSTEM_PROMPT)
+
+    private val fileExplorerStateHolder = FileExplorerStateHolder(userPreferencesRepository, viewModelScope)
+
+    val currentPath = fileExplorerStateHolder.currentPath
+    val currentDirectoryChildren = fileExplorerStateHolder.currentDirectoryChildren
+    val allowedDirectories = fileExplorerStateHolder.allowedDirectories
+    val isLoadingDirectories = fileExplorerStateHolder.isLoading
 
     init {
         viewModelScope.launch {
@@ -125,42 +130,39 @@ class SettingsViewModel @Inject constructor(
             }
         }
 
-        loadDirectoryPreferences()
+        initializeAllowedDirectories()
     }
 
-    private fun loadDirectoryPreferences() {
+    private fun initializeAllowedDirectories() {
         viewModelScope.launch {
-            userPreferencesRepository.allowedDirectoriesFlow.combine(
-                flow {
-                    emit(musicRepository.getAllUniqueAudioDirectories())
-                }.onStart { _uiState.update { it.copy(isLoadingDirectories = true) } }
-            ) { allowedDirs, allFoundDirs ->
-                val initialSetupDone = userPreferencesRepository.initialSetupDoneFlow.first()
-
-                allFoundDirs.map { dirPath ->
-                    val isAllowed = if (!initialSetupDone) true else allowedDirs.contains(dirPath)
-                    DirectoryItem(path = dirPath, isAllowed = isAllowed)
-                }.sortedBy { it.displayName }
-            }.catch { e ->
-                _uiState.update { it.copy(isLoadingDirectories = false, directoryItems = emptyList()) }
-            }.collectLatest { directoryItems ->
-                _uiState.update { it.copy(directoryItems = directoryItems, isLoadingDirectories = false) }
+            if (!userPreferencesRepository.initialSetupDoneFlow.first()) {
+                val allowedDirs = userPreferencesRepository.allowedDirectoriesFlow.first()
+                if (allowedDirs.isEmpty()) {
+                    val allAudioDirs = musicRepository.getAllUniqueAudioDirectories().toSet()
+                    userPreferencesRepository.updateAllowedDirectories(allAudioDirs)
+                }
             }
         }
     }
 
     // Método para alternar el estado de un directorio y guardar en preferencias
-    fun toggleDirectoryAllowed(directoryItem: DirectoryItem) {
-        viewModelScope.launch {
-            val currentAllowed = userPreferencesRepository.allowedDirectoriesFlow.first().toMutableSet()
-            if (directoryItem.isAllowed) {
-                currentAllowed.remove(directoryItem.path)
-            } else {
-                currentAllowed.add(directoryItem.path)
-            }
-            userPreferencesRepository.updateAllowedDirectories(currentAllowed)
-        }
+    fun loadDirectory(file: File) {
+        fileExplorerStateHolder.loadDirectory(file)
     }
+
+    fun navigateUp(): Boolean = fileExplorerStateHolder.navigateUp()
+
+    fun resetExplorerToRoot() {
+        fileExplorerStateHolder.resetToRoot()
+    }
+
+    fun toggleDirectoryAllowed(file: File) {
+        fileExplorerStateHolder.toggleDirectoryAllowed(file)
+    }
+
+    fun canNavigateUp(): Boolean = fileExplorerStateHolder.canNavigateUp()
+
+    fun explorerRoot(): File = fileExplorerStateHolder.rootPath
 
     // Método para guardar la preferencia de tema del reproductor
     fun setPlayerThemePreference(preference: String) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SetupViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SetupViewModel.kt
@@ -8,31 +8,22 @@ import android.os.Environment
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.theveloper.pixelplay.data.model.DirectoryItem
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.repository.MusicRepository
 import com.theveloper.pixelplay.data.worker.SyncManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.File
 import javax.inject.Inject
 
 data class SetupUiState(
     val mediaPermissionGranted: Boolean = false,
     val notificationsPermissionGranted: Boolean = false,
     val allFilesAccessGranted: Boolean = false,
-    val directoryItems: ImmutableList<DirectoryItem> = persistentListOf(),
-    val isLoadingDirectories: Boolean = false,
 ) {
     val allPermissionsGranted: Boolean
         get() {
@@ -52,6 +43,13 @@ class SetupViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(SetupUiState())
     val uiState = _uiState.asStateFlow()
+
+    private val fileExplorerStateHolder = FileExplorerStateHolder(userPreferencesRepository, viewModelScope)
+
+    val currentPath = fileExplorerStateHolder.currentPath
+    val currentDirectoryChildren = fileExplorerStateHolder.currentDirectoryChildren
+    val allowedDirectories = fileExplorerStateHolder.allowedDirectories
+    val isLoadingDirectories = fileExplorerStateHolder.isLoading
 
     // init block removed
 
@@ -92,34 +90,26 @@ class SetupViewModel @Inject constructor(
                     userPreferencesRepository.updateAllowedDirectories(allAudioDirs)
                 }
             }
-
-            userPreferencesRepository.allowedDirectoriesFlow.combine(
-                flow {
-                    emit(musicRepository.getAllUniqueAudioDirectories())
-                }.onStart { _uiState.update { it.copy(isLoadingDirectories = true) } }
-            ) { allowedDirs, allFoundDirs ->
-                allFoundDirs.map { dirPath ->
-                    DirectoryItem(path = dirPath, isAllowed = allowedDirs.contains(dirPath))
-                }.sortedBy { it.displayName }
-            }.catch {
-                _uiState.update { it.copy(isLoadingDirectories = false, directoryItems = persistentListOf()) }
-            }.collect { directoryItems ->
-                _uiState.update { it.copy(directoryItems = directoryItems.toImmutableList(), isLoadingDirectories = false) }
-            }
         }
     }
 
-    fun toggleDirectoryAllowed(directoryItem: DirectoryItem) {
-        viewModelScope.launch {
-            val currentAllowed = userPreferencesRepository.allowedDirectoriesFlow.first().toMutableSet()
-            if (directoryItem.isAllowed) {
-                currentAllowed.remove(directoryItem.path)
-            } else {
-                currentAllowed.add(directoryItem.path)
-            }
-            userPreferencesRepository.updateAllowedDirectories(currentAllowed)
-        }
+    fun loadDirectory(file: File) {
+        fileExplorerStateHolder.loadDirectory(file)
     }
+
+    fun navigateUp(): Boolean = fileExplorerStateHolder.navigateUp()
+
+    fun resetExplorerToRoot() {
+        fileExplorerStateHolder.resetToRoot()
+    }
+
+    fun toggleDirectoryAllowed(file: File) {
+        fileExplorerStateHolder.toggleDirectoryAllowed(file)
+    }
+
+    fun canNavigateUp(): Boolean = fileExplorerStateHolder.canNavigateUp()
+
+    fun explorerRoot(): File = fileExplorerStateHolder.rootPath
 
     fun setSetupComplete() {
         viewModelScope.launch {


### PR DESCRIPTION
## Summary
- add a shared file explorer state holder and modal bottom sheet to browse folders hierarchically and mark allowed music directories
- refactor setup and settings view models/screens to use the hierarchical explorer with permission-aware navigation handling
- style the explorer with Material 3 expressive patterns including smooth corner shapes and animated transitions

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b1c86590832f83374a6f327688f5)