### PR TITLE
feat(equalizer): stabilize audio effects and improve state persistence

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -95,6 +95,13 @@ class DualPlayerEngine @Inject constructor(
                 }
             }
         }
+
+        override fun onAudioSessionIdChanged(audioSessionId: Int) {
+            if (audioSessionId != 0 && _activeAudioSessionId.value != audioSessionId) {
+                _activeAudioSessionId.value = audioSessionId
+                Timber.tag("TransitionDebug").d("Master audio session changed: %d", audioSessionId)
+            }
+        }
     }
 
     fun addPlayerSwapListener(listener: (Player) -> Unit) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
@@ -1249,7 +1249,7 @@ private fun EffectControlsSection(
             EffectCard(
                 title = "Loudness",
                 value = loudnessStrength,
-                valueRange = 0f..3000f,
+                valueRange = 0f..1000f,
                 isEnabled = loudnessEnabled,
                 onValueChange = { onLoudnessStrengthChange(it) },
                 onEnabledChange = onLoudnessEnabledChange


### PR DESCRIPTION
- **Core Audio**:
    - Implement `onAudioSessionIdChanged` in `DualPlayerEngine` to track and update the active audio session ID.
    - Standardize the number of equalizer bands to 10 across the repository and UI.
    - Clamp `LoudnessEnhancer` gain to a stable range of 0–1000 mB (10dB) to ensure cross-device consistency.

- **State Management**:
    - Add a synchronous flush of equalizer and audio effect settings in `EqualizerViewModel.onCleared()` to prevent data loss from debounced updates when the screen is dismissed.
    - Improve data normalization in `UserPreferencesRepository` for equalizer bands and loudness strength.

- **Equalizer Engine**:
    - Refactor `EqualizerManager` to better synchronize effect states (Bass Boost, Virtualizer, Loudness) when re-attaching to a new audio session.
    - Ensure target gain is applied before enabling `LoudnessEnhancer` to prevent audio spikes.

- **UI**:
    - Update `EqualizerScreen` slider ranges to match the new 1000 mB limit for Loudness.