### PR TITLE
Allow nested folder overrides in directory exclusion logic

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/utils/DirectoryRuleResolver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/DirectoryRuleResolver.kt
@@ -1,0 +1,28 @@
+package com.theveloper.pixelplay.utils
+
+/**
+ * Resolves directory allow/deny rules using the nearest ancestor match strategy.
+ * A more specific rule (longer path) always overrides a parent rule. Allowed rules
+ * take precedence over blocked rules at the same depth to enable explicit overrides
+ * inside excluded trees.
+ */
+class DirectoryRuleResolver(
+    private val allowed: Set<String>,
+    private val blocked: Set<String>
+) {
+
+    fun isBlocked(path: String): Boolean {
+        var searchIndex = path.length
+
+        while (searchIndex > 0) {
+            val candidate = path.substring(0, searchIndex)
+
+            if (allowed.contains(candidate)) return false
+            if (blocked.contains(candidate)) return true
+
+            searchIndex = path.lastIndexOf('/', searchIndex - 1)
+        }
+
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
- add a directory rule resolver to efficiently evaluate allow/deny overrides by ancestor specificity
- track allowed directory overrides in the file explorer and toggle logic so excluded parents can contain re-included children
- honor allowed overrides during music filtering and folder aggregation to keep library views consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf723fd38832f8c6299ccd2e63fae)