### PR TITLE
Implement Recently Played system and expressive UI refinements

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -476,6 +476,7 @@ class MainActivity : ComponentActivity() {
                 Screen.Settings.route,
                 Screen.PlaylistDetail.route,
                 Screen.DailyMixScreen.route,
+                Screen.RecentlyPlayed.route,
                 Screen.GenreDetail.route,
                 Screen.AlbumDetail.route,
                 Screen.ArtistDetail.route,
@@ -489,7 +490,8 @@ class MainActivity : ComponentActivity() {
                 Screen.Equalizer.route,
                 Screen.SettingsCategory.route,
                 Screen.DelimiterConfig.route,
-                Screen.PaletteStyle.route
+                Screen.PaletteStyle.route,
+                Screen.RecentlyPlayed.route
             )
         }
         val shouldHideNavigationBar by remember(currentRoute, isSearchBarActive) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/RecentlyPlayedSection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/RecentlyPlayedSection.kt
@@ -1,0 +1,324 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.presentation.model.RecentlyPlayedSongUiModel
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+private val HomeRecentlyPlayedPillHeight = 58.dp
+private val HomeRecentlyPlayedPillSpacing = 8.dp
+private const val HomeRecentlyPlayedPillsLimit = 10
+private const val HomeRecentlyPlayedPillsPerColumn = 3
+private val HomeRecentlyPlayedWidthSteps = listOf(148.dp, 166.dp, 184.dp, 202.dp, 220.dp)
+private val HomeRecentlyPlayedDefaultContentPadding = PaddingValues(horizontal = 8.dp)
+
+private data class RecentlyPlayedPillCell(
+    val item: RecentlyPlayedSongUiModel,
+    val width: Dp
+)
+
+private data class RecentlyPlayedPillRow(
+    val pills: List<RecentlyPlayedPillCell>,
+    val contentWidth: Dp
+)
+
+@Composable
+fun RecentlyPlayedSection(
+    songs: List<RecentlyPlayedSongUiModel>,
+    onSongClick: (Song) -> Unit,
+    onOpenAllClick: () -> Unit,
+    currentSongId: String? = null,
+    contentPadding: PaddingValues = HomeRecentlyPlayedDefaultContentPadding,
+    modifier: Modifier = Modifier
+) {
+    val layoutDirection = LocalLayoutDirection.current
+    val startContentPadding = remember(contentPadding, layoutDirection) {
+        contentPadding.calculateLeftPadding(layoutDirection)
+    }
+    val endContentPadding = remember(contentPadding, layoutDirection) {
+        contentPadding.calculateRightPadding(layoutDirection)
+    }
+
+    val visibleSongs = remember(songs) { songs.take(HomeRecentlyPlayedPillsLimit) }
+    val songRows = remember(visibleSongs, startContentPadding, endContentPadding) {
+        val rows = MutableList(HomeRecentlyPlayedPillsPerColumn) { mutableListOf<RecentlyPlayedPillCell>() }
+        visibleSongs.forEachIndexed { index, item ->
+            val rowIndex = index % HomeRecentlyPlayedPillsPerColumn
+            rows[rowIndex] += RecentlyPlayedPillCell(
+                item = item,
+                width = resolveRecentlyPlayedPillWidth(item = item, rowIndex = rowIndex)
+            )
+        }
+        rows.map { pills ->
+            val pillsWidth = pills.fold(0.dp) { acc, cell -> acc + cell.width }
+            val rowSpacing = if (pills.size > 1) HomeRecentlyPlayedPillSpacing * (pills.size - 1) else 0.dp
+            val rowWidth = pillsWidth + rowSpacing + startContentPadding + endContentPadding
+            RecentlyPlayedPillRow(
+                pills = pills,
+                contentWidth = rowWidth
+            )
+        }
+    }
+    val maxRowContentWidth = remember(songRows) {
+        songRows.maxOfOrNull { it.contentWidth } ?: 0.dp
+    }
+    val sharedScrollState = rememberScrollState()
+
+    val sectionHeight = HomeRecentlyPlayedPillHeight * HomeRecentlyPlayedPillsPerColumn +
+            HomeRecentlyPlayedPillSpacing * (HomeRecentlyPlayedPillsPerColumn - 1)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier.padding(start = 6.dp),
+                text = "Recently Played",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            FilledIconButton(
+                modifier = Modifier
+                    .height(40.dp)
+                    .width(64.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    contentColor = MaterialTheme.colorScheme.secondary
+                ),
+                onClick = onOpenAllClick,
+                enabled = songs.isNotEmpty()
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+
+        if (visibleSongs.isEmpty()) {
+            Card(
+                shape = AbsoluteSmoothCornerShape(
+                    cornerRadiusTL = 24.dp,
+                    smoothnessAsPercentTR = 60,
+                    cornerRadiusTR = 24.dp,
+                    smoothnessAsPercentBR = 60,
+                    cornerRadiusBL = 24.dp,
+                    smoothnessAsPercentBL = 60,
+                    cornerRadiusBR = 24.dp,
+                    smoothnessAsPercentTL = 60
+                ),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = "Play a few songs to populate this section.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)
+                )
+            }
+        } else {
+            // Exactly three stacked rows (staggered look with variable-width pills).
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = sectionHeight)
+                    .horizontalScroll(state = sharedScrollState)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .width(maxRowContentWidth)
+                        .height(sectionHeight),
+                    verticalArrangement = Arrangement.spacedBy(HomeRecentlyPlayedPillSpacing),
+                    horizontalAlignment = Alignment.Start
+                ) {
+                    songRows.forEach { row ->
+                        if (row.pills.isEmpty()) {
+                            Spacer(modifier = Modifier.height(HomeRecentlyPlayedPillHeight))
+                        } else {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(HomeRecentlyPlayedPillHeight),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(HomeRecentlyPlayedPillSpacing)
+                            ) {
+                                if (startContentPadding > 0.dp) {
+                                    Spacer(modifier = Modifier.width(startContentPadding))
+                                }
+                                row.pills.forEach { cell ->
+                                    RecentlyPlayedPill(
+                                        item = cell.item,
+                                        isCurrentSong = currentSongId == cell.item.song.id,
+                                        modifier = Modifier.width(cell.width),
+                                        onClick = { onSongClick(cell.item.song) }
+                                    )
+                                }
+                                if (endContentPadding > 0.dp) {
+                                    Spacer(modifier = Modifier.width(endContentPadding))
+                                }
+                                val trailingGap = (maxRowContentWidth - row.contentWidth).coerceAtLeast(0.dp)
+                                if (trailingGap > 0.dp) {
+                                    Spacer(modifier = Modifier.width(trailingGap))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentlyPlayedPill(
+    item: RecentlyPlayedSongUiModel,
+    isCurrentSong: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val animatedCorner by animateDpAsState(
+        targetValue = if (isCurrentSong) 14.dp else (HomeRecentlyPlayedPillHeight / 2),
+        animationSpec = tween(durationMillis = 280),
+        label = "pillCorner"
+    )
+    val animatedContainer by animateColorAsState(
+        targetValue = if (isCurrentSong) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+        animationSpec = tween(durationMillis = 280),
+        label = "pillContainer"
+    )
+    val titleColor by animateColorAsState(
+        targetValue = if (isCurrentSong) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
+        animationSpec = tween(durationMillis = 280),
+        label = "pillTitleColor"
+    )
+    val artistColor by animateColorAsState(
+        targetValue = if (isCurrentSong) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.80f)
+        else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(durationMillis = 280),
+        label = "pillArtistColor"
+    )
+    val shape = RoundedCornerShape(animatedCorner)
+
+    Card(
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = animatedContainer),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        modifier = modifier
+            .height(HomeRecentlyPlayedPillHeight)
+            .clip(shape)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(HomeRecentlyPlayedPillHeight)
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            SmartImage(
+                model = item.song.albumArtUriString,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                shape = CircleShape,
+                modifier = Modifier.size(38.dp)
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = item.song.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = titleColor
+                )
+                Text(
+                    text = item.song.displayArtist,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = artistColor
+                )
+            }
+        }
+    }
+}
+
+private fun resolveRecentlyPlayedPillWidth(
+    item: RecentlyPlayedSongUiModel,
+    rowIndex: Int
+): Dp {
+    val titleLength = item.song.title.trim().length
+    val artistLength = item.song.displayArtist.trim().length
+    val weightedTextLength = titleLength + (artistLength * 0.55f)
+
+    val baseStep = when {
+        weightedTextLength < 18f -> 0
+        weightedTextLength < 28f -> 1
+        weightedTextLength < 40f -> 2
+        weightedTextLength < 54f -> 3
+        else -> 4
+    }
+
+    val staggerOffset = when (rowIndex) {
+        0 -> -1
+        1 -> 0
+        else -> 1
+    }
+
+    val resolvedStep = (baseStep + staggerOffset).coerceIn(0, HomeRecentlyPlayedWidthSteps.lastIndex)
+    return HomeRecentlyPlayedWidthSteps[resolvedStep]
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/model/RecentlyPlayedSongUi.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/model/RecentlyPlayedSongUi.kt
@@ -1,0 +1,80 @@
+package com.theveloper.pixelplay.presentation.model
+
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.stats.PlaybackStatsRepository
+import com.theveloper.pixelplay.data.stats.StatsTimeRange
+import java.time.ZoneId
+import java.time.temporal.TemporalAdjusters
+
+data class RecentlyPlayedSongUiModel(
+    val song: Song,
+    val lastPlayedTimestamp: Long
+)
+
+fun mapRecentlyPlayedSongs(
+    playbackHistory: List<PlaybackStatsRepository.PlaybackHistoryEntry>,
+    songs: List<Song>,
+    range: StatsTimeRange? = null,
+    nowMillis: Long = System.currentTimeMillis(),
+    maxItems: Int = Int.MAX_VALUE
+): List<RecentlyPlayedSongUiModel> {
+    if (maxItems <= 0 || playbackHistory.isEmpty() || songs.isEmpty()) return emptyList()
+
+    val songById = songs.associateBy { it.id }
+    val (startBound, endBound) = range.resolveBounds(
+        nowMillis = nowMillis.coerceAtLeast(0L),
+        zoneId = ZoneId.systemDefault()
+    )
+
+    val seenSongIds = HashSet<String>()
+    val deduped = ArrayList<RecentlyPlayedSongUiModel>(maxItems.coerceAtMost(playbackHistory.size))
+
+    for (entry in playbackHistory.sortedByDescending { it.timestamp }) {
+        if (deduped.size >= maxItems) break
+        val safeTimestamp = entry.timestamp.coerceAtLeast(0L)
+        if (safeTimestamp > endBound) continue
+        if (startBound != null && safeTimestamp < startBound) continue
+        if (!seenSongIds.add(entry.songId)) continue
+
+        val song = songById[entry.songId] ?: continue
+        deduped += RecentlyPlayedSongUiModel(
+            song = song,
+            lastPlayedTimestamp = safeTimestamp
+        )
+    }
+
+    return deduped
+}
+
+private fun StatsTimeRange?.resolveBounds(
+    nowMillis: Long,
+    zoneId: ZoneId
+): Pair<Long?, Long> {
+    val safeNow = nowMillis.coerceAtLeast(0L)
+    val zonedNow = java.time.Instant.ofEpochMilli(safeNow).atZone(zoneId)
+
+    return when (this) {
+        StatsTimeRange.DAY -> {
+            val start = zonedNow.toLocalDate().atStartOfDay(zoneId).toInstant().toEpochMilli()
+            start to safeNow
+        }
+        StatsTimeRange.WEEK -> {
+            val startOfWeek = zonedNow.toLocalDate().with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))
+            val start = startOfWeek.atStartOfDay(zoneId).toInstant().toEpochMilli()
+            start to safeNow
+        }
+        StatsTimeRange.MONTH -> {
+            val startOfMonth = zonedNow.toLocalDate().withDayOfMonth(1)
+            val start = startOfMonth.atStartOfDay(zoneId).toInstant().toEpochMilli()
+            start to safeNow
+        }
+        StatsTimeRange.YEAR -> {
+            val startOfYear = zonedNow.toLocalDate().withDayOfYear(1)
+            val start = startOfYear.atStartOfDay(zoneId).toInstant().toEpochMilli()
+            start to safeNow
+        }
+        StatsTimeRange.ALL, null -> {
+            null to safeNow
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -43,6 +43,7 @@ import com.theveloper.pixelplay.presentation.screens.MashupScreen
 import com.theveloper.pixelplay.presentation.screens.NavBarCornerRadiusScreen
 import com.theveloper.pixelplay.presentation.screens.PaletteStyleSettingsScreen
 import com.theveloper.pixelplay.presentation.screens.PlaylistDetailScreen
+import com.theveloper.pixelplay.presentation.screens.RecentlyPlayedScreen
 
 import com.theveloper.pixelplay.presentation.screens.AboutScreen
 import com.theveloper.pixelplay.presentation.screens.SearchScreen
@@ -269,6 +270,20 @@ fun AppNavigation(
             ) {
                 ScreenWrapper(navController = navController) {
                     DailyMixScreen(
+                        playerViewModel = playerViewModel,
+                        navController = navController
+                    )
+                }
+            }
+            composable(
+                Screen.RecentlyPlayed.route,
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) {
+                ScreenWrapper(navController = navController) {
+                    RecentlyPlayedScreen(
                         playerViewModel = playerViewModel,
                         navController = navController
                     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
@@ -20,6 +20,7 @@ sealed class Screen(val route: String) {
     }
 
     object  DailyMixScreen : Screen("daily_mix")
+    object RecentlyPlayed : Screen("recently_played")
     object Stats : Screen("stats")
     object GenreDetail : Screen("genre_detail/{genreId}") { // New screen
         fun createRoute(genreId: String) = "genre_detail/$genreId"

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -57,8 +57,14 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
@@ -393,6 +399,8 @@ private fun ExpressiveDailyMixHeader(
         }
     }
 
+    val titleStyle = rememberDailyMixTitleStyle()
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -422,22 +430,13 @@ private fun ExpressiveDailyMixHeader(
                     }
                     val shape = threeShapeSwitch(index, thirdShapeCornerRadius = 30.dp)
 
-                    // --- INICIO DE LA CORRECCIÓN ---
                     if (index == 2) {
-                        // Para la 3ra imagen, usamos Modifier.layout para controlar la medición y el posicionamiento.
                         Box(
                             modifier = Modifier.layout { measurable, constraints ->
-                                // 1. Medimos el contenido (la imagen) para que sea un cuadrado perfecto de `size` x `size`,
-                                // ignorando las restricciones de ancho que puedan venir del padre (el Row).
                                 val placeable = measurable.measure(
                                     Constraints.fixed(width = size.roundToPx(), height = size.roundToPx())
                                 )
-
-                                // 2. Le decimos al Row que nuestro layout ocupará el ancho que él nos dio (`constraints.maxWidth`),
-                                // de esta forma no empujamos a los otros elementos. La altura será la de nuestro cuadrado.
                                 layout(constraints.maxWidth, placeable.height) {
-                                    // 3. Colocamos nuestro contenido cuadrado (`placeable`) dentro del espacio asignado.
-                                    // Lo centramos horizontalmente para que se desborde por ambos lados si es necesario.
                                     val xOffset = (constraints.maxWidth - placeable.width) / 2
                                     placeable.placeRelative(xOffset, 0)
                                 }
@@ -453,12 +452,11 @@ private fun ExpressiveDailyMixHeader(
                                     model = artUrl ?: R.drawable.rounded_album_24,
                                     contentDescription = null,
                                     contentScale = ContentScale.Crop,
-                                    modifier = Modifier.fillMaxSize() // Llena el tamaño cuadrado que le dimos.
+                                    modifier = Modifier.fillMaxSize()
                                 )
                             }
                         }
                     } else {
-                        // Lógica original para las otras dos imágenes
                         Box(
                             modifier = Modifier
                                 .size(size)
@@ -473,7 +471,6 @@ private fun ExpressiveDailyMixHeader(
                             )
                         }
                     }
-                    // --- FIN DE LA CORRECCIÓN ---
                 }
             }
         }
@@ -509,11 +506,15 @@ private fun ExpressiveDailyMixHeader(
                 horizontalAlignment = Alignment.Start
             ) {
                 Text(
-                    text = "Daily Mix", style = MaterialTheme.typography.headlineLarge,
-                    fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface
+                    text = "Daily Mix",
+//                    style = MaterialTheme.typography.headlineLarge,
+                    style = titleStyle,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
+                    modifier = Modifier.padding(start = 3.dp),
                     text = "${songs.size} Songs • ${formatDuration(totalDuration)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
@@ -537,4 +538,31 @@ private fun ExpressiveDailyMixHeader(
         }
     }
     Trace.endSection()
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+private fun rememberDailyMixTitleStyle(): TextStyle {
+    return remember {
+        TextStyle(
+            fontFamily = FontFamily(
+                Font(
+                    resId = R.font.gflex_variable,
+                    variationSettings = FontVariation.Settings(
+                        FontVariation.weight(436),
+                        FontVariation.width(102f),
+                        //FontVariation.grade(40),
+                        FontVariation.Setting("ROND", 100f),
+                        FontVariation.Setting("XTRA", 520f),
+                        FontVariation.Setting("YOPQ", 90f),
+                        FontVariation.Setting("YTLC", 505f)
+                    )
+                )
+            ),
+            fontWeight = FontWeight(760),
+            fontSize = 44.sp,
+            //lineHeight = 62.sp,
+//            letterSpacing = (-0.4).sp
+        )
+    }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
@@ -1,0 +1,786 @@
+package com.theveloper.pixelplay.presentation.screens
+
+import android.os.Trace
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ContainedLoadingIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.media3.common.util.UnstableApi
+import androidx.navigation.NavController
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.stats.StatsTimeRange
+import com.theveloper.pixelplay.presentation.components.MiniPlayerHeight
+import com.theveloper.pixelplay.presentation.components.PlaylistBottomSheet
+import com.theveloper.pixelplay.presentation.components.SongInfoBottomSheet
+import com.theveloper.pixelplay.presentation.components.SmartImage
+import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
+import com.theveloper.pixelplay.presentation.navigation.Screen
+import com.theveloper.pixelplay.presentation.model.RecentlyPlayedSongUiModel
+import com.theveloper.pixelplay.presentation.model.mapRecentlyPlayedSongs
+import com.theveloper.pixelplay.presentation.viewmodel.PlaylistViewModel
+import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun RecentlyPlayedScreen(
+    playerViewModel: PlayerViewModel,
+    playlistViewModel: PlaylistViewModel = hiltViewModel(),
+    navController: NavController
+) {
+    Trace.beginSection("RecentlyPlayedScreen.Composition")
+
+    val allSongs by playerViewModel.allSongsFlow.collectAsState()
+    val playbackHistory by playerViewModel.playbackHistory.collectAsState()
+    val currentSongId by remember(playerViewModel.stablePlayerState) {
+        playerViewModel.stablePlayerState.map { it.currentSong?.id }.distinctUntilChanged()
+    }.collectAsState(initial = null)
+    val isPlaying by remember(playerViewModel.stablePlayerState) {
+        playerViewModel.stablePlayerState.map { it.isPlaying }.distinctUntilChanged()
+    }.collectAsState(initial = false)
+    val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsState()
+    val playlistUiState by playlistViewModel.uiState.collectAsState()
+
+    var selectedRange by rememberSaveable { mutableStateOf(StatsTimeRange.WEEK) }
+    val lazyListState = rememberLazyListState()
+    var showSongInfoBottomSheet by remember { mutableStateOf(false) }
+    var showPlaylistBottomSheet by remember { mutableStateOf(false) }
+    var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
+    val bottomBarHeightDp = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
+    val recentlyPlayedSongs = remember(playbackHistory, allSongs, selectedRange) {
+        mapRecentlyPlayedSongs(
+            playbackHistory = playbackHistory,
+            songs = allSongs,
+            range = selectedRange,
+            maxItems = Int.MAX_VALUE
+        )
+    }
+    val groupedSongs = remember(recentlyPlayedSongs, selectedRange) {
+        groupRecentlyPlayedSongs(
+            songs = recentlyPlayedSongs,
+            range = selectedRange
+        )
+    }
+    val queueSongs = remember(recentlyPlayedSongs) {
+        recentlyPlayedSongs.map { it.song }.toImmutableList()
+    }
+
+    val bgColors = listOf(
+        MaterialTheme.colorScheme.secondary.copy(alpha = 0.24f),
+        MaterialTheme.colorScheme.surface.copy(alpha = 0.55f),
+        MaterialTheme.colorScheme.surface
+    )
+
+    val backgroundBrush = remember {
+        Brush.verticalGradient(
+            colors = bgColors,
+            endY = 1200f
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundBrush)
+    ) {
+        if (allSongs.isEmpty() && playbackHistory.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                ContainedLoadingIndicator()
+            }
+        } else {
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    bottom = MiniPlayerHeight + WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + 16.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                item(key = "recently_played_header") {
+                    ExpressiveRecentlyPlayedHeader(
+                        songs = recentlyPlayedSongs,
+                        selectedRange = selectedRange,
+                        scrollState = lazyListState
+                    )
+                }
+
+                item(key = "recently_played_range_selector") {
+                    RecentlyPlayedRangeSelector(
+                        selected = selectedRange,
+                        onRangeSelected = { selectedRange = it },
+                        modifier = Modifier.padding(horizontal = 0.dp)
+                    )
+                }
+
+                if (recentlyPlayedSongs.isNotEmpty()) {
+                    item(key = "recently_played_actions") {
+                        RecentlyPlayedActions(
+                            onPlay = {
+                                val firstSong = queueSongs.firstOrNull() ?: return@RecentlyPlayedActions
+                                playerViewModel.playSongs(queueSongs, firstSong, "Recently Played")
+                            },
+                            onShuffle = {
+                                playerViewModel.playSongsShuffled(
+                                    songsToPlay = queueSongs,
+                                    queueName = "Recently Played"
+                                )
+                            },
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                }
+
+                if (recentlyPlayedSongs.isEmpty()) {
+                    item(key = "recently_played_empty") {
+                        RecentlyPlayedEmptyState(
+                            range = selectedRange,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
+                } else {
+                    groupedSongs.forEachIndexed { groupIndex, group ->
+                        item(key = "recently_played_time_${groupIndex}_${group.key}") {
+                            RecentlyPlayedTimestampDivider(
+                                label = group.label,
+                                isHourBucket = group.isHourBucket,
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                        }
+                        items(group.songs, key = { songUi -> songUi.song.id }) { item ->
+                            EnhancedSongListItem(
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                song = item.song,
+                                isCurrentSong = currentSongId == item.song.id,
+                                isPlaying = currentSongId == item.song.id && isPlaying,
+                                onClick = {
+                                    playerViewModel.playSongs(
+                                        songsToPlay = queueSongs,
+                                        startSong = item.song,
+                                        queueName = "Recently Played"
+                                    )
+                                },
+                                onMoreOptionsClick = { song ->
+                                    selectedSongForInfo = song
+                                    showSongInfoBottomSheet = true
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (showSongInfoBottomSheet && selectedSongForInfo != null) {
+            val song = selectedSongForInfo!!
+            SongInfoBottomSheet(
+                song = song,
+                isFavorite = favoriteSongIds.contains(song.id),
+                onToggleFavorite = {
+                    playerViewModel.toggleFavoriteSpecificSong(song)
+                },
+                onDismiss = {
+                    showSongInfoBottomSheet = false
+                    showPlaylistBottomSheet = false
+                    selectedSongForInfo = null
+                },
+                onPlaySong = {
+                    if (queueSongs.isNotEmpty()) {
+                        playerViewModel.playSongs(queueSongs, song, "Recently Played")
+                    }
+                    showSongInfoBottomSheet = false
+                },
+                onAddToQueue = {
+                    playerViewModel.addSongToQueue(song)
+                    showSongInfoBottomSheet = false
+                },
+                onAddNextToQueue = {
+                    playerViewModel.addSongNextToQueue(song)
+                    showSongInfoBottomSheet = false
+                },
+                onAddToPlayList = {
+                    showPlaylistBottomSheet = true
+                },
+                onDeleteFromDevice = playerViewModel::deleteFromDevice,
+                onNavigateToAlbum = {
+                    navController.navigate(Screen.AlbumDetail.createRoute(song.albumId))
+                    showSongInfoBottomSheet = false
+                },
+                onNavigateToArtist = {
+                    navController.navigate(Screen.ArtistDetail.createRoute(song.artistId))
+                    showSongInfoBottomSheet = false
+                },
+                onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, coverArtUpdate ->
+                    playerViewModel.editSongMetadata(
+                        song,
+                        newTitle,
+                        newArtist,
+                        newAlbum,
+                        newGenre,
+                        newLyrics,
+                        newTrackNumber,
+                        coverArtUpdate
+                    )
+                },
+                generateAiMetadata = { fields ->
+                    playerViewModel.generateAiMetadata(song, fields)
+                },
+                removeFromListTrigger = {}
+            )
+
+            if (showPlaylistBottomSheet) {
+                PlaylistBottomSheet(
+                    playlistUiState = playlistUiState,
+                    songs = listOf(song),
+                    onDismiss = { showPlaylistBottomSheet = false },
+                    bottomBarHeight = bottomBarHeightDp,
+                    playerViewModel = playerViewModel,
+                )
+            }
+        }
+
+        FilledIconButton(
+            onClick = { navController.popBackStack() },
+            colors = IconButtonDefaults.filledIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ),
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(start = 10.dp, top = 8.dp)
+                .clip(CircleShape)
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.ArrowBack,
+                contentDescription = "Back"
+            )
+        }
+    }
+
+    Trace.endSection()
+}
+
+@Composable
+private fun ExpressiveRecentlyPlayedHeader(
+    songs: List<RecentlyPlayedSongUiModel>,
+    selectedRange: StatsTimeRange,
+    scrollState: LazyListState
+) {
+    val highlightedArt = remember(songs) { songs.take(4).map { it.song.albumArtUriString } }
+    val parallaxOffset by remember {
+        derivedStateOf {
+            if (scrollState.firstVisibleItemIndex == 0) scrollState.firstVisibleItemScrollOffset * 0.36f else 0f
+        }
+    }
+    val headerAlpha by remember {
+        derivedStateOf {
+            (1f - (scrollState.firstVisibleItemScrollOffset / 520f)).coerceIn(0f, 1f)
+        }
+    }
+
+    val surface = MaterialTheme.colorScheme.surface
+    val primary = MaterialTheme.colorScheme.primary
+    val secondary = MaterialTheme.colorScheme.secondary
+    val titleStyle = rememberRecentlyPlayedTitleStyle()
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(190.dp)
+            .graphicsLayer {
+                translationY = parallaxOffset
+                alpha = headerAlpha
+            }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            secondary.copy(alpha = 0.24f),
+                            primary.copy(alpha = 0.10f),
+                            surface.copy(alpha = 0.95f),
+                            surface
+                        ),
+                        endY = 780f
+                    )
+                )
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+//            Surface(
+//                color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.88f),
+//                shape = RoundedCornerShape(50),
+//                tonalElevation = 0.dp
+//            ) {
+//                Text(
+//                    text = "LIVE HISTORY · ${selectedRange.displayName.uppercase()}",
+//                    style = MaterialTheme.typography.labelMedium,
+//                    fontWeight = FontWeight.SemiBold,
+//                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+//                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 7.dp)
+//                )
+//            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Text(
+                text = "Recently Played",
+                style = titleStyle,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+private fun rememberRecentlyPlayedTitleStyle(): TextStyle {
+    return remember {
+        TextStyle(
+            fontFamily = FontFamily(
+                Font(
+                    resId = R.font.gflex_variable,
+                    variationSettings = FontVariation.Settings(
+                        FontVariation.weight(760),
+                        FontVariation.width(112f),
+                        FontVariation.grade(40),
+                        FontVariation.Setting("ROND", 100f),
+                        FontVariation.Setting("XTRA", 520f),
+                        FontVariation.Setting("YOPQ", 90f),
+                        FontVariation.Setting("YTLC", 505f)
+                    )
+                )
+            ),
+            fontWeight = FontWeight(760),
+            fontSize = 34.sp,
+            lineHeight = 38.sp,
+            letterSpacing = (-0.4).sp
+        )
+    }
+}
+
+@Composable
+private fun RecentlyPlayedRangeSelector(
+    selected: StatsTimeRange,
+    onRangeSelected: (StatsTimeRange) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp)
+    ) {
+        items(StatsTimeRange.entries, key = { it.name }) { range ->
+            FilterChip(
+                modifier = Modifier.height(38.dp),
+                selected = selected == range,
+                onClick = { onRangeSelected(range) },
+                label = { Text(range.displayName) },
+                border = BorderStroke(
+                    width = 2.dp,
+                    color = MaterialTheme.colorScheme.tertiary
+                ),
+                shape = CircleShape,
+                leadingIcon = if (selected == range) {
+                    {
+                        Icon(
+                            imageVector = Icons.Outlined.History,
+                            contentDescription = null,
+                            modifier = Modifier.size(FilterChipDefaults.IconSize)
+                        )
+                    }
+                } else {
+                    null
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    selectedLeadingIconColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    labelColor = MaterialTheme.colorScheme.tertiary
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecentlyPlayedActions(
+    onPlay: () -> Unit,
+    onShuffle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Button(
+            onClick = onPlay,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxSize(),
+            shape = RoundedCornerShape(
+                topStart = 52.dp,
+                topEnd = 14.dp,
+                bottomStart = 52.dp,
+                bottomEnd = 14.dp
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.PlayArrow,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize)
+            )
+            Spacer(Modifier.width(ButtonDefaults.IconSpacing))
+            Text("Play latest")
+        }
+
+        FilledTonalButton(
+            onClick = onShuffle,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxSize(),
+            shape = RoundedCornerShape(
+                topStart = 14.dp,
+                topEnd = 52.dp,
+                bottomStart = 14.dp,
+                bottomEnd = 52.dp
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Shuffle,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize)
+            )
+            Spacer(Modifier.width(ButtonDefaults.IconSpacing))
+            Text("Shuffle")
+        }
+    }
+}
+
+@Composable
+private fun RecentlyPlayedTimestampDivider(
+    label: String,
+    isHourBucket: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val colors = MaterialTheme.colorScheme
+    val railColor = if (isHourBucket) colors.primary else colors.secondary
+    val chipContainer = if (isHourBucket) {
+        colors.primaryContainer.copy(alpha = 0.78f)
+    } else {
+        colors.secondaryContainer.copy(alpha = 0.78f)
+    }
+    val chipContent = if (isHourBucket) colors.onPrimaryContainer else colors.onSecondaryContainer
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 4.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(
+                    Brush.horizontalGradient(
+                        colors = listOf(
+                            railColor.copy(alpha = 0f),
+                            railColor.copy(alpha = 0.50f)
+                        )
+                    )
+                )
+        )
+        Surface(
+            color = chipContainer,
+            shape = AbsoluteSmoothCornerShape(
+                cornerRadiusTL = 22.dp,
+                smoothnessAsPercentTR = 60,
+                cornerRadiusTR = 22.dp,
+                smoothnessAsPercentBR = 60,
+                cornerRadiusBL = 22.dp,
+                smoothnessAsPercentBL = 60,
+                cornerRadiusBR = 22.dp,
+                smoothnessAsPercentTL = 60
+            )
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(railColor)
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = chipContent
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(8.dp)
+                .clip(RoundedCornerShape(50))
+                .background(
+                    Brush.horizontalGradient(
+                        colors = listOf(
+                            railColor.copy(alpha = 0.50f),
+                            railColor.copy(alpha = 0f)
+                        )
+                    )
+                )
+        )
+    }
+}
+
+@Composable
+private fun RecentlyPlayedEmptyState(
+    range: StatsTimeRange,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = AbsoluteSmoothCornerShape(
+            cornerRadiusTL = 26.dp,
+            smoothnessAsPercentTR = 60,
+            cornerRadiusTR = 26.dp,
+            smoothnessAsPercentBR = 60,
+            cornerRadiusBL = 26.dp,
+            smoothnessAsPercentBL = 60,
+            cornerRadiusBR = 26.dp,
+            smoothnessAsPercentTL = 60
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "No recent plays in ${range.displayName.lowercase()}",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Change the range or play more songs to fill this timeline.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private data class TimestampGroup(
+    val key: String,
+    val label: String,
+    val isHourBucket: Boolean,
+    val songs: List<RecentlyPlayedSongUiModel>
+)
+
+private fun groupRecentlyPlayedSongs(
+    songs: List<RecentlyPlayedSongUiModel>,
+    range: StatsTimeRange
+): List<TimestampGroup> {
+    if (songs.isEmpty()) return emptyList()
+    val zoneId = ZoneId.systemDefault()
+    val sorted = songs.sortedByDescending { it.lastPlayedTimestamp }
+
+    val groups = mutableListOf<TimestampGroup>()
+    var currentBucketKey: String? = null
+    var currentLabel: String? = null
+    var currentIsHourBucket = false
+    var bucket = mutableListOf<RecentlyPlayedSongUiModel>()
+
+    sorted.forEach { item ->
+        val timeBucket = resolveTimestampBucket(
+            timestamp = item.lastPlayedTimestamp,
+            range = range,
+            zoneId = zoneId
+        )
+        if (currentBucketKey == null || currentBucketKey == timeBucket.key) {
+            currentBucketKey = timeBucket.key
+            currentLabel = timeBucket.label
+            currentIsHourBucket = timeBucket.isHourBucket
+            bucket += item
+        } else {
+            groups += TimestampGroup(
+                key = currentBucketKey ?: "",
+                label = currentLabel ?: "",
+                isHourBucket = currentIsHourBucket,
+                songs = bucket
+            )
+            currentBucketKey = timeBucket.key
+            currentLabel = timeBucket.label
+            currentIsHourBucket = timeBucket.isHourBucket
+            bucket = mutableListOf(item)
+        }
+    }
+
+    if (bucket.isNotEmpty() && currentLabel != null && currentBucketKey != null) {
+        groups += TimestampGroup(
+            key = currentBucketKey ?: "",
+            label = currentLabel ?: "",
+            isHourBucket = currentIsHourBucket,
+            songs = bucket
+        )
+    }
+
+    return groups
+}
+
+private data class TimestampBucket(
+    val key: String,
+    val label: String,
+    val isHourBucket: Boolean
+)
+
+private fun resolveTimestampBucket(
+    timestamp: Long,
+    range: StatsTimeRange,
+    zoneId: ZoneId
+): TimestampBucket {
+    val safeTimestamp = timestamp.coerceAtLeast(0L)
+    val safeNow = System.currentTimeMillis().coerceAtLeast(0L)
+    val zonedDateTime = Instant.ofEpochMilli(safeTimestamp).atZone(zoneId)
+    val date = zonedDateTime.toLocalDate()
+    val nowDate = Instant.ofEpochMilli(safeNow).atZone(zoneId).toLocalDate()
+
+    if (range == StatsTimeRange.DAY) {
+        val hourStart = zonedDateTime
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+        return TimestampBucket(
+            key = hourStart.toInstant().toEpochMilli().toString(),
+            label = hourStart.format(DateTimeFormatter.ofPattern("h a", Locale.getDefault())),
+            isHourBucket = true
+        )
+    }
+
+    return when {
+        date == nowDate -> {
+            TimestampBucket(
+                key = date.toString(),
+                label = "Today",
+                isHourBucket = false
+            )
+        }
+        date == nowDate.minusDays(1) -> {
+            TimestampBucket(
+                key = date.toString(),
+                label = "Yesterday",
+                isHourBucket = false
+            )
+        }
+        range == StatsTimeRange.YEAR || range == StatsTimeRange.ALL -> {
+            TimestampBucket(
+                key = date.toString(),
+                label = date.format(DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.getDefault())),
+                isHourBucket = false
+            )
+        }
+        else -> {
+            TimestampBucket(
+                key = date.toString(),
+                label = date.format(DateTimeFormatter.ofPattern("EEE, MMM d", Locale.getDefault())),
+                isHourBucket = false
+            )
+        }
+    }
+}


### PR DESCRIPTION
- **Recently Played Feature**:
    - Introduces `Recently Played` screen with time-range filtering (Day, Week, Month, Year, All) and grouped chronological timelines.
    - Implements `RecentlyPlayedSection` on the Home screen featuring a staggered, variable-width horizontal "pill" layout for quick access.
    - Adds `mapRecentlyPlayedSongs` utility to deduplicate and filter playback history against the local library with configurable time bounds.
    - Integrates dedicated play and shuffle actions specifically for the recently played queue.
- **UI & Typography**:
    - Introduces expressive variable font styling for "Recently Played", "Your Mix", and "Daily Mix" headers using `gflex_variable`.
    - Refines the `Daily Mix` header layout with improved image layering and composition logic.
    - Adds smooth-cornered (Squircle) dividers and cards across the history and home screens for a more cohesive Material 3 identity.
- **Navigation & Integration**:
    - Registers the new `RecentlyPlayed` route in `AppNavigation` and `Screen` definitions.
    - Updates `MainActivity` to handle navigation bar visibility and transitions for the new history screen.
    - Enhances the `HomeScreen` with a direct entry point to the full playback history.