### PR TITLE
Hide navigation bar when search is active

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -398,6 +398,7 @@ class MainActivity : ComponentActivity() {
         }
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
+        var isSearchBarActive by remember { mutableStateOf(false) }
         val routesWithHiddenNavigationBar = remember {
             setOf(
                 Screen.Settings.route,
@@ -415,17 +416,21 @@ class MainActivity : ComponentActivity() {
                 Screen.ArtistSettings.route
             )
         }
-        val shouldHideNavigationBar by remember(currentRoute) {
+        val shouldHideNavigationBar by remember(currentRoute, isSearchBarActive) {
             derivedStateOf {
-                currentRoute?.let { route ->
-                    routesWithHiddenNavigationBar.any { hiddenRoute ->
-                        if (hiddenRoute.contains("{")) {
-                            route.startsWith(hiddenRoute.substringBefore("{"))
-                        } else {
-                            route == hiddenRoute
+                if (currentRoute == Screen.Search.route && isSearchBarActive) {
+                    true
+                } else {
+                    currentRoute?.let { route ->
+                        routesWithHiddenNavigationBar.any { hiddenRoute ->
+                            if (hiddenRoute.contains("{")) {
+                                route.startsWith(hiddenRoute.substringBefore("{"))
+                            } else {
+                                route == hiddenRoute
+                            }
                         }
-                    }
-                } ?: false
+                    } ?: false
+                }
             }
         }
 
@@ -581,7 +586,8 @@ class MainActivity : ComponentActivity() {
                     playerViewModel = playerViewModel,
                     navController = navController,
                     paddingValues = innerPadding,
-                    userPreferencesRepository = userPreferencesRepository
+                    userPreferencesRepository = userPreferencesRepository,
+                    onSearchBarActiveChange = { isSearchBarActive = it }
                 )
 
                 UnifiedPlayerSheet(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -48,7 +48,8 @@ fun AppNavigation(
     playerViewModel: PlayerViewModel,
     navController: NavHostController,
     paddingValues: PaddingValues,
-    userPreferencesRepository: UserPreferencesRepository
+    userPreferencesRepository: UserPreferencesRepository,
+    onSearchBarActiveChange: (Boolean) -> Unit
 ) {
     var startDestination by remember { mutableStateOf<String?>(null) }
 
@@ -79,7 +80,12 @@ fun AppNavigation(
                 popEnterTransition = { enterTransition() },
                 popExitTransition = { exitTransition() },
             ) {
-                SearchScreen(paddingValues = paddingValues, playerViewModel = playerViewModel, navController = navController)
+                SearchScreen(
+                    paddingValues = paddingValues,
+                    playerViewModel = playerViewModel,
+                    navController = navController,
+                    onSearchBarActiveChange = onSearchBarActiveChange
+                )
             }
             composable(
                 Screen.Library.route,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -111,7 +112,8 @@ fun SearchScreen(
     paddingValues: PaddingValues,
     playerViewModel: PlayerViewModel = hiltViewModel(),
     playlistViewModel: PlaylistViewModel = hiltViewModel(),
-    navController: NavHostController
+    navController: NavHostController,
+    onSearchBarActiveChange: (Boolean) -> Unit = {}
 ) {
     var searchQuery by remember { mutableStateOf("") }
     var active by remember { mutableStateOf(false) }
@@ -169,6 +171,14 @@ fun SearchScreen(
     }
 
     val colorScheme = MaterialTheme.colorScheme
+
+    LaunchedEffect(active) {
+        onSearchBarActiveChange(active)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { onSearchBarActiveChange(false) }
+    }
 
     Box(
         modifier = Modifier


### PR DESCRIPTION
## Summary
- add a callback from SearchScreen to report when the search bar is expanded
- allow AppNavigation/MainActivity to hide the navigation bar only while the Search screen is active and the bar is expanded

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459ed3c758832fa28563ea0d326cfe)