### PR TITLE
Fix Glance widget placeholder and preview reliability

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -1163,14 +1163,31 @@ class PixelPlayGlanceWidget : GlanceAppWidget() {
                     contentScale = ContentScale.Crop
                 )
             } else {
-                // Placeholder with tint
-                Image(
-                    provider = ImageProvider(R.drawable.rounded_album_24),
-                    contentDescription = "Album Art Placeholder",
-                    modifier = GlanceModifier.fillMaxSize().cornerRadius(cornerRadius),
-                    contentScale = ContentScale.Crop,
-                    colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurface)
-                )
+                val placeholderBaseSize = size ?: minOf(widgetDpSize.width, widgetDpSize.height)
+                val resolvedPlaceholderBaseSize = when {
+                    placeholderBaseSize == Dp.Unspecified || placeholderBaseSize <= 0.dp -> 72.dp
+                    else -> placeholderBaseSize
+                }
+
+                val placeholderSize = resolvedPlaceholderBaseSize
+                    .times(0.65f)
+                    .coerceIn(36.dp, 96.dp)
+
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .cornerRadius(cornerRadius)
+                        .background(GlanceTheme.colors.surfaceVariant),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        provider = ImageProvider(R.drawable.ic_music_placeholder),
+                        contentDescription = "Album Art Placeholder",
+                        modifier = GlanceModifier.size(placeholderSize),
+                        contentScale = ContentScale.Fit,
+                        colorFilter = ColorFilter.tint(GlanceTheme.colors.onSurfaceVariant)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/res/layout/glance_widget_preview_4x2.xml
+++ b/app/src/main/res/layout/glance_widget_preview_4x2.xml
@@ -4,7 +4,6 @@
     android:layout_width="250dp"
     android:layout_height="180dp"
     android:orientation="vertical"
-    android:theme="@style/Theme.Material3.DynamicColors.DayNight"
     android:background="@drawable/widget_preview_background"
     android:gravity="center_horizontal"
     android:padding="16dp">
@@ -21,8 +20,9 @@
             android:layout_width="80dp"
             android:layout_height="80dp"
             android:background="@drawable/widget_preview_album_art_background"
-            android:src="@drawable/ic_music_note_widget_preview"
-            android:padding="20dp" />
+            android:src="@drawable/ic_music_placeholder"
+            android:scaleType="centerInside"
+            android:padding="18dp" />
 
         <Space
             android:layout_width="12dp"
@@ -38,7 +38,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Song Title"
-                android:textColor="?attr/colorOnSurface"
+                android:textColor="@color/white"
                 android:textSize="16sp"
                 android:textStyle="bold"
                 android:maxLines="2"
@@ -54,7 +54,7 @@
                 android:text="Artist"
                 android:maxLines="2"
                 android:ellipsize="end"
-                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textColor="@color/white"
                 android:textSize="13sp" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/xml/pixelplay_glance_widget_info.xml
+++ b/app/src/main/res/xml/pixelplay_glance_widget_info.xml
@@ -8,6 +8,7 @@
     android:initialLayout="@layout/glance_default_layout"
     android:description="@string/glance_widget_description"
     android:previewLayout="@layout/glance_widget_preview_4x2"
+    android:previewImage="@drawable/widget_preview_background"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:widgetFeatures="reconfigurable|configuration_optional">


### PR DESCRIPTION
## Summary
- align Glance widget album art placeholder with the app’s musical note icon and scale it responsively across widget sizes
- refresh the widget preview layout to use the same placeholder styling without relying on theme attributes
- declare a dedicated preview image to improve launcher widget picker rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad28947fc832f95185050fde7043b)