### PR TITLE
feat: implement "start at zero" shuffle and refine playback logic

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -265,8 +265,8 @@ fun ArtistDetailScreen(
                         onBackPressed = { navController.popBackStack() },
                         onPlayClick = {
                             if (songs.isNotEmpty()) {
-                                val randomSong = songs.random()
-                                playerViewModel.showAndPlaySong(randomSong, songs) }
+                                playerViewModel.playSongsShuffled(songs, artist.name, startAtZero = true)
+                            }
                         }
                     )
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolder.kt
@@ -106,7 +106,11 @@ class QueueStateHolder @Inject constructor() {
      * Suspendable variant for large queues.
      * Runs the heavy shuffle computation on Default dispatcher to avoid UI stalls.
      */
-    suspend fun prepareShuffledQueueSuspending(songs: List<Song>, queueName: String): Pair<List<Song>, Song>? {
+    suspend fun prepareShuffledQueueSuspending(
+        songs: List<Song>, 
+        queueName: String, 
+        startAtZero: Boolean = false
+    ): Pair<List<Song>, Song>? {
         if (songs.isEmpty()) return null
 
         val startSong = songs.random()
@@ -114,7 +118,7 @@ class QueueStateHolder @Inject constructor() {
 
         val startIndex = songs.indexOfFirst { it.id == startSong.id }.coerceAtLeast(0)
         val shuffledQueue = withContext(Dispatchers.Default) {
-            QueueUtils.buildAnchoredShuffleQueueSuspending(songs, startIndex)
+            QueueUtils.buildAnchoredShuffleQueueSuspending(songs, startIndex, startAtZero)
         }
         return Pair(shuffledQueue, startSong)
     }


### PR DESCRIPTION
- **Queue Management**:
    - Add `generateShuffleOrderStartAtZero` to `QueueUtils` to ensure a specific anchor song always occupies the first position in a shuffled queue.
    - Update `buildAnchoredShuffleQueueSuspending` and `QueueStateHolder` to support the new `startAtZero` shuffle behavior.

- **Player Logic**:
    - Modify `PlayerViewModel.playSongsShuffled` to accept an optional `startAtZero` parameter.
    - Remove strict `openInputStream` validation in `PlayerViewModel` to prevent valid songs from being incorrectly filtered out due to transient access issues.

- **Artist Detail UI**:
    - Update the shuffle/play button in `ArtistDetailScreen` to use the new `playSongsShuffled` logic with `startAtZero = true` for a more consistent playback experience.