### PR TITLE
Refine full player expansion logic and enhance placeholder customization

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/FullPlayerLoadingTweaks.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/FullPlayerLoadingTweaks.kt
@@ -8,5 +8,7 @@ data class FullPlayerLoadingTweaks(
     val delayControls: Boolean = false,
     val showPlaceholders: Boolean = false,
     val transparentPlaceholders: Boolean = false,
-    val contentAppearThresholdPercent: Int = 100
+    val applyPlaceholdersOnClose: Boolean = true,
+    val contentAppearThresholdPercent: Int = 100,
+    val contentCloseThresholdPercent: Int = 0
 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -132,7 +132,9 @@ constructor(
         val FULL_PLAYER_DELAY_CONTROLS = booleanPreferencesKey("full_player_delay_controls")
         val FULL_PLAYER_PLACEHOLDERS = booleanPreferencesKey("full_player_placeholders")
         val FULL_PLAYER_PLACEHOLDER_TRANSPARENT = booleanPreferencesKey("full_player_placeholder_transparent")
+        val FULL_PLAYER_PLACEHOLDERS_ON_CLOSE = booleanPreferencesKey("full_player_placeholders_on_close")
         val FULL_PLAYER_DELAY_THRESHOLD = intPreferencesKey("full_player_delay_threshold_percent")
+        val FULL_PLAYER_CLOSE_THRESHOLD = intPreferencesKey("full_player_close_threshold_percent")
 
         // Multi-Artist Settings
         val ARTIST_DELIMITERS = stringPreferencesKey("artist_delimiters")
@@ -730,7 +732,9 @@ constructor(
                 delayControls = delayControls,
                 showPlaceholders = preferences[PreferencesKeys.FULL_PLAYER_PLACEHOLDERS] ?: false,
                 transparentPlaceholders = preferences[PreferencesKeys.FULL_PLAYER_PLACEHOLDER_TRANSPARENT] ?: false,
-                contentAppearThresholdPercent = preferences[PreferencesKeys.FULL_PLAYER_DELAY_THRESHOLD] ?: 100
+                applyPlaceholdersOnClose = preferences[PreferencesKeys.FULL_PLAYER_PLACEHOLDERS_ON_CLOSE] ?: true,
+                contentAppearThresholdPercent = preferences[PreferencesKeys.FULL_PLAYER_DELAY_THRESHOLD] ?: 100,
+                contentCloseThresholdPercent = preferences[PreferencesKeys.FULL_PLAYER_CLOSE_THRESHOLD] ?: 0
             )
         }
 
@@ -1363,10 +1367,23 @@ constructor(
         }
     }
 
+    suspend fun setFullPlayerPlaceholdersOnClose(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.FULL_PLAYER_PLACEHOLDERS_ON_CLOSE] = enabled
+        }
+    }
+
     suspend fun setFullPlayerAppearThreshold(thresholdPercent: Int) {
         val coercedValue = thresholdPercent.coerceIn(50, 100)
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.FULL_PLAYER_DELAY_THRESHOLD] = coercedValue
+        }
+    }
+
+    suspend fun setFullPlayerCloseThreshold(thresholdPercent: Int) {
+        val coercedValue = thresholdPercent.coerceIn(0, 100)
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.FULL_PLAYER_CLOSE_THRESHOLD] = coercedValue
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/BottomToggleRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/BottomToggleRow.kt
@@ -55,7 +55,7 @@ fun BottomToggleRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(10.dp)
+                .padding(8.dp)
                 .clip(
                     AbsoluteSmoothCornerShape(
                         cornerRadiusBL = rowCorners,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ExperimentalSettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ExperimentalSettingsScreen.kt
@@ -198,6 +198,7 @@ fun ExperimentalSettingsScreen(
                         ) {
                             val delayAllEnabled = uiState.fullPlayerLoadingTweaks.delayAll
                             val appearThresholdPercent = uiState.fullPlayerLoadingTweaks.contentAppearThresholdPercent
+                            val closeThresholdPercent = uiState.fullPlayerLoadingTweaks.contentCloseThresholdPercent
                             val isAnyDelayEnabled = uiState.fullPlayerLoadingTweaks.let {
                                 it.delayAll || it.delayAlbumCarousel || it.delaySongMetadata || it.delayProgressBar || it.delayControls
                             }
@@ -300,12 +301,12 @@ fun ExperimentalSettingsScreen(
 
                                         Column(modifier = Modifier.weight(1f)) {
                                             Text(
-                                                text = "Full player content appear threshold",
+                                                text = "Expand threshold",
                                                 style = MaterialTheme.typography.titleMedium,
                                                 color = MaterialTheme.colorScheme.onSurface
                                             )
                                             Text(
-                                                text = "Control when delayed full player components become visible during expansion.",
+                                                text = "Choose how expanded the sheet must be before delayed components become visible.",
                                                 style = MaterialTheme.typography.bodyMedium,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             )
@@ -328,11 +329,78 @@ fun ExperimentalSettingsScreen(
                                 }
                             }
 
+                            Surface(
+                                color = MaterialTheme.colorScheme.surfaceContainer,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(10.dp))
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.LinearScale,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.secondary
+                                        )
+
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text(
+                                                text = "Close threshold",
+                                                style = MaterialTheme.typography.titleMedium,
+                                                color = MaterialTheme.colorScheme.onSurface
+                                            )
+                                            Text(
+                                                text = "Choose how much the sheet must collapse before placeholders take over while closing.",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        }
+                                    }
+
+                                    Slider(
+                                        value = closeThresholdPercent.toFloat(),
+                                        onValueChange = { settingsViewModel.setFullPlayerCloseThreshold(it.roundToInt()) },
+                                        valueRange = 0f..100f,
+                                        steps = 99,
+                                        enabled = isAnyDelayEnabled && uiState.fullPlayerLoadingTweaks.applyPlaceholdersOnClose
+                                    )
+
+                                    Text(
+                                        text = "Placeholders appear after ${closeThresholdPercent}% collapse",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+
                             SwitchSettingItem(
                                 title = "Use placeholders for delayed items",
                                 subtitle = "Keep layout stable by rendering lightweight placeholders while components wait for expansion.",
                                 checked = uiState.fullPlayerLoadingTweaks.showPlaceholders,
                                 onCheckedChange = settingsViewModel::setFullPlayerPlaceholders,
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Rectangle,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.secondary
+                                    )
+                                }
+                            )
+
+                            SwitchSettingItem(
+                                title = "Also apply on player close",
+                                subtitle = "Show delayed placeholders immediately when the player starts collapsing.",
+                                checked = uiState.fullPlayerLoadingTweaks.applyPlaceholdersOnClose,
+                                onCheckedChange = settingsViewModel::setFullPlayerPlaceholdersOnClose,
+                                enabled = uiState.fullPlayerLoadingTweaks.showPlaceholders,
                                 leadingIcon = {
                                     Icon(
                                         imageVector = Icons.Rounded.Rectangle,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -495,9 +495,21 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setFullPlayerPlaceholdersOnClose(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setFullPlayerPlaceholdersOnClose(enabled)
+        }
+    }
+
     fun setFullPlayerAppearThreshold(thresholdPercent: Int) {
         viewModelScope.launch {
             userPreferencesRepository.setFullPlayerAppearThreshold(thresholdPercent)
+        }
+    }
+
+    fun setFullPlayerCloseThreshold(thresholdPercent: Int) {
+        viewModelScope.launch {
+            userPreferencesRepository.setFullPlayerCloseThreshold(thresholdPercent)
         }
     }
 


### PR DESCRIPTION
- **Full Player UI**:
    - Replaces `Crossfade` with manual alpha blending in `DelayedContent` for smoother transitions between placeholders and actual content.
    - Implements logic to track collapse/expand direction, allowing placeholders to be triggered at a specific "close threshold" when the player is dismissed.
    - Refines placeholder components (`AlbumPlaceholder`, `MetadataPlaceholder`, `ProgressPlaceholder`, `ControlsPlaceholder`) to better match the visual density and layout of real components, including landscape support and audio metadata chips.
    - Adds `graphicsLayer` transformations to placeholders to synchronize their appearance with the sheet expansion fraction.

- **Settings & Configuration**:
    - Adds "Close threshold" slider to Experimental Settings to control when placeholders appear during collapse.
    - Introduces a toggle to enable/disable placeholder delay specifically when closing the player.
    - Renames "Full player content appear threshold" to "Expand threshold" for clarity.

- **Data & State**:
    - Updates `FullPlayerLoadingTweaks` and `UserPreferencesRepository` to persist new threshold and close-behavior preferences.
    - Adds corresponding setter methods in `SettingsViewModel`.

- **UI Refinements**:
    - Adjusts padding in `BottomToggleRow` and layout spacing in `FullPlayerContent` for better visual alignment.