### PR TITLE
Configure media exposure and stabilize cast progress

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,8 @@
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />
                 <action android:name="androidx.media3.session.MediaSessionService"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.APP_MUSIC" />
             </intent-filter>
         </service>
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -278,6 +278,11 @@ class MusicService : MediaSessionService() {
             mediaSession?.let { refreshMediaSessionUi(it) }
         }
 
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            Timber.tag(TAG).d("Playback state changed: $playbackState")
+            mediaSession?.let { refreshMediaSessionUi(it) }
+        }
+
         override fun onMediaItemTransition(item: MediaItem?, reason: Int) {
             requestWidgetFullUpdate(force = true)
             mediaSession?.let { refreshMediaSessionUi(it) }


### PR DESCRIPTION
## Summary
- expose MusicService as a browsable media playback service and refresh playback state updates
- reset cast item tracking and progress when remote items change to avoid stale slider positions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536a2d02dc832f92d3299ef16714c1)