### PR TITLE
Fix background playback resilience

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -95,6 +95,7 @@ class MusicService : MediaSessionService() {
     override fun onCreate() {
         super.onCreate()
 
+        engine.ensureInitialized()
         engine.masterPlayer.addListener(playerListener)
 
         // Handle player swaps (crossfade) to keep MediaSession in sync
@@ -309,9 +310,13 @@ class MusicService : MediaSessionService() {
             return
         }
 
-        if (player == null || !player.playWhenReady || player.mediaItemCount == 0 || player.playbackState == Player.STATE_ENDED) {
+        if (player == null || player.mediaItemCount == 0) {
             stopSelf()
+            super.onTaskRemoved(rootIntent)
+            return
         }
+
+        mediaSession?.let { onUpdateNotification(it) }
         super.onTaskRemoved(rootIntent)
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -43,6 +43,7 @@ class DualPlayerEngine @Inject constructor(
 
     private var playerA: ExoPlayer
     private var playerB: ExoPlayer
+    private var isReleased = false
 
     private val onPlayerSwappedListeners = mutableListOf<(Player) -> Unit>()
 
@@ -100,7 +101,10 @@ class DualPlayerEngine @Inject constructor(
 
     /** The master player instance that should be connected to the MediaSession. */
     val masterPlayer: Player
-        get() = playerA
+        get() {
+            ensureInitialized()
+            return playerA
+        }
 
     fun isTransitionRunning(): Boolean = transitionRunning
 
@@ -109,9 +113,19 @@ class DualPlayerEngine @Inject constructor(
         // We manage Audio Focus manually via AudioFocusManager.
         playerA = buildPlayer(handleAudioFocus = false)
         playerB = buildPlayer(handleAudioFocus = false)
+        isReleased = false
 
         // Attach listener to initial master
         playerA.addListener(masterPlayerListener)
+    }
+
+    fun ensureInitialized() {
+        if (!isReleased) return
+
+        playerA = buildPlayer(handleAudioFocus = false)
+        playerB = buildPlayer(handleAudioFocus = false)
+        playerA.addListener(masterPlayerListener)
+        isReleased = false
     }
 
     private fun requestAudioFocus() {
@@ -402,5 +416,6 @@ class DualPlayerEngine @Inject constructor(
         transitionJob?.cancel()
         playerA.release()
         playerB.release()
+        isReleased = true
     }
 }


### PR DESCRIPTION
## Summary
- ensure the dual-player engine can reinitialize after a service shutdown so playback can restart cleanly
- keep the music service alive when background playback is allowed and refresh the notification instead of stopping during task removal

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfb711ac4832f899a46614963f586)