### PR TITLE
Add album size sort option

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
@@ -19,6 +19,8 @@ sealed class SortOption(val storageKey: String, val displayName: String) {
     object AlbumTitleZA : SortOption("album_title_za", "Title (Z-A)")
     object AlbumArtist : SortOption("album_artist", "Artist")
     object AlbumReleaseYear : SortOption("album_release_year", "Release Year")
+    object AlbumSizeAsc : SortOption("album_size_asc", "Fewest Songs")
+    object AlbumSizeDesc : SortOption("album_size_desc", "Most Songs")
 
     // Artist Sort Options
     object ArtistNameAZ : SortOption("artist_name_az", "Name (A-Z)")
@@ -56,7 +58,9 @@ sealed class SortOption(val storageKey: String, val displayName: String) {
             AlbumTitleAZ,
             AlbumTitleZA,
             AlbumArtist,
-            AlbumReleaseYear
+            AlbumReleaseYear,
+            AlbumSizeAsc,
+            AlbumSizeDesc
         )
         val ARTISTS: List<SortOption> = listOf(
             ArtistNameAZ,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -4558,6 +4558,8 @@ class PlayerViewModel @Inject constructor(
             SortOption.AlbumTitleZA -> _playerUiState.value.albums.sortedByDescending { it.title.lowercase() }
             SortOption.AlbumArtist -> _playerUiState.value.albums.sortedBy { it.artist.lowercase() }
             SortOption.AlbumReleaseYear -> _playerUiState.value.albums.sortedByDescending { it.year }
+            SortOption.AlbumSizeAsc -> _playerUiState.value.albums.sortedWith(compareBy<Album> { it.songCount }.thenBy { it.title.lowercase() })
+            SortOption.AlbumSizeDesc -> _playerUiState.value.albums.sortedWith(compareByDescending<Album> { it.songCount }.thenBy { it.title.lowercase() })
             else -> _playerUiState.value.albums
         }.toImmutableList()
         _playerUiState.update {


### PR DESCRIPTION
Added sort option for the song count of each album as requested in #521. Wondering if it should be "Size (Fewest/Most Songs)", but it felt repetitive, so went with just the text in the parenthesis.

Also made it sort alphabetically if amount of songs are the same for several albums, just to tighten and polish it a bit.

(love the project btw)

<img width="216" height="480" alt="Options" src="https://github.com/user-attachments/assets/b3ca4ae3-c652-4798-a2d5-72bba7c5ff88" />
<img width="216" height="480" alt="Fewest" src="https://github.com/user-attachments/assets/a886b057-1b2e-4c89-81a3-ca988d97d27c" />
<img width="216" height="480" alt="Most" src="https://github.com/user-attachments/assets/5bb5d2d9-2670-422f-a15c-e09b8717603c" />

Closes #521 