### PR TITLE
Fix: Ensure up-to-date metadata is used after editing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,6 +248,8 @@ dependencies {
 
     // TagLib for metadata editing (supports mp3, flac, m4a, etc.)
     implementation(libs.taglib)
+    // VorbisJava for Opus/Ogg metadata editing (TagLib has issues with Opus via file descriptors)
+    implementation(libs.vorbisjava.core)
 
     // Retrofit & OkHttp
     implementation(libs.retrofit)

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -6,16 +6,26 @@ import android.content.Context
 import android.media.MediaScannerConnection
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
+import android.util.Log
 import androidx.core.net.toUri
 import com.kyant.taglib.Picture
 import com.kyant.taglib.TagLib
 import com.theveloper.pixelplay.data.database.MusicDao
 import kotlinx.coroutines.runBlocking
+import org.gagravarr.opus.OpusFile
+import org.gagravarr.opus.OpusTags
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
+import java.util.Locale
+
+private const val TAG = "SongMetadataEditor"
+
 
 class SongMetadataEditor(private val context: Context, private val musicDao: MusicDao) {
+
+    // File extensions that require VorbisJava (TagLib has issues with these via file descriptors)
+    private val opusExtensions = setOf("opus", "ogg")
 
     fun editSongMetadata(
         songId: Long,
@@ -33,20 +43,43 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
             val normalizedGenre = trimmedGenre.takeIf { it.isNotBlank() }
             val normalizedLyrics = trimmedLyrics.takeIf { it.isNotBlank() }
 
-            // 1. FIRST: Update the actual file with ALL metadata using TagLib
-            val fileUpdateSuccess = updateFileMetadataWithTagLib(
-                songId = songId,
-                newTitle = newTitle,
-                newArtist = newArtist,
-                newAlbum = newAlbum,
-                newGenre = trimmedGenre,
-                newLyrics = trimmedLyrics,
-                newTrackNumber = newTrackNumber,
-                coverArtUpdate = coverArtUpdate
-            )
+            // Get file path to determine which library to use
+            val filePath = getFilePathFromMediaStore(songId)
+            if (filePath == null) {
+                Log.e(TAG, "Could not get file path for songId: $songId")
+                return SongMetadataEditResult(success = false, updatedAlbumArtUri = null)
+            }
+
+            // Get file extension to determine which library to use
+            val extension = filePath.substringAfterLast('.', "").lowercase(Locale.ROOT)
+            val useVorbisJava = extension in opusExtensions
+
+            // 1. FIRST: Update the actual file with ALL metadata
+            // For Opus/Ogg files, we skip file modification because:
+            // - TagLib can't detect Opus via file descriptors
+            // - jaudiotagger doesn't support Opus
+            // - VorbisJava corrupts files (adds .pending, changes extension to .oga)
+            // Instead, we only update MediaStore and local DB, which is enough for the app
+            val fileUpdateSuccess = if (useVorbisJava) {
+                Log.e(TAG, "METADATA_EDIT: Opus/Ogg file detected - skipping file modification to prevent corruption")
+                Log.e(TAG, "METADATA_EDIT: Will update MediaStore and local DB only for: $filePath")
+                true // Skip file modification, proceed to MediaStore update
+            } else {
+                Log.e(TAG, "METADATA_EDIT: Using TagLib for $extension file: $filePath")
+                updateFileMetadataWithTagLib(
+                    filePath = filePath,
+                    newTitle = newTitle,
+                    newArtist = newArtist,
+                    newAlbum = newAlbum,
+                    newGenre = trimmedGenre,
+                    newLyrics = trimmedLyrics,
+                    newTrackNumber = newTrackNumber,
+                    coverArtUpdate = coverArtUpdate
+                )
+            }
 
             if (!fileUpdateSuccess) {
-                Timber.e("Failed to update file metadata for songId: $songId")
+                Log.e(TAG, "Failed to update file metadata for songId: $songId")
                 return SongMetadataEditResult(success = false, updatedAlbumArtUri = null)
             }
 
@@ -86,10 +119,10 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
                 }
             }
 
-            // 4. Force media rescan
-            forceMediaRescan(songId)
+            // 4. Force media rescan with the known file path
+            forceMediaRescan(filePath)
 
-            Timber.d("Successfully updated metadata for songId: $songId")
+            Log.e(TAG, "METADATA_EDIT: Successfully updated metadata for songId: $songId")
             SongMetadataEditResult(success = true, updatedAlbumArtUri = storedCoverArtUri)
 
         } catch (e: Exception) {
@@ -99,7 +132,7 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
     }
 
     private fun updateFileMetadataWithTagLib(
-        songId: Long,
+        filePath: String,
         newTitle: String,
         newArtist: String,
         newAlbum: String,
@@ -109,23 +142,20 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
         coverArtUpdate: CoverArtUpdate? = null
     ): Boolean {
         return try {
-            val filePath = getFilePathFromMediaStore(songId)
-            if (filePath == null) {
-                Timber.e("Could not get file path for songId: $songId")
-                return false
-            }
-
             val audioFile = File(filePath)
             if (!audioFile.exists()) {
-                Timber.e("Audio file does not exist: $filePath")
+                Log.e(TAG, "TAGLIB: Audio file does not exist: $filePath")
                 return false
             }
+            Log.e(TAG, "TAGLIB: Opening file: $filePath")
 
             // Open file with read/write permissions
             ParcelFileDescriptor.open(audioFile, ParcelFileDescriptor.MODE_READ_WRITE).use { fd ->
                 // Get existing metadata or create empty map
+                Log.e(TAG, "TAGLIB: Getting existing metadata...")
                 val metadataFd = fd.dup()
                 val existingMetadata = TagLib.getMetadata(metadataFd.detachFd())
+                Log.e(TAG, "TAGLIB: Existing metadata: ${existingMetadata?.propertyMap?.keys}")
                 val propertyMap = HashMap(existingMetadata?.propertyMap ?: emptyMap())
 
                 // Update metadata fields
@@ -136,12 +166,14 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
                 propertyMap.upsertOrRemove("LYRICS", newLyrics)
                 propertyMap["TRACKNUMBER"] = arrayOf(newTrackNumber.toString())
                 propertyMap["ALBUMARTIST"] = arrayOf(newArtist)
+                Log.e(TAG, "TAGLIB: Updated property map, saving...")
 
                 // Save metadata
                 val saveFd = fd.dup()
                 val metadataSaved = TagLib.savePropertyMap(saveFd.detachFd(), propertyMap)
+                Log.e(TAG, "TAGLIB: savePropertyMap result: $metadataSaved")
                 if (!metadataSaved) {
-                    Timber.e("Failed to save metadata for songId: $songId")
+                    Log.e(TAG, "TAGLIB: Failed to save metadata for file: $filePath")
                     return false
                 }
 
@@ -156,9 +188,9 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
                     val pictureFd = fd.dup()
                     val coverSaved = TagLib.savePictures(pictureFd.detachFd(), arrayOf(picture))
                     if (!coverSaved) {
-                        Timber.w("Failed to save cover art, but metadata was saved for songId: $songId")
+                        Log.w(TAG, "TAGLIB: Failed to save cover art, but metadata was saved")
                     } else {
-                        Timber.d("Successfully embedded cover art for songId: $songId")
+                        Log.d(TAG, "TAGLIB: Successfully embedded cover art")
                     }
                 }
             }
@@ -169,14 +201,126 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
                     raf.fd.sync()
                 }
             } catch (e: Exception) {
-                Timber.w(e, "Could not sync file, changes should still be persisted")
+                Log.w(TAG, "Could not sync file, changes should still be persisted", e)
             }
 
-            Timber.d("Successfully updated file metadata: ${audioFile.path}")
+            Log.e(TAG, "TAGLIB: SUCCESS - Updated file metadata: ${audioFile.path}")
             true
 
         } catch (e: Exception) {
-            Timber.e(e, "Error updating file metadata for songId: $songId")
+            Log.e(TAG, "TAGLIB ERROR: ${e.javaClass.simpleName}: ${e.message}")
+            e.printStackTrace()
+            false
+        }
+    }
+
+    private fun updateFileMetadataWithVorbisJava(
+        filePath: String,
+        newTitle: String,
+        newArtist: String,
+        newAlbum: String,
+        newGenre: String,
+        newLyrics: String,
+        newTrackNumber: Int
+    ): Boolean {
+        val audioFile = File(filePath)
+        val originalExtension = audioFile.extension
+        var tempFile: File? = null
+        var backupFile: File? = null
+        
+        return try {
+            if (!audioFile.exists()) {
+                Log.e(TAG, "VORBISJAVA: Audio file does not exist: $filePath")
+                return false
+            }
+
+            Log.e(TAG, "VORBISJAVA: Reading Opus file: $filePath")
+            
+            // Read existing file
+            val opusFile = OpusFile(audioFile)
+            val tags = opusFile.tags ?: OpusTags()
+            
+            Log.e(TAG, "VORBISJAVA: Existing tags: ${tags.allComments}")
+            
+            // Clear existing tags and set new ones
+            tags.removeComments("TITLE")
+            tags.removeComments("ARTIST")
+            tags.removeComments("ALBUM")
+            tags.removeComments("GENRE")
+            tags.removeComments("LYRICS")
+            tags.removeComments("TRACKNUMBER")
+            tags.removeComments("ALBUMARTIST")
+            
+            // Add new values (only if not blank)
+            if (newTitle.isNotBlank()) tags.addComment("TITLE", newTitle)
+            if (newArtist.isNotBlank()) {
+                tags.addComment("ARTIST", newArtist)
+                tags.addComment("ALBUMARTIST", newArtist)
+            }
+            if (newAlbum.isNotBlank()) tags.addComment("ALBUM", newAlbum)
+            if (newGenre.isNotBlank()) tags.addComment("GENRE", newGenre)
+            if (newLyrics.isNotBlank()) tags.addComment("LYRICS", newLyrics)
+            if (newTrackNumber > 0) tags.addComment("TRACKNUMBER", newTrackNumber.toString())
+            
+            Log.e(TAG, "VORBISJAVA: Updated tags: ${tags.allComments}")
+            
+            // Create temp file with same extension as original
+            tempFile = File(audioFile.parentFile, "${audioFile.nameWithoutExtension}_temp.${originalExtension}")
+            
+            Log.e(TAG, "VORBISJAVA: Writing to temp file: ${tempFile.path}")
+            FileOutputStream(tempFile).use { fos ->
+                val newOpusFile = OpusFile(fos, opusFile.info, tags)
+                
+                // Copy audio packets
+                var packet = opusFile.nextAudioPacket
+                while (packet != null) {
+                    newOpusFile.writeAudioData(packet)
+                    packet = opusFile.nextAudioPacket
+                }
+                
+                newOpusFile.close()
+            }
+            opusFile.close()
+            
+            // Verify temp file was created and has content
+            if (!tempFile.exists() || tempFile.length() == 0L) {
+                Log.e(TAG, "VORBISJAVA: Temp file creation failed or is empty")
+                return false
+            }
+            Log.e(TAG, "VORBISJAVA: Temp file size: ${tempFile.length()} bytes, original: ${audioFile.length()} bytes")
+            
+            // Create backup of original file before replacing
+            backupFile = File(audioFile.parentFile, "${audioFile.nameWithoutExtension}_backup.${originalExtension}")
+            if (!audioFile.renameTo(backupFile)) {
+                Log.e(TAG, "VORBISJAVA: Failed to create backup of original file")
+                tempFile.delete()
+                return false
+            }
+            Log.e(TAG, "VORBISJAVA: Created backup: ${backupFile.path}")
+            
+            // Rename temp file to original name
+            if (!tempFile.renameTo(audioFile)) {
+                Log.e(TAG, "VORBISJAVA: Failed to rename temp file to original")
+                // Restore backup
+                backupFile.renameTo(audioFile)
+                return false
+            }
+            
+            // Delete backup on success
+            backupFile.delete()
+            Log.e(TAG, "VORBISJAVA: SUCCESS - Updated file metadata: ${audioFile.path}")
+            true
+
+        } catch (e: Exception) {
+            Log.e(TAG, "VORBISJAVA ERROR: ${e.javaClass.simpleName}: ${e.message}")
+            e.printStackTrace()
+            
+            // Cleanup on error
+            tempFile?.delete()
+            // Try to restore backup if it exists
+            if (backupFile?.exists() == true && !audioFile.exists()) {
+                backupFile.renameTo(audioFile)
+            }
             false
         }
     }
@@ -215,39 +359,57 @@ class SongMetadataEditor(private val context: Context, private val musicDao: Mus
         }
     }
 
-    private fun forceMediaRescan(songId: Long) {
+    private fun forceMediaRescan(filePath: String) {
         try {
-            val filePath = getFilePathFromMediaStore(songId)
-            if (filePath != null && File(filePath).exists()) {
+            val file = File(filePath)
+            if (file.exists()) {
+                Log.e(TAG, "RESCAN: Starting MediaScanner for: $filePath")
                 // Use MediaScannerConnection to force rescan
+                val latch = java.util.concurrent.CountDownLatch(1)
                 MediaScannerConnection.scanFile(
                     context,
                     arrayOf(filePath),
                     null
                 ) { path, uri ->
-                    Timber.d("Media scan completed for: $path")
+                    Log.e(TAG, "RESCAN: Completed for: $path, new URI: $uri")
+                    latch.countDown()
                 }
-                Timber.d("Triggered media scan for songId: $songId")
+                // Wait for scan to complete (max 5 seconds)
+                val completed = latch.await(5, java.util.concurrent.TimeUnit.SECONDS)
+                if (!completed) {
+                    Log.w(TAG, "RESCAN: MediaScanner timeout for: $filePath")
+                }
+            } else {
+                Log.e(TAG, "RESCAN: File does not exist: $filePath")
             }
         } catch (e: Exception) {
-            Timber.e(e, "Failed to force media rescan for songId: $songId")
+            Log.e(TAG, "RESCAN ERROR: ${e.message}")
         }
     }
 
     private fun getFilePathFromMediaStore(songId: Long): String? {
-        return context.contentResolver.query(
-            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
-            arrayOf(MediaStore.Audio.Media.DATA),
-            "${MediaStore.Audio.Media._ID} = ?",
-            arrayOf(songId.toString()),
-            null
-        )?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA))
-            } else {
-                Timber.e("No file found for songId: $songId")
+        Log.e(TAG, "getFilePathFromMediaStore: Looking up songId: $songId")
+        return try {
+            context.contentResolver.query(
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                arrayOf(MediaStore.Audio.Media.DATA),
+                "${MediaStore.Audio.Media._ID} = ?",
+                arrayOf(songId.toString()),
                 null
+            )?.use { cursor ->
+                Log.e(TAG, "getFilePathFromMediaStore: Cursor count: ${cursor.count}")
+                if (cursor.moveToFirst()) {
+                    val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA))
+                    Log.e(TAG, "getFilePathFromMediaStore: Found path: $path")
+                    path
+                } else {
+                    Log.e(TAG, "getFilePathFromMediaStore: No file found for songId: $songId")
+                    null
+                }
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "getFilePathFromMediaStore: Error querying MediaStore: ${e.message}")
+            null
         }
     }
     private fun saveCoverArtPreview(songId: Long, coverArtUpdate: CoverArtUpdate): String? {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,8 @@ roomRuntime = "2.7.1"
 accompanist = "0.37.3"
 checkerframework = "3.49.5" # O la versión más reciente que encuentres
 taglib = "1.0.5"
+jaudiotagger = "3.0.1"
+vorbisjava = "0.8"
 datastore = "1.1.1"
 androidxTestCore = "1.6.1"
 
@@ -166,6 +168,8 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 wavy-slider = { module = "ir.mahozad.multiplatform:wavy-slider", version.ref = "wavySlider" }
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
 taglib = { group = "io.github.kyant0", name = "taglib", version.ref = "taglib" }
+jaudiotagger = { group = "net.jthink", name = "jaudiotagger", version.ref = "jaudiotagger" }
+vorbisjava-core = { group = "org.gagravarr", name = "vorbis-java-core", version.ref = "vorbisjava" }
 reorderables = { group = "sh.calvin.reorderable", name = "reorderable", version.ref = "reorderables" }
 generativeai = { group = "com.google.ai.client.generativeai", name = "generativeai", version.ref = "generativeai" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }


### PR DESCRIPTION
Ensures that when a song is played or its metadata is edited, the most current version of the song's information is used, preventing stale data from being displayed or used.

- In `PlayerViewModel`, the `showAndPlaySong` function now retrieves the latest version of the song from the `allSongs` list. This ensures any recent metadata changes are immediately reflected when the song is played.
- Skips direct file modification for `.opus` and `.ogg` files during metadata editing to prevent file corruption issues caused by tagging libraries. The app will now only update the MediaStore and its local database for these formats, which is sufficient for the changes to be reflected within the app.
- Refactors the metadata editing logic in `SongMetadataEditor` to use the file path directly instead of the song ID for media rescans and file operations, making the process more reliable.
- Adds extensive logging to the metadata editing process for improved debugging.