### PR TITLE
Fix pause playback when headphones are disconnected

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -172,7 +172,7 @@ class DualPlayerEngine @Inject constructor(
 
         return ExoPlayer.Builder(context, renderersFactory).build().apply {
             setAudioAttributes(audioAttributes, handleAudioFocus)
-            setHandleAudioBecomingNoisy(handleAudioFocus)
+            setHandleAudioBecomingNoisy(true)
             // Explicitly keep both players live so they can overlap without affecting each other
             playWhenReady = false
         }


### PR DESCRIPTION
### What’s changed
Playback now reliably pauses when audio output changes (e.g. earbuds or headphones are disconnected).

### Why
Currently, audio may continue playing through device speakers after headphones are unplugged, which is unexpected behavior and has been reported in multiple issues.

This change forces `setHandleAudioBecomingNoisy(true)` so the player responds correctly to audio routing changes.

### Related issues
- #845
- #691