### PR TITLE
feat: Add Deezer API integration for artist artwork

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/ArtistEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/ArtistEntity.kt
@@ -14,14 +14,16 @@ import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 data class ArtistEntity(
     @PrimaryKey val id: Long,
     @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "track_count") val trackCount: Int
+    @ColumnInfo(name = "track_count") val trackCount: Int,
+    @ColumnInfo(name = "image_url") val imageUrl: String? = null
 )
 
 fun ArtistEntity.toArtist(): Artist {
     return Artist(
         id = this.id,
         name = this.name.normalizeMetadataTextOrEmpty(),
-        songCount = this.trackCount // El modelo Artist usa songCount, MediaStore usa NUMBER_OF_TRACKS
+        songCount = this.trackCount, // El modelo Artist usa songCount, MediaStore usa NUMBER_OF_TRACKS
+        imageUrl = this.imageUrl
     )
 }
 
@@ -33,6 +35,7 @@ fun Artist.toEntity(): ArtistEntity {
     return ArtistEntity(
         id = this.id,
         name = this.name,
-        trackCount = this.songCount
+        trackCount = this.songCount,
+        imageUrl = this.imageUrl
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -211,6 +211,13 @@ interface MusicDao {
         applyDirectoryFilter: Boolean
     ): Flow<List<ArtistEntity>>
 
+    // --- Artist Image Operations ---
+    @Query("SELECT image_url FROM artists WHERE id = :artistId")
+    suspend fun getArtistImageUrl(artistId: Long): String?
+
+    @Query("UPDATE artists SET image_url = :imageUrl WHERE id = :artistId")
+    suspend fun updateArtistImageUrl(artistId: Long, imageUrl: String)
+
     // --- Genre Queries ---
     // Example: Get all songs for a specific genre
     @Query("""
@@ -396,7 +403,7 @@ interface MusicDao {
      * Get all artists with their song counts computed from the junction table.
      */
     @Query("""
-        SELECT artists.id, artists.name, 
+        SELECT artists.id, artists.name, artists.image_url,
                (SELECT COUNT(*) FROM song_artist_cross_ref WHERE song_artist_cross_ref.artist_id = artists.id) AS track_count
         FROM artists
         ORDER BY artists.name ASC
@@ -407,7 +414,7 @@ interface MusicDao {
      * Get all artists with song counts, filtered by allowed directories.
      */
     @Query("""
-        SELECT DISTINCT artists.id, artists.name,
+        SELECT DISTINCT artists.id, artists.name, artists.image_url,
                (SELECT COUNT(*) FROM song_artist_cross_ref 
                 INNER JOIN songs ON song_artist_cross_ref.song_id = songs.id
                 WHERE song_artist_cross_ref.artist_id = artists.id

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -16,7 +16,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         TransitionRuleEntity::class,
         SongArtistCrossRef::class
     ],
-    version = 10, // Incremented version for multi-artist support
+    version = 11, // Incremented version for artist image support
     exportSchema = false
 )
 abstract class PixelPlayDatabase : RoomDatabase() {
@@ -79,6 +79,13 @@ abstract class PixelPlayDatabase : RoomDatabase() {
                     INSERT OR REPLACE INTO song_artist_cross_ref (song_id, artist_id, is_primary)
                     SELECT id, artist_id, 1 FROM songs WHERE artist_id IS NOT NULL
                 """.trimIndent())
+            }
+        }
+
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Add image_url column to artists table for Deezer artist images
+                db.execSQL("ALTER TABLE artists ADD COLUMN image_url TEXT DEFAULT NULL")
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
@@ -17,8 +17,8 @@ data class Album(
 data class Artist(
     val id: Long, // MediaStore.Audio.Artists._ID
     val name: String,
-    val songCount: Int
-    // Podrías añadir una forma de obtener una imagen representativa del artista si es necesario
+    val songCount: Int,
+    val imageUrl: String? = null // Deezer artist image URL
 )
 
 /**

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/deezer/DeezerApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/deezer/DeezerApiService.kt
@@ -1,0 +1,23 @@
+package com.theveloper.pixelplay.data.network.deezer
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * Retrofit interface for Deezer API.
+ * Used primarily for fetching artist artwork.
+ */
+interface DeezerApiService {
+
+    /**
+     * Search for an artist by name.
+     * @param query Artist name to search for
+     * @param limit Maximum number of results to return
+     * @return Search response containing list of matching artists
+     */
+    @GET("search/artist")
+    suspend fun searchArtist(
+        @Query("q") query: String,
+        @Query("limit") limit: Int = 1
+    ): DeezerSearchResponse
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/deezer/DeezerModels.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/deezer/DeezerModels.kt
@@ -1,0 +1,27 @@
+package com.theveloper.pixelplay.data.network.deezer
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Response from Deezer artist search API.
+ */
+data class DeezerSearchResponse(
+    @SerializedName("data") val data: List<DeezerArtist> = emptyList(),
+    @SerializedName("total") val total: Int = 0
+)
+
+/**
+ * Artist data from Deezer API.
+ * Contains multiple image sizes for different use cases.
+ */
+data class DeezerArtist(
+    @SerializedName("id") val id: Long,
+    @SerializedName("name") val name: String,
+    @SerializedName("picture") val picture: String? = null,
+    @SerializedName("picture_small") val pictureSmall: String? = null,
+    @SerializedName("picture_medium") val pictureMedium: String? = null,
+    @SerializedName("picture_big") val pictureBig: String? = null,
+    @SerializedName("picture_xl") val pictureXl: String? = null,
+    @SerializedName("nb_album") val albumCount: Int = 0,
+    @SerializedName("nb_fan") val fanCount: Int = 0
+)

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/ArtistImageRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/ArtistImageRepository.kt
@@ -1,0 +1,138 @@
+package com.theveloper.pixelplay.data.repository
+
+import android.util.Log
+import android.util.LruCache
+import com.theveloper.pixelplay.data.database.MusicDao
+import com.theveloper.pixelplay.data.network.deezer.DeezerApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository for fetching and caching artist images from Deezer API.
+ * Uses both in-memory LRU cache and Room database for persistent storage.
+ */
+@Singleton
+class ArtistImageRepository @Inject constructor(
+    private val deezerApiService: DeezerApiService,
+    private val musicDao: MusicDao
+) {
+    companion object {
+        private const val TAG = "ArtistImageRepository"
+        private const val CACHE_SIZE = 100 // Number of artist images to cache in memory
+    }
+
+    // In-memory LRU cache for quick access
+    private val memoryCache = LruCache<String, String>(CACHE_SIZE)
+    
+    // Mutex to prevent duplicate API calls for the same artist
+    private val fetchMutex = Mutex()
+    private val pendingFetches = mutableSetOf<String>()
+
+    /**
+     * Get artist image URL, fetching from Deezer if not cached.
+     * @param artistName Name of the artist
+     * @param artistId Room database ID of the artist (for caching)
+     * @return Image URL or null if not found
+     */
+    suspend fun getArtistImageUrl(artistName: String, artistId: Long): String? {
+        if (artistName.isBlank()) return null
+
+        val normalizedName = artistName.trim().lowercase()
+
+        // Check memory cache first
+        memoryCache.get(normalizedName)?.let { cachedUrl ->
+            return cachedUrl
+        }
+
+        // Check database cache
+        val dbCachedUrl = withContext(Dispatchers.IO) {
+            musicDao.getArtistImageUrl(artistId)
+        }
+        if (!dbCachedUrl.isNullOrEmpty()) {
+            memoryCache.put(normalizedName, dbCachedUrl)
+            return dbCachedUrl
+        }
+
+        // Fetch from Deezer API
+        return fetchAndCacheArtistImage(artistName, artistId, normalizedName)
+    }
+
+    /**
+     * Prefetch artist images for a list of artists in background.
+     * Useful for batch loading when displaying artist lists.
+     */
+    suspend fun prefetchArtistImages(artists: List<Pair<Long, String>>) {
+        withContext(Dispatchers.IO) {
+            artists.forEach { (artistId, artistName) ->
+                try {
+                    getArtistImageUrl(artistName, artistId)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to prefetch image for $artistName: ${e.message}")
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchAndCacheArtistImage(
+        artistName: String,
+        artistId: Long,
+        normalizedName: String
+    ): String? {
+        // Prevent duplicate fetches for the same artist
+        fetchMutex.withLock {
+            if (pendingFetches.contains(normalizedName)) {
+                return null // Already fetching
+            }
+            pendingFetches.add(normalizedName)
+        }
+
+        return try {
+            withContext(Dispatchers.IO) {
+                val response = deezerApiService.searchArtist(artistName, limit = 1)
+                val deezerArtist = response.data.firstOrNull()
+
+                if (deezerArtist != null) {
+                    // Use picture_medium for list views, picture_big for detail views
+                    // We store the medium size as default, UI can request bigger sizes if needed
+                    val imageUrl = deezerArtist.pictureMedium 
+                        ?: deezerArtist.pictureBig 
+                        ?: deezerArtist.picture
+
+                    if (!imageUrl.isNullOrEmpty()) {
+                        // Cache in memory
+                        memoryCache.put(normalizedName, imageUrl)
+                        
+                        // Cache in database
+                        musicDao.updateArtistImageUrl(artistId, imageUrl)
+                        
+                        Log.d(TAG, "Fetched and cached image for $artistName: $imageUrl")
+                        imageUrl
+                    } else {
+                        null
+                    }
+                } else {
+                    Log.d(TAG, "No Deezer artist found for: $artistName")
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error fetching artist image for $artistName: ${e.message}")
+            null
+        } finally {
+            fetchMutex.withLock {
+                pendingFetches.remove(normalizedName)
+            }
+        }
+    }
+
+    /**
+     * Clear all cached images. Useful for debugging or forced refresh.
+     */
+    fun clearCache() {
+        memoryCache.evictAll()
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -59,6 +59,10 @@ import com.theveloper.pixelplay.presentation.viewmodel.PlaylistViewModel
 import com.theveloper.pixelplay.utils.shapes.RoundedStarShape
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -425,18 +429,32 @@ private fun CustomCollapsingTopBar(
                 .fillMaxSize()
                 .graphicsLayer { alpha = headerContentAlpha }
         ) {
-            MusicIconPattern(
-                modifier = Modifier.fillMaxSize(),
-                collapseFraction = collapseFraction
-            )
+            // Artist artwork or fallback pattern
+            if (!artist.imageUrl.isNullOrEmpty()) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(artist.imageUrl)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = artist.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                MusicIconPattern(
+                    modifier = Modifier.fillMaxSize(),
+                    collapseFraction = collapseFraction
+                )
+            }
 
+            // Gradient overlay for text readability
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
                         Brush.verticalGradient(
                             colorStops = arrayOf(
-                                0.4f to Color.Transparent,
+                                0.3f to Color.Transparent,
                                 1f to MaterialTheme.colorScheme.surface
                             )
                         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
+import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.imageLoader
 import coil.request.ImageRequest
@@ -2308,15 +2309,32 @@ fun ArtistListItem(artist: Artist, onClick: () -> Unit) {
         )
     ) {
         Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                painter = painterResource(R.drawable.rounded_artist_24),
-                contentDescription = "Artista",
+            Box(
                 modifier = Modifier
                     .size(48.dp)
-                    .background(MaterialTheme.colorScheme.primaryContainer, CircleShape)
-                    .padding(8.dp),
-                tint = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                if (!artist.imageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(artist.imageUrl)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = artist.name,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(R.drawable.rounded_artist_24),
+                        contentDescription = "Artista",
+                        modifier = Modifier.padding(8.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
             Spacer(modifier = Modifier.width(16.dp))
             Column {
                 Text(artist.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)


### PR DESCRIPTION
## Summary
Deezer API entegrasyonu ile sanatçı fotoğraflarını çekip gösterme özelliği eklendi.

## Changes
- **Deezer API Layer**: `DeezerApiService` ve `DeezerModels` oluşturuldu
- **Caching**: `ArtistImageRepository` ile LRU memory cache + Room database cache
- **Database Migration**: `ArtistEntity`'ye `image_url` kolonu eklendi (v10→v11)
- **Model Update**: `Artist` data class'a `imageUrl` eklendi
- **UI Updates**:
  - `ArtistListItem` (Library → Artists tab) artwork gösteriyor
  - `ArtistDetailScreen` header'da büyük artwork gösteriyor
- **Background Fetching**: Artist load edildiğinde Deezer'dan görsel çekiliyor

## Testing
- Library → Artists tab'ında görseller yüklenmeli
- Artist'e tıklayınca detail sayfasında da görsel görünmeli
- Görseller database'de cache'leniyor, offline'da da çalışır