### PR TITLE
perf: optimize playback state updates and recomposition frequency

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -158,7 +158,7 @@ fun CastBottomSheet(
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsState()
     val isCastConnecting by playerViewModel.isCastConnecting.collectAsState()
     val trackVolume by playerViewModel.trackVolume.collectAsState()
-    val isPlaying = playerViewModel.stablePlayerState.collectAsState().value.isPlaying
+    val isPlaying = playerViewModel.stablePlayerStateInfrequent.collectAsState().value.isPlaying
     val context = LocalContext.current
 
     val requiredPermissions = remember {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -231,7 +231,7 @@ fun PlaylistItems(
     filteredPlaylists: List<Playlist>,
     selectedPlaylists: SnapshotStateMap<String, Boolean>? = null
 ) {
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val listState = rememberLazyListState()
 
     androidx.compose.runtime.LaunchedEffect(filteredPlaylists) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -228,11 +228,7 @@ fun QueueBottomSheet(
     var showClearQueueDialog by remember { mutableStateOf(false) }
     var isFabExpanded by rememberSaveable { mutableStateOf(false) }
 
-    val infrequentPlayerState by remember {
-        viewModel.stablePlayerState
-            .map { it.copy(currentPosition = 0L) }
-            .distinctUntilChanged()
-    }.collectAsState(initial = StablePlayerState())
+    val infrequentPlayerState by viewModel.stablePlayerStateInfrequent.collectAsState()
 
     val albumColorSchemePair by viewModel.currentAlbumArtColorSchemePair.collectAsState()
     val isDark = isSystemInDarkTheme()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -147,16 +147,10 @@ fun UnifiedPlayerSheet(
         }
     }
 
-    val infrequentPlayerStateReference = remember {
-        playerViewModel.stablePlayerState
-            .map { it.copy(currentPosition = 0L) } // Keep totalDuration, only mask volatile position
-            .distinctUntilChanged()
-    }.collectAsState(initial = StablePlayerState())
+    val infrequentPlayerStateReference = playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val infrequentPlayerState = infrequentPlayerStateReference.value
 
-    val currentPositionState = remember {
-        playerViewModel.playerUiState.map { it.currentPosition }.distinctUntilChanged()
-    }.collectAsState(initial = 0L)
+    val currentPositionState = playerViewModel.currentPlaybackPosition.collectAsState()
 
     val remotePositionState = playerViewModel.remotePosition.collectAsState()
     // We observe isRemotePlaybackActive directly as switching modes is a major event

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -108,16 +108,10 @@ fun UnifiedPlayerSheetV2(
         }
     }
 
-    val infrequentPlayerStateReference = remember {
-        playerViewModel.stablePlayerState
-            .map { it.copy(currentPosition = 0L) }
-            .distinctUntilChanged()
-    }.collectAsState(initial = StablePlayerState())
+    val infrequentPlayerStateReference = playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val infrequentPlayerState = infrequentPlayerStateReference.value
 
-    val currentPositionState = remember {
-        playerViewModel.playerUiState.map { it.currentPosition }.distinctUntilChanged()
-    }.collectAsState(initial = 0L)
+    val currentPositionState = playerViewModel.currentPlaybackPosition.collectAsState()
     val remotePositionState = playerViewModel.remotePosition.collectAsState()
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsState()
     val positionToDisplayProvider = remember(isRemotePlaybackActive) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/external/ExternalPlayerOverlay.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/external/ExternalPlayerOverlay.kt
@@ -69,8 +69,8 @@ fun ExternalPlayerOverlay(
     onDismiss: () -> Unit,
     onOpenFullPlayer: () -> Unit
 ) {
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
-    val playerUiState by playerViewModel.playerUiState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
+    val playbackPosition by playerViewModel.currentPlaybackPosition.collectAsState()
     val remotePosition by playerViewModel.remotePosition.collectAsState()
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsState()
     val navBarCornerRadius by playerViewModel.navBarCornerRadius.collectAsState()
@@ -160,7 +160,7 @@ fun ExternalPlayerOverlay(
                     }
                 } else {
                     val totalDuration = stablePlayerState.totalDuration.coerceAtLeast(0L)
-                    val rawPosition = if (isRemotePlaybackActive) remotePosition else playerUiState.currentPosition
+                    val rawPosition = if (isRemotePlaybackActive) remotePosition else playbackPosition
                     val position = rawPosition.coerceIn(0L, totalDuration)
                     val progressFraction = if (totalDuration > 0) position.toFloat() / totalDuration else 0f
 
@@ -271,7 +271,8 @@ fun ExternalPlayerOverlay(
                             },
                             waveLength = 30.dp,
                             isPlaying = stablePlayerState.isPlaying,
-                            isWaveEligible = true
+                            isWaveEligible = true,
+                            semanticsLabel = "Playback position"
                         )
 
                         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/PlayerSeekBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/PlayerSeekBar.kt
@@ -105,7 +105,8 @@ fun PlayerSeekBar(
             inactiveTrackColor = primaryColor.copy(alpha = 0.2f),
             thumbColor = primaryColor,
             wavelength = 30.dp, // Was waveLength
-            isPlaying = isPlaying
+            isPlaying = isPlaying,
+            semanticsLabel = "Playback position"
         )
 //        Text(
 //            modifier = Modifier.weight(0.2f),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
@@ -273,7 +273,7 @@ fun AboutScreen(
     }
 
     var showBrickBreaker by remember { mutableStateOf(false) }
-    val stablePlayerState by viewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by viewModel.stablePlayerStateInfrequent.collectAsState()
     val currentSong = stablePlayerState.currentSong
 
     Box(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
@@ -103,7 +103,7 @@ fun AlbumDetailScreen(
     playlistViewModel: PlaylistViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val playerSheetState by playerViewModel.sheetState.collectAsState()
     val favoriteIds by playerViewModel.favoriteSongIds.collectAsState()
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -79,7 +79,7 @@ fun ArtistDetailScreen(
     playlistViewModel: PlaylistViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val playerSheetState by playerViewModel.sheetState.collectAsState()
     val lazyListState = rememberLazyListState()
     val favoriteIds by playerViewModel.favoriteSongIds.collectAsState()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -108,7 +108,7 @@ fun DailyMixScreen(
     val bottomBarHeightDp = NavBarContentHeight + systemNavBarInset
     var showPlaylistBottomSheet by remember { mutableStateOf(false) }
     val playerSheetState by playerViewModel.sheetState.collectAsState() // This is a simple enum, less critical but fine
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsState()
 
     val showAiSheet by playerViewModel.showAiPlaylistSheet.collectAsState()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
@@ -115,7 +115,7 @@ fun GenreDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val playerSheetState by playerViewModel.sheetState.collectAsState()
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsState()
     val playlistUiState by playlistViewModel.uiState.collectAsState()
     val libraryGenres by playerViewModel.genres.collectAsState()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -489,7 +489,7 @@ fun SongListItemFavsWrapper(
     modifier: Modifier = Modifier
 ) {
     // Collect the stablePlayerState once
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
 
     // Derive isThisSongPlaying using remember
     val isThisSongPlaying = remember(song.id, stablePlayerState.currentSong?.id, stablePlayerState.isPlaying) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -624,7 +624,7 @@ fun LibraryScreen(
                         }
                         val playerUiState by playerViewModel.playerUiState.collectAsState()
                         val playlistUiState by playlistViewModel.uiState.collectAsState()
-                        val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                        val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
                         val favoritePagingItems = libraryViewModel.favoritesPagingFlow.collectAsLazyPagingItems()
 
                         val currentSelectedSortOption: SortOption? = when (currentTabId) {
@@ -879,7 +879,7 @@ fun LibraryScreen(
                                         val allSongsLazyPagingItems = libraryViewModel.songsPagingFlow.collectAsLazyPagingItems()
                                         // We can use libraryViewModel.isLoadingLibrary or similar if needed for global loading state
                                         val isLibraryLoading by libraryViewModel.isLoadingLibrary.collectAsState()
-                                        val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                                        val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
                                         val playerUiState by playerViewModel.playerUiState.collectAsState()
 
                                         LibrarySongsTab(
@@ -991,7 +991,7 @@ fun LibraryScreen(
                                             val folders = playerUiState.musicFolders
                                             val currentFolder = playerUiState.currentFolder
                                             val isLoading = playerUiState.isLoadingLibraryCategories
-                                            val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                                            val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
 
                                             LibraryFoldersTab(
                                                 folders = folders,
@@ -2081,7 +2081,7 @@ fun LibraryFavoritesTab(
     onLocateCurrentSongVisibilityChanged: (Boolean) -> Unit = {},
     onRegisterLocateCurrentSongAction: ((() -> Unit)?) -> Unit = {}
 ) {
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
     val visibilityCallback by rememberUpdatedState(onLocateCurrentSongVisibilityChanged)
@@ -2672,7 +2672,7 @@ fun LibraryAlbumsTab(
                             }
                         }
                         // ScrollBar Overlay for List
-                        val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                        val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
                         val bottomPadding = if (stablePlayerState.currentSong != null && stablePlayerState.currentSong != Song.emptySong())
                             bottomBarHeight + MiniPlayerHeight + 16.dp
                         else
@@ -2717,7 +2717,7 @@ fun LibraryAlbumsTab(
                         }
 
                         // ScrollBar Overlay for Grid
-                        val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                        val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
                         val bottomPadding = if (stablePlayerState.currentSong != null && stablePlayerState.currentSong != Song.emptySong())
                             bottomBarHeight + MiniPlayerHeight + 16.dp
                         else
@@ -2976,7 +2976,7 @@ fun LibraryArtistsTab(
                     }
 
                     // ScrollBar Overlay
-                    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+                    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
                     val bottomPadding = if (stablePlayerState.currentSong != null && stablePlayerState.currentSong != Song.emptySong())
                         bottomBarHeight + MiniPlayerHeight + 16.dp
                     else

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PaletteStyleSettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PaletteStyleSettingsScreen.kt
@@ -74,7 +74,7 @@ fun PaletteStyleSettingsScreen(
 ) {
     val uiState by settingsViewModel.uiState.collectAsState()
     val playerSheetState by playerViewModel.sheetState.collectAsState()
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val isDarkTheme = LocalPixelPlayDarkTheme.current
     val albumSchemePair by playerViewModel.currentAlbumArtColorSchemePair.collectAsState()
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -144,7 +144,7 @@ fun PlaylistDetailScreen(
     navController: NavController
 ) {
     val uiState by playlistViewModel.uiState.collectAsState()
-    val playerStableState by playerViewModel.stablePlayerState.collectAsState()
+    val playerStableState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val playerSheetState by playerViewModel.sheetState.collectAsState()
     val context = LocalContext.current
     val currentPlaylist = uiState.currentPlaylistDetails

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -127,7 +127,7 @@ fun SearchScreen(
     val currentFilter by remember { derivedStateOf { uiState.selectedSearchFilter } }
     val searchHistory = uiState.searchHistory
     val genres by playerViewModel.genres.collectAsState()
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsState()
+    val stablePlayerState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsState()
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }
     var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
@@ -654,7 +654,7 @@ fun SearchResultsList(
     navController: NavHostController
 ) {
     val localDensity = LocalDensity.current
-    val playerStableState by playerViewModel.stablePlayerState.collectAsState()
+    val playerStableState by playerViewModel.stablePlayerStateInfrequent.collectAsState()
 
     if (results.isEmpty()) {
         Box(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -297,13 +297,23 @@ class PlaybackStateHolder @Inject constructor(
 
                         listeningStatsTracker.onProgress(currentPosition, isRemotePlaying)
 
-                        _stablePlayerState.update {
-                             it.copy(
-                                 currentPosition = if (isRemotelySeeking) it.currentPosition else currentPosition,
-                                 totalDuration = duration,
-                                 isPlaying = isRemotePlaying,
-                                 playWhenReady = isRemotePlaying
-                             )
+                        _stablePlayerState.update { state ->
+                            val nextPosition = if (isRemotelySeeking) state.currentPosition else currentPosition
+                            if (
+                                state.currentPosition == nextPosition &&
+                                state.totalDuration == duration &&
+                                state.isPlaying == isRemotePlaying &&
+                                state.playWhenReady == isRemotePlaying
+                            ) {
+                                state
+                            } else {
+                                state.copy(
+                                    currentPosition = nextPosition,
+                                    totalDuration = duration,
+                                    isPlaying = isRemotePlaying,
+                                    playWhenReady = isRemotePlaying
+                                )
+                            }
                         }
                     }
                 } else {
@@ -336,8 +346,12 @@ class PlaybackStateHolder @Inject constructor(
                          
                          listeningStatsTracker.onProgress(currentPosition, true)
                          
-                         _stablePlayerState.update {
-                             it.copy(currentPosition = currentPosition, totalDuration = duration)
+                         _stablePlayerState.update { state ->
+                             if (state.currentPosition == currentPosition && state.totalDuration == duration) {
+                                 state
+                             } else {
+                                 state.copy(currentPosition = currentPosition, totalDuration = duration)
+                             }
                         }
                      }
                 }


### PR DESCRIPTION
- **State Management**:
    - Introduced `stablePlayerStateInfrequent` in `PlayerViewModel` to decouple structural playback changes (song, play/pause) from high-frequency position updates, reducing unnecessary recompositions across most screens.
    - Added `currentPlaybackPosition` flow for components requiring real-time updates (seek bars, lyrics).
    - Updated `PlaybackStateHolder` to suppress redundant state updates when values are unchanged.

- **UI & Performance**:
    - Migrated major screens (`Home`, `Library`, `AlbumDetail`, `PlaylistDetail`, etc.) to use `stablePlayerStateInfrequent`.
    - Refactored `UnifiedPlayerSheet` and `LyricsSheet` to use granular position flows instead of the full UI state.
    - Quantized position strings in `FullPlayerContent` to update only every second, minimizing UI churn.

- **Accessibility & Controls**:
    - Implemented accessibility semantics for `WavySliderExpressive` and `WavyMusicSlider`, including `semanticsLabel` and quantized `ProgressBarRangeInfo` to reduce accessibility event noise.
    - Refined haptic feedback granularity in `WavyMusicSlider`.

- **Animations**:
    - Replaced `InfiniteTransition` with manual `Animatable` loops in `PlayingEqIcon` to allow clean pausing/resuming of animations based on playback state.