### PR TITLE
feat(netease): stabilize cloud sync, rebuild restore, and pre-push test regressions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,13 @@
             android:theme="@style/Theme.PixelPlay" />
 
         <activity
+            android:name=".presentation.netease.auth.NeteaseLoginActivity"
+            android:exported="false"
+            android:label="Netease Login"
+            android:theme="@style/Theme.PixelPlay" />
+
+
+        <activity
             android:name=".ExternalPlayerActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NeteaseDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NeteaseDao.kt
@@ -1,0 +1,59 @@
+package com.theveloper.pixelplay.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface NeteaseDao {
+
+    // ─── Songs ─────────────────────────────────────────────────────────
+
+    @Query("SELECT * FROM netease_songs ORDER BY date_added DESC")
+    fun getAllNeteaseSongs(): Flow<List<NeteaseSongEntity>>
+
+    @Query("SELECT * FROM netease_songs ORDER BY date_added DESC")
+    suspend fun getAllNeteaseSongsList(): List<NeteaseSongEntity>
+
+    @Query("SELECT * FROM netease_songs WHERE playlist_id = :playlistId ORDER BY date_added DESC")
+    fun getSongsByPlaylist(playlistId: Long): Flow<List<NeteaseSongEntity>>
+
+    @Query("SELECT * FROM netease_songs WHERE title LIKE '%' || :query || '%' OR artist LIKE '%' || :query || '%'")
+    fun searchSongs(query: String): Flow<List<NeteaseSongEntity>>
+
+    @Query("SELECT * FROM netease_songs WHERE id IN (:ids)")
+    fun getSongsByIds(ids: List<String>): Flow<List<NeteaseSongEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSongs(songs: List<NeteaseSongEntity>)
+
+    @Query("DELETE FROM netease_songs WHERE id = :songId")
+    suspend fun deleteSong(songId: String)
+
+    @Query("DELETE FROM netease_songs WHERE playlist_id = :playlistId")
+    suspend fun deleteSongsByPlaylist(playlistId: Long)
+
+    // ─── Playlists ─────────────────────────────────────────────────────
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertPlaylist(playlist: NeteasePlaylistEntity)
+
+    @Query("SELECT * FROM netease_playlists ORDER BY name ASC")
+    fun getAllPlaylists(): Flow<List<NeteasePlaylistEntity>>
+
+    @Query("SELECT * FROM netease_playlists")
+    suspend fun getAllPlaylistsList(): List<NeteasePlaylistEntity>
+
+    @Query("DELETE FROM netease_playlists WHERE id = :playlistId")
+    suspend fun deletePlaylist(playlistId: Long)
+
+    // ─── Clear All ─────────────────────────────────────────────────────
+
+    @Query("DELETE FROM netease_songs")
+    suspend fun clearAllSongs()
+
+    @Query("DELETE FROM netease_playlists")
+    suspend fun clearAllPlaylists()
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NeteasePlaylistEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NeteasePlaylistEntity.kt
@@ -1,0 +1,14 @@
+package com.theveloper.pixelplay.data.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "netease_playlists")
+data class NeteasePlaylistEntity(
+    @PrimaryKey val id: Long,
+    val name: String,
+    @ColumnInfo(name = "cover_url") val coverUrl: String?,
+    @ColumnInfo(name = "song_count") val songCount: Int,
+    @ColumnInfo(name = "last_sync_time") val lastSyncTime: Long
+)

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NeteaseSongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NeteaseSongEntity.kt
@@ -1,0 +1,69 @@
+package com.theveloper.pixelplay.data.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.theveloper.pixelplay.data.model.Song
+
+@Entity(tableName = "netease_songs")
+data class NeteaseSongEntity(
+    @PrimaryKey val id: String,                          // Netease song ID as string
+    @ColumnInfo(name = "netease_id") val neteaseId: Long, // Raw Netease numeric ID
+    @ColumnInfo(name = "playlist_id") val playlistId: Long,
+    val title: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id") val albumId: Long,
+    val duration: Long,                                   // milliseconds
+    @ColumnInfo(name = "album_art_url") val albumArtUrl: String?,
+    @ColumnInfo(name = "mime_type") val mimeType: String,
+    val bitrate: Int?,
+    @ColumnInfo(name = "date_added") val dateAdded: Long
+)
+
+/**
+ * Convert a [NeteaseSongEntity] to the app's [Song] data model.
+ */
+fun NeteaseSongEntity.toSong(): Song {
+    return Song(
+        id = "netease_$id",
+        title = title,
+        artist = artist,
+        artistId = -1L,
+        album = album,
+        albumId = albumId,
+        path = "",
+        contentUriString = "netease://$neteaseId",
+        albumArtUriString = albumArtUrl,
+        duration = duration,
+        mimeType = mimeType,
+        bitrate = bitrate,
+        sampleRate = 0,
+        year = 0,
+        trackNumber = 0,
+        dateAdded = dateAdded,
+        isFavorite = false,
+        neteaseId = neteaseId
+    )
+}
+
+/**
+ * Convert a [Song] to a [NeteaseSongEntity] for database storage.
+ */
+fun Song.toNeteaseEntity(playlistId: Long): NeteaseSongEntity {
+    val resolvedNeteaseId = neteaseId ?: 0L
+    return NeteaseSongEntity(
+        id = "${playlistId}_${resolvedNeteaseId}",
+        neteaseId = resolvedNeteaseId,
+        playlistId = playlistId,
+        title = title,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        duration = duration,
+        albumArtUrl = albumArtUriString,
+        mimeType = mimeType ?: "audio/mpeg",
+        bitrate = bitrate,
+        dateAdded = dateAdded
+    )
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -18,9 +18,11 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         TelegramChannelEntity::class,
         SongEngagementEntity::class,
         FavoritesEntity::class,
-        LyricsEntity::class
+        LyricsEntity::class,
+        NeteaseSongEntity::class,
+        NeteasePlaylistEntity::class
     ],
-    version = 20, // Incremented for Telegram table schema reconciliation
+    version = 21, // Incremented for Netease Cloud Music tables
 
     exportSchema = false
 )
@@ -32,7 +34,8 @@ abstract class PixelPlayDatabase : RoomDatabase() {
     abstract fun telegramDao(): TelegramDao
     abstract fun engagementDao(): EngagementDao
     abstract fun favoritesDao(): FavoritesDao
-    abstract fun lyricsDao(): LyricsDao // Added FavoritesDao
+    abstract fun lyricsDao(): LyricsDao
+    abstract fun neteaseDao(): NeteaseDao
 
     companion object {
         // Gap-bridging no-op migrations for missing version ranges.
@@ -356,6 +359,40 @@ abstract class PixelPlayDatabase : RoomDatabase() {
                         song_count INTEGER NOT NULL DEFAULT 0,
                         last_sync_time INTEGER NOT NULL DEFAULT 0,
                         photo_path TEXT
+                    )
+                """.trimIndent())
+            }
+        }
+
+        /**
+         * Add Netease Cloud Music tables.
+         */
+        val MIGRATION_20_21 = object : Migration(20, 21) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS netease_songs (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        netease_id INTEGER NOT NULL,
+                        playlist_id INTEGER NOT NULL,
+                        title TEXT NOT NULL,
+                        artist TEXT NOT NULL,
+                        album TEXT NOT NULL,
+                        album_id INTEGER NOT NULL,
+                        duration INTEGER NOT NULL,
+                        album_art_url TEXT,
+                        mime_type TEXT NOT NULL,
+                        bitrate INTEGER,
+                        date_added INTEGER NOT NULL
+                    )
+                """.trimIndent())
+
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS netease_playlists (
+                        id INTEGER NOT NULL PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        cover_url TEXT,
+                        song_count INTEGER NOT NULL,
+                        last_sync_time INTEGER NOT NULL
                     )
                 """.trimIndent())
             }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
@@ -90,6 +90,9 @@ fun SongEntity.toSong(): Song {
         telegramFileId = if (this.contentUriString.startsWith("telegram://")) {
             this.contentUriString.removePrefix("telegram://").split("/").getOrNull(1)?.toIntOrNull()
         } else null,
+        neteaseId = if (this.contentUriString.startsWith("netease://")) {
+            this.contentUriString.removePrefix("netease://").toLongOrNull()
+        } else null,
         mimeType = this.mimeType,
         bitrate = this.bitrate,
         sampleRate = this.sampleRate
@@ -135,6 +138,9 @@ fun SongEntity.toSongWithArtistRefs(artists: List<ArtistEntity>, crossRefs: List
         } else null,
         telegramFileId = if (this.contentUriString.startsWith("telegram://")) {
             this.contentUriString.removePrefix("telegram://").split("/").getOrNull(1)?.toIntOrNull()
+        } else null,
+        neteaseId = if (this.contentUriString.startsWith("netease://")) {
+            this.contentUriString.removePrefix("netease://").toLongOrNull()
         } else null,
         mimeType = this.mimeType,
         bitrate = this.bitrate,

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/Song.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/Song.kt
@@ -37,6 +37,7 @@ data class Song(
     val sampleRate: Int?,
     val telegramFileId: Int? = null, // ID of the file in Telegram
     val telegramChatId: Long? = null, // ID of the chat where the file is located
+    val neteaseId: Long? = null, // Netease Cloud Music song ID
 ) : Parcelable {
     private val defaultArtistDelimiters = listOf("/", ";", ",", "+", "&")
 
@@ -90,7 +91,8 @@ data class Song(
                 bitrate = 0,
                 sampleRate = 0,
                 telegramFileId = null,
-                telegramChatId = null
+                telegramChatId = null,
+                neteaseId = null
             )
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseStreamProxy.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseStreamProxy.kt
@@ -1,0 +1,179 @@
+package com.theveloper.pixelplay.data.netease
+
+import android.net.Uri
+import com.theveloper.pixelplay.utils.LogUtils
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.engine.*
+import io.ktor.server.cio.*
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.server.response.header
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import timber.log.Timber
+import java.net.ServerSocket
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Local HTTP proxy server for streaming Netease Cloud Music audio.
+ *
+ * Resolves `netease://{songId}` URIs by fetching temporary streaming URLs
+ * from the Netease API and proxying the audio data to ExoPlayer.
+ *
+ * Follows the same architectural pattern as [TelegramStreamProxy] using Ktor CIO.
+ */
+@Singleton
+class NeteaseStreamProxy @Inject constructor(
+    private val repository: NeteaseRepository,
+    private val okHttpClient: OkHttpClient
+) {
+    private var server: ApplicationEngine? = null
+    private var actualPort: Int = 0
+
+    // Cache of resolved streaming URLs (they expire, so we track timestamp)
+    private val urlCache = ConcurrentHashMap<Long, CachedUrl>()
+
+    private data class CachedUrl(val url: String, val timestamp: Long) {
+        // Netease URLs typically expire in ~20 minutes, re-fetch after 15
+        fun isExpired(): Boolean = System.currentTimeMillis() - timestamp > 15 * 60 * 1000
+    }
+
+    fun isReady(): Boolean = actualPort > 0
+
+    fun getProxyUrl(songId: Long): String {
+        if (actualPort == 0) {
+            Timber.w("NeteaseStreamProxy: getProxyUrl called but actualPort is 0")
+            return ""
+        }
+        return "http://127.0.0.1:$actualPort/netease/$songId"
+    }
+
+    /**
+     * Parse a `netease://` URI and return the proxy URL.
+     * Returns null if the URI is not a valid Netease URI.
+     */
+    fun resolveNeteaseUri(uriString: String): String? {
+        val uri = Uri.parse(uriString)
+        if (uri.scheme != "netease") return null
+        val songId = uri.host?.toLongOrNull() ?: return null
+        return getProxyUrl(songId)
+    }
+
+    fun start() {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val freePort = ServerSocket(0).use { it.localPort }
+                server = createServer(freePort)
+                server!!.start(wait = false)
+                actualPort = freePort
+                Timber.d("NeteaseStreamProxy started on port $actualPort")
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to start NeteaseStreamProxy")
+            }
+        }
+    }
+
+    fun stop() {
+        server?.stop(1000, 2000)
+        server = null
+        actualPort = 0
+        urlCache.clear()
+        Timber.d("NeteaseStreamProxy stopped")
+    }
+
+    private fun createServer(port: Int): ApplicationEngine {
+        return embeddedServer(CIO, port = port) {
+            routing {
+                get("/netease/{songId}") {
+                    val songId = call.parameters["songId"]?.toLongOrNull()
+                    if (songId == null) {
+                        call.respond(HttpStatusCode.BadRequest, "Invalid Song ID")
+                        return@get
+                    }
+
+                    try {
+                        val streamUrl = getOrFetchStreamUrl(songId)
+                        if (streamUrl == null) {
+                            call.respond(HttpStatusCode.NotFound, "No stream URL available")
+                            return@get
+                        }
+
+                        // Proxy the audio stream
+                        val rangeHeader = call.request.headers["Range"]
+                        val requestBuilder = Request.Builder().url(streamUrl)
+                        if (rangeHeader != null) {
+                            requestBuilder.header("Range", rangeHeader)
+                        }
+
+                        val response = withContext(Dispatchers.IO) {
+                            okHttpClient.newCall(requestBuilder.build()).execute()
+                        }
+                        val body = response.body
+
+                        if (body == null) {
+                            call.respond(HttpStatusCode.BadGateway, "No response body")
+                            return@get
+                        }
+
+                        val contentLength = response.header("Content-Length")
+                        val contentRange = response.header("Content-Range")
+                        val acceptRanges = response.header("Accept-Ranges")
+
+                        if (response.code == 206) {
+                            call.response.status(HttpStatusCode.PartialContent)
+                        }
+                        call.response.header("Accept-Ranges", acceptRanges ?: "bytes")
+                        contentLength?.let { call.response.header("Content-Length", it) }
+                        contentRange?.let { call.response.header("Content-Range", it) }
+
+                        call.respondBytesWriter(contentType = ContentType.Audio.Any) {
+                            withContext(Dispatchers.IO) {
+                                body.byteStream().use { input ->
+                                    val buffer = ByteArray(64 * 1024)
+                                    var bytesRead: Int
+                                    while (input.read(buffer).also { bytesRead = it } != -1) {
+                                        writeFully(buffer, 0, bytesRead)
+                                    }
+                                }
+                            }
+                        }
+                    } catch (e: Exception) {
+                        val msg = e.toString()
+                        if (msg.contains("ChannelWriteException") ||
+                            msg.contains("ClosedChannelException") ||
+                            msg.contains("Broken pipe") ||
+                            msg.contains("JobCancellationException")) {
+                            // Client disconnected, normal behavior
+                        } else {
+                            Timber.e(e, "Error streaming Netease song $songId")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun getOrFetchStreamUrl(songId: Long): String? {
+        // Check cache first
+        urlCache[songId]?.let { cached ->
+            if (!cached.isExpired()) return cached.url
+        }
+
+        // Fetch fresh URL
+        val result = repository.getSongUrl(songId)
+        return result.getOrNull()?.also { url ->
+            urlCache[songId] = CachedUrl(url, System.currentTimeMillis())
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/CryptoMode.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/CryptoMode.kt
@@ -1,0 +1,16 @@
+package com.theveloper.pixelplay.data.network.netease
+
+/**
+ * Encryption mode for Netease Cloud Music API.
+ * Different endpoints require different encryption methods.
+ */
+enum class CryptoMode {
+    /** WeAPI — double AES-CBC + RSA. Used for search, playlists. */
+    WEAPI,
+    /** EAPI — AES-ECB with MD5 digest. Used for login, song URLs. */
+    EAPI,
+    /** Linux API — AES-ECB with fixed key. */
+    LINUX,
+    /** Plain API — no encryption, pass params directly. */
+    API
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseApiService.kt
@@ -1,0 +1,316 @@
+package com.theveloper.pixelplay.data.network.netease
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.FormBody
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Direct Netease Cloud Music API client.
+ *
+ * Modeled after NeriPlayer's NeteaseClient — uses OkHttp with cookie management,
+ * supports all 4 crypto modes, and calls music.163.com/interface.music.163.com directly.
+ */
+@Singleton
+class NeteaseApiService @Inject constructor() {
+
+    companion object {
+        private const val TAG = "NeteaseApi"
+    }
+
+    private val cookieStore: MutableMap<String, MutableList<Cookie>> = mutableMapOf()
+
+    @Volatile
+    private var persistedCookies: Map<String, String> = emptyMap()
+
+    private val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .cookieJar(object : CookieJar {
+            override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                val host = url.host
+                val list = cookieStore.getOrPut(host) { mutableListOf() }
+                list.removeAll { c -> cookies.any { it.name == c.name } }
+                list.addAll(cookies)
+            }
+
+            override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                return cookieStore[url.host] ?: emptyList()
+            }
+        })
+        .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+        .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+        .build()
+
+    // ─── Cookie Management ─────────────────────────────────────────────
+
+    /** Check if user is logged in (has MUSIC_U cookie) */
+    fun hasLogin(): Boolean = !persistedCookies["MUSIC_U"].isNullOrBlank()
+
+    /** Set persisted cookies from saved state and inject into CookieJar */
+    fun setPersistedCookies(cookies: Map<String, String>) {
+        val m = cookies.toMutableMap()
+        m.putIfAbsent("os", "pc")
+        m.putIfAbsent("appver", "8.10.35")
+        persistedCookies = m.toMap()
+
+        seedCookieJarFromPersisted("music.163.com")
+        seedCookieJarFromPersisted("interface.music.163.com")
+    }
+
+    /** Get all cookies currently in memory */
+    fun getCookies(): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        cookieStore.values.forEach { list ->
+            list.forEach { cookie -> result[cookie.name] = cookie.value }
+        }
+        return result
+    }
+
+    fun logout() {
+        cookieStore.clear()
+        persistedCookies = emptyMap()
+    }
+
+    private fun seedCookieJarFromPersisted(host: String) {
+        val list = cookieStore.getOrPut(host) { mutableListOf() }
+        persistedCookies.forEach { (name, value) ->
+            val c = Cookie.Builder()
+                .name(name).value(value)
+                .domain(host).path("/")
+                .build()
+            list.removeAll { it.name == name }
+            list.add(c)
+        }
+    }
+
+    private fun getCookie(name: String): String? = cookieStore.values
+        .asSequence()
+        .flatMap { it.asSequence() }
+        .firstOrNull { it.name == name }
+        ?.value
+
+    private fun buildPersistedCookieHeader(): String? {
+        val map = persistedCookies.toMutableMap()
+        map.putIfAbsent("os", "pc")
+        map.putIfAbsent("appver", "8.10.35")
+        if (map.isEmpty()) return null
+        return map.entries.joinToString("; ") { (k, v) -> "$k=$v" }
+    }
+
+    // ─── Core Request Method ───────────────────────────────────────────
+
+    /** Visit music.163.com homepage to obtain __csrf cookie */
+    @Throws(IOException::class)
+    fun ensureWeapiSession() {
+        request(
+            url = "https://music.163.com/",
+            params = emptyMap(), mode = CryptoMode.API,
+            method = "GET", usePersistedCookies = true
+        )
+    }
+
+    @Throws(IOException::class)
+    fun request(
+        url: String,
+        params: Map<String, Any>,
+        mode: CryptoMode = CryptoMode.WEAPI,
+        method: String = "POST",
+        usePersistedCookies: Boolean = true
+    ): String {
+        val requestUrl = url.toHttpUrl()
+        Timber.d("$TAG: >>> $method $url [mode=$mode, persistedCookies=${usePersistedCookies}]")
+        Timber.d("$TAG: >>> params keys=${params.keys}")
+        Timber.d("$TAG: >>> hasLogin=${hasLogin()}, MUSIC_U=${persistedCookies["MUSIC_U"]?.take(20)}...")
+
+        val bodyParams: Map<String, String> = when (mode) {
+            CryptoMode.WEAPI -> NeteaseEncryption.weApiEncrypt(params)
+            CryptoMode.EAPI -> NeteaseEncryption.eApiEncrypt(requestUrl.encodedPath, params)
+            CryptoMode.LINUX -> NeteaseEncryption.linuxApiEncrypt(params)
+            CryptoMode.API -> params.mapValues { it.value.toString() }
+        }
+
+        var reqUrl = requestUrl
+        val builder = Request.Builder()
+            .header("Accept", "*/*")
+            .header("Accept-Language", "zh-CN,zh-Hans;q=0.9")
+            .header("Connection", "keep-alive")
+            .header("Referer", "https://music.163.com")
+            .header("Host", requestUrl.host)
+            .header("User-Agent", "Mozilla/5.0 (Linux; Android 14; PixelPlayer) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36")
+
+        if (usePersistedCookies) {
+            buildPersistedCookieHeader()?.let { builder.header("Cookie", it) }
+        }
+
+        // WEAPI requires csrf_token
+        if (mode == CryptoMode.WEAPI) {
+            val csrf = persistedCookies["__csrf"] ?: getCookie("__csrf") ?: ""
+            reqUrl = requestUrl.newBuilder()
+                .setQueryParameter("csrf_token", csrf)
+                .build()
+        }
+
+        builder.url(reqUrl)
+
+        when (method.uppercase(Locale.getDefault())) {
+            "POST" -> {
+                val formBodyBuilder = FormBody.Builder(StandardCharsets.UTF_8)
+                bodyParams.forEach { (k, v) -> formBodyBuilder.add(k, v) }
+                builder.post(formBodyBuilder.build())
+            }
+            "GET" -> {
+                val urlBuilder = reqUrl.newBuilder()
+                bodyParams.forEach { (k, v) -> urlBuilder.addQueryParameter(k, v) }
+                builder.url(urlBuilder.build())
+            }
+            else -> throw IllegalArgumentException("Unsupported method: $method")
+        }
+
+        try {
+            okHttpClient.newCall(builder.build()).execute().use { resp ->
+                val code = resp.code
+                Timber.d("$TAG: <<< HTTP $code for $url")
+                val bytes = resp.body?.bytes() ?: throw IOException("Empty response body")
+                val body = String(bytes, StandardCharsets.UTF_8)
+                Timber.d("$TAG: <<< body[${body.length}]: ${body.take(500)}")
+                return body
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "$TAG: !!! FAILED $method $url")
+            throw e
+        }
+    }
+
+    // ─── Convenience Methods ───────────────────────────────────────────
+
+    fun callWeApi(path: String, params: Map<String, Any>, usePersistedCookies: Boolean = true): String {
+        val p = if (path.startsWith("/")) path else "/$path"
+        return request("https://music.163.com/weapi$p", params, CryptoMode.WEAPI, "POST", usePersistedCookies)
+    }
+
+    fun callEApi(path: String, params: Map<String, Any>, usePersistedCookies: Boolean = true): String {
+        val p = if (path.startsWith("/")) path else "/$path"
+        return request("https://interface.music.163.com/eapi$p", params, CryptoMode.EAPI, "POST", usePersistedCookies)
+    }
+
+    // ─── Authentication ────────────────────────────────────────────────
+
+    fun sendCaptcha(phone: String, ctcode: Int = 86): String {
+        val params = mapOf("cellphone" to phone, "ctcode" to ctcode.toString())
+        return request("https://interface.music.163.com/weapi/sms/captcha/sent", params, CryptoMode.WEAPI, "POST", usePersistedCookies = false)
+    }
+
+    fun loginByCaptcha(phone: String, captcha: String, ctcode: Int = 86): String {
+        val params = mutableMapOf<String, Any>(
+            "phone" to phone,
+            "countrycode" to ctcode.toString(),
+            "remember" to "true",
+            "type" to "1",
+            "captcha" to captcha
+        )
+        return callEApi("/w/login/cellphone", params, usePersistedCookies = false)
+    }
+
+    // ─── User Info ─────────────────────────────────────────────────────
+
+    fun getCurrentUserAccount(): String {
+        return callWeApi("/w/nuser/account/get", emptyMap(), usePersistedCookies = true)
+    }
+
+    fun getCurrentUserId(): Long {
+        val raw = getCurrentUserAccount()
+        val root = JSONObject(raw)
+        if (root.optInt("code", -1) != 200) {
+            throw IllegalStateException("Failed to get user info: $raw")
+        }
+        return root.optJSONObject("profile")?.optLong("userId")
+            ?: throw IllegalStateException("userId not found")
+    }
+
+    // ─── Content ───────────────────────────────────────────────────────
+
+    fun getUserPlaylists(userId: Long, offset: Int = 0, limit: Int = 50): String {
+        val params = mutableMapOf<String, Any>(
+            "uid" to userId.toString(),
+            "offset" to offset.toString(),
+            "limit" to limit.toString(),
+            "includeVideo" to "true"
+        )
+        return request("https://music.163.com/weapi/user/playlist", params, CryptoMode.WEAPI, "POST", usePersistedCookies = true)
+    }
+
+    fun getPlaylistDetail(playlistId: Long): String {
+        val params = mutableMapOf<String, Any>(
+            "id" to playlistId.toString(),
+            "n" to "100000",
+            "s" to "8"
+        )
+        return request("https://music.163.com/api/v6/playlist/detail", params, CryptoMode.API, "POST", usePersistedCookies = true)
+    }
+
+    // ─── Song Data ─────────────────────────────────────────────────────
+
+    /**
+     * Get song download/streaming URL.
+     * Uses EAPI encryption (like NeriPlayer).
+     * Will retry with session warm-up if needed.
+     */
+    fun getSongDownloadUrl(songId: Long, level: String = "exhigh"): String {
+        fun call(): String {
+            val params = mutableMapOf<String, Any>(
+                "ids" to "[$songId]",
+                "level" to level,
+                "encodeType" to "flac"
+            )
+            return callEApi("/song/enhance/player/url/v1", params, usePersistedCookies = false)
+        }
+
+        var resp = call()
+        return try {
+            val code = JSONObject(resp).optInt("code", -1)
+            if (code == 301 && hasLogin()) {
+                try { ensureWeapiSession() } catch (_: Exception) {}
+                resp = call()
+            }
+            resp
+        } catch (_: Exception) {
+            resp
+        }
+    }
+
+    // ─── Search ────────────────────────────────────────────────────────
+
+    fun searchSongs(keyword: String, limit: Int = 30, offset: Int = 0): String {
+        val params = mutableMapOf<String, Any>(
+            "s" to keyword,
+            "type" to "1",
+            "limit" to limit.toString(),
+            "offset" to offset.toString(),
+            "total" to "true"
+        )
+        return request("https://music.163.com/weapi/cloudsearch/get/web", params, CryptoMode.WEAPI, "POST", usePersistedCookies = true)
+    }
+
+    // ─── Lyrics ────────────────────────────────────────────────────────
+
+    fun getLyrics(songId: Long): String {
+        val params = mutableMapOf<String, Any>(
+            "id" to songId.toString(),
+            "cp" to "false",
+            "lv" to 0,
+            "tv" to 0
+        )
+        return callEApi("/song/lyric/v1", params, usePersistedCookies = true)
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseEncryption.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseEncryption.kt
@@ -1,0 +1,187 @@
+package com.theveloper.pixelplay.data.network.netease
+
+import android.util.Base64
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.KeyFactory
+import java.security.MessageDigest
+import java.security.spec.X509EncodedKeySpec
+import java.util.Locale
+import java.util.Random
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Netease Cloud Music crypto utility.
+ * Supports all 4 encryption modes used by the API.
+ *
+ * Reference: NeriPlayer's NeteaseCrypto.kt (GPL-3.0)
+ */
+object NeteaseEncryption {
+
+    private const val BASE62 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    private const val PRESET_KEY = "0CoJUm6Qyw8W8jud"
+    private const val IV = "0102030405060708"
+    private const val LINUX_KEY = "rFgB&h#%2?^eDg:Q"
+    private const val EAPI_KEY = "e82ckenh8dichen8"
+    private const val EAPI_FORMAT = "%s-36cd479b6b5-%s-36cd479b6b5-%s"
+    private const val EAPI_SALT = "nobody%suse%smd5forencrypt"
+    private const val PUBLIC_KEY_PEM = """
+        -----BEGIN PUBLIC KEY-----
+        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDgtQn2JZ34ZC28NWYpAUd98iZ37BUrX/aKzmFb
+        t7clFSs6sXqHauqKWqdtLkF2KexO40H1YTX8z2lSgBBOAxLsvaklV8k4cBFK9snQXE9/DDaFt6Rr7iVZ
+        MldczhC0JNgTz+SHXT6CBHuX3e9SdB1Ua44oncaTWz7OBGLbCiK45wIDAQAB
+        -----END PUBLIC KEY-----
+    """
+
+    private fun randomKey(): String {
+        val random = Random()
+        return buildString { repeat(16) { append(BASE62[random.nextInt(BASE62.length)]) } }
+    }
+
+    // ─── AES ───────────────────────────────────────────────────────────
+
+    private fun aesEncrypt(text: String, key: String, iv: String, mode: String, format: String): String {
+        val secretKey = SecretKeySpec(key.toByteArray(StandardCharsets.UTF_8), "AES")
+        val cipher = when (mode.lowercase(Locale.getDefault())) {
+            "cbc" -> {
+                Cipher.getInstance("AES/CBC/PKCS5Padding").apply {
+                    init(Cipher.ENCRYPT_MODE, secretKey, IvParameterSpec(iv.toByteArray(StandardCharsets.UTF_8)))
+                }
+            }
+            "ecb" -> {
+                Cipher.getInstance("AES/ECB/PKCS5Padding").apply {
+                    init(Cipher.ENCRYPT_MODE, secretKey)
+                }
+            }
+            else -> throw IllegalArgumentException("Unknown AES mode: $mode")
+        }
+        val encrypted = cipher.doFinal(text.toByteArray(StandardCharsets.UTF_8))
+        return when (format.lowercase(Locale.getDefault())) {
+            "base64" -> Base64.encodeToString(encrypted, Base64.NO_WRAP)
+            "hex" -> encrypted.joinToString("") { "%02x".format(it) }
+            else -> throw IllegalArgumentException("Unknown format: $format")
+        }
+    }
+
+    // ─── RSA ───────────────────────────────────────────────────────────
+
+    private fun rsaEncrypt(text: String): String {
+        return try {
+            val cleanedKey = PUBLIC_KEY_PEM
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replace("\\s".toRegex(), "")
+            val keyBytes = java.util.Base64.getDecoder().decode(cleanedKey)
+            val keySpec = X509EncodedKeySpec(keyBytes)
+            val pubKey = KeyFactory.getInstance("RSA")
+                .generatePublic(keySpec) as java.security.interfaces.RSAPublicKey
+
+            val message = BigInteger(1, text.toByteArray(StandardCharsets.UTF_8))
+            val result = message.modPow(pubKey.publicExponent, pubKey.modulus)
+
+            var bytes = result.toByteArray()
+            if (bytes.isNotEmpty() && bytes[0] == 0.toByte()) {
+                bytes = bytes.copyOfRange(1, bytes.size)
+            }
+            bytes.joinToString("") { "%02x".format(it) }
+        } catch (e: Exception) {
+            throw RuntimeException("RSA encryption failed", e)
+        }
+    }
+
+    // ─── MD5 ───────────────────────────────────────────────────────────
+
+    fun md5Hex(data: String): String {
+        val md = MessageDigest.getInstance("MD5")
+        return md.digest(data.toByteArray(StandardCharsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    // ─── Public Encrypt Methods ────────────────────────────────────────
+
+    /**
+     * WeAPI encryption: double AES-CBC + RSA.
+     * Used for search, playlists, lyrics, etc.
+     */
+    fun weApiEncrypt(payload: Map<String, Any>): Map<String, String> {
+        val json = toJson(payload)
+        val secretKey = randomKey()
+        val enc1 = aesEncrypt(json, PRESET_KEY, IV, "cbc", "base64")
+        val params = aesEncrypt(enc1, secretKey, IV, "cbc", "base64")
+        val encSecKey = rsaEncrypt(secretKey.reversed())
+        return mapOf("params" to params, "encSecKey" to encSecKey)
+    }
+
+    /**
+     * EAPI encryption: AES-ECB with MD5 digest.
+     * Used for login, song URL resolution.
+     */
+    fun eApiEncrypt(url: String, payload: Map<String, Any>): Map<String, String> {
+        val data = toJson(payload)
+        val apiUrl = url.replace("/eapi", "/api")
+        val message = String.format(
+            EAPI_FORMAT,
+            apiUrl, data,
+            md5Hex(String.format(EAPI_SALT, apiUrl, data))
+        )
+        val cipher = aesEncrypt(message, EAPI_KEY, "", "ecb", "hex")
+            .uppercase(Locale.getDefault())
+        return mapOf("params" to cipher)
+    }
+
+    /**
+     * Linux API encryption: AES-ECB with fixed key.
+     */
+    fun linuxApiEncrypt(payload: Map<String, Any>): Map<String, String> {
+        return mapOf("eparams" to aesEncrypt(toJson(payload), LINUX_KEY, "", "ecb", "hex"))
+    }
+
+    // ─── JSON Utility ──────────────────────────────────────────────────
+
+    /** Simple JSON serializer (no external deps) matching NeriPlayer's approach */
+    private fun toJson(map: Map<String, Any>): String {
+        val sb = StringBuilder("{")
+        val it = map.entries.iterator()
+        while (it.hasNext()) {
+            val (k, v) = it.next()
+            sb.append("\"").append(k).append("\":")
+            sb.append(toJsonValue(v))
+            if (it.hasNext()) sb.append(",")
+        }
+        sb.append("}")
+        return sb.toString()
+    }
+
+    private fun toJsonValue(v: Any?): String = when (v) {
+        null -> "null"
+        is String -> jsonQuote(v)
+        is Number, is Boolean -> v.toString()
+        is Map<*, *> -> {
+            @Suppress("UNCHECKED_CAST")
+            toJson(v as Map<String, Any>)
+        }
+        is List<*> -> v.joinToString(prefix = "[", postfix = "]") { toJsonValue(it) }
+        else -> jsonQuote(v.toString())
+    }
+
+    private fun jsonQuote(s: String): String {
+        val sb = StringBuilder(s.length + 16)
+        sb.append('"')
+        for (ch in s) {
+            when (ch) {
+                '\\' -> sb.append("\\\\")
+                '"'  -> sb.append("\\\"")
+                '\b' -> sb.append("\\b")
+                '\u000C' -> sb.append("\\f")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> if (ch < ' ') sb.append(String.format("\\u%04x", ch.code)) else sb.append(ch)
+            }
+        }
+        sb.append('"')
+        return sb.toString()
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseModels.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseModels.kt
@@ -1,0 +1,154 @@
+package com.theveloper.pixelplay.data.network.netease
+
+import com.google.gson.annotations.SerializedName
+
+// ─── Login ─────────────────────────────────────────────────────────────
+
+data class NeteaseLoginResponse(
+    val code: Int,
+    val cookie: String?,
+    val token: String?,
+    val profile: NeteaseProfile?
+)
+
+data class NeteaseProfile(
+    val userId: Long,
+    val nickname: String,
+    val avatarUrl: String?,
+    val signature: String?
+)
+
+data class NeteaseLoginStatusResponse(
+    val data: NeteaseLoginStatusData?
+)
+
+data class NeteaseLoginStatusData(
+    val code: Int,
+    val profile: NeteaseProfile?
+)
+
+// ─── Playlists ─────────────────────────────────────────────────────────
+
+data class NeteaseUserPlaylistResponse(
+    val code: Int,
+    val playlist: List<NeteasePlaylist>?
+)
+
+data class NeteasePlaylist(
+    val id: Long,
+    val name: String,
+    val coverImgUrl: String?,
+    val trackCount: Int,
+    val userId: Long,
+    val description: String?,
+    @SerializedName("playCount") val playCount: Long?
+)
+
+// ─── Tracks / Songs ────────────────────────────────────────────────────
+
+data class NeteasePlaylistTrackResponse(
+    val code: Int,
+    val songs: List<NeteaseTrack>?
+)
+
+data class NeteaseTrack(
+    val id: Long,
+    val name: String,
+    @SerializedName("ar") val artists: List<NeteaseArtist>?,
+    @SerializedName("al") val album: NeteaseAlbum?,
+    @SerializedName("dt") val duration: Long, // milliseconds
+    @SerializedName("mv") val mvId: Long?,
+    @SerializedName("publishTime") val publishTime: Long?
+)
+
+data class NeteaseArtist(
+    val id: Long,
+    val name: String
+)
+
+data class NeteaseAlbum(
+    val id: Long,
+    val name: String,
+    val picUrl: String?
+)
+
+// ─── Song URL ──────────────────────────────────────────────────────────
+
+data class NeteaseSongUrlResponse(
+    val code: Int,
+    val data: List<NeteaseSongUrl>?
+)
+
+data class NeteaseSongUrl(
+    val id: Long,
+    val url: String?,
+    val br: Int?, // bitrate
+    val size: Long?,
+    val type: String?, // mp3, flac, etc.
+    @SerializedName("encodeType") val encodeType: String?,
+    val level: String? // standard, higher, exhigh, lossless, hires
+)
+
+// ─── Song Detail ───────────────────────────────────────────────────────
+
+data class NeteaseSongDetailResponse(
+    val code: Int,
+    val songs: List<NeteaseTrack>?
+)
+
+// ─── Search ────────────────────────────────────────────────────────────
+
+data class NeteaseSearchResponse(
+    val code: Int,
+    val result: NeteaseSearchResult?
+)
+
+data class NeteaseSearchResult(
+    val songCount: Int?,
+    val songs: List<NeteaseTrack>?
+)
+
+// ─── Lyrics ────────────────────────────────────────────────────────────
+
+data class NeteaseLyricResponse(
+    val code: Int,
+    val lrc: NeteaseLyricContent?,
+    val tlyric: NeteaseLyricContent? // translated lyrics
+)
+
+data class NeteaseLyricContent(
+    val version: Int?,
+    val lyric: String?
+)
+
+// ─── Like List ─────────────────────────────────────────────────────────
+
+data class NeteaseLikeListResponse(
+    val code: Int,
+    val ids: List<Long>?
+)
+
+// ─── Base Response ─────────────────────────────────────────────────────
+
+/** Generic response for simple operations (logout, SMS send, etc.) */
+data class NeteaseBaseResponse(
+    val code: Int,
+    val message: String? = null,
+    val data: Boolean? = null
+)
+
+// ─── Playlist Detail (v6 endpoint wraps tracks inside playlist) ───────
+
+data class NeteasePlaylistDetailResponse(
+    val code: Int,
+    val playlist: NeteasePlaylistDetail?
+)
+
+data class NeteasePlaylistDetail(
+    val id: Long,
+    val name: String,
+    val coverImgUrl: String?,
+    val trackCount: Int,
+    val tracks: List<NeteaseTrack>?
+)
+

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -641,7 +641,7 @@ class MusicRepositoryImpl @Inject constructor(
         val (allowedParentDirs, applyFilter) = computeAllowedDirs(allowedDirsFlow, blockedDirsFlow)
 
         // Map StorageFilter to filterMode
-        // 0: All, 1: Local only (telegram_file_id IS NULL), 2: Telegram only (telegram_file_id IS NOT NULL)
+        // 0: All, 1: Local device files only, 2: Cloud sources (Telegram/Netease)
         val filterMode = when (storageFilter) {
             com.theveloper.pixelplay.data.model.StorageFilter.ALL -> 0
             com.theveloper.pixelplay.data.model.StorageFilter.OFFLINE -> 1

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -23,6 +23,7 @@ import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.preferences.dataStore
 import com.theveloper.pixelplay.data.media.SongMetadataEditor
 import com.theveloper.pixelplay.data.network.deezer.DeezerApiService
+import com.theveloper.pixelplay.data.network.netease.NeteaseApiService
 import com.theveloper.pixelplay.data.network.lyrics.LrcLibApiService
 import com.theveloper.pixelplay.data.repository.ArtistImageRepository
 import com.theveloper.pixelplay.data.repository.LyricsRepository
@@ -57,6 +58,12 @@ object AppModule {
     @Provides
     fun provideApplication(@ApplicationContext app: Context): PixelPlayApplication {
         return app as PixelPlayApplication
+    }
+
+    @Singleton
+    @Provides
+    fun provideGson(): com.google.gson.Gson {
+        return com.google.gson.Gson()
     }
 
     @Singleton
@@ -108,7 +115,8 @@ object AppModule {
             PixelPlayDatabase.MIGRATION_16_17,
             PixelPlayDatabase.MIGRATION_17_18,
             PixelPlayDatabase.MIGRATION_18_19,
-            PixelPlayDatabase.MIGRATION_19_20
+            PixelPlayDatabase.MIGRATION_19_20,
+            PixelPlayDatabase.MIGRATION_20_21
         )
             .fallbackToDestructiveMigration(dropAllTables = true)
             .build()
@@ -215,6 +223,12 @@ object AppModule {
     @Provides
     fun provideTelegramDao(database: PixelPlayDatabase): com.theveloper.pixelplay.data.database.TelegramDao {
         return database.telegramDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideNeteaseDao(database: PixelPlayDatabase): com.theveloper.pixelplay.data.database.NeteaseDao {
+        return database.neteaseDao()
     }
 
     @Provides
@@ -449,3 +463,4 @@ object AppModule {
         return ArtistImageRepository(deezerApiService, musicDao)
     }
 }
+

--- a/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
@@ -22,3 +22,11 @@ annotation class FastOkHttpClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class BackupGson
+
+/**
+ * Qualifier for Netease Cloud Music Retrofit instance.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NeteaseRetrofit
+

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
@@ -1,0 +1,188 @@
+package com.theveloper.pixelplay.presentation.components
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Cloud
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.data.netease.NeteaseRepository
+import com.theveloper.pixelplay.presentation.netease.auth.NeteaseLoginActivity
+import com.theveloper.pixelplay.presentation.telegram.auth.TelegramLoginActivity
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+/**
+ * Bottom sheet that lets the user choose between streaming providers
+ * (Telegram, Netease Cloud Music).
+ *
+ * For Netease: if already logged in, navigates to dashboard.
+ * If not logged in, launches WebView login activity.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StreamingProviderSheet(
+    onDismissRequest: () -> Unit,
+    isNeteaseLoggedIn: Boolean = false,
+    onNavigateToNeteaseDashboard: () -> Unit = {},
+    sheetState: SheetState = rememberModalBottomSheetState()
+) {
+    val context = LocalContext.current
+
+    val cardShape = AbsoluteSmoothCornerShape(
+        cornerRadiusTR = 20.dp, cornerRadiusTL = 20.dp,
+        cornerRadiusBR = 20.dp, cornerRadiusBL = 20.dp,
+        smoothnessAsPercentTR = 60, smoothnessAsPercentTL = 60,
+        smoothnessAsPercentBR = 60, smoothnessAsPercentBL = 60
+    )
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Cloud Streaming",
+                style = MaterialTheme.typography.titleLarge,
+                fontFamily = GoogleSansRounded,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = "Stream music from your cloud accounts",
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = GoogleSansRounded,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // Telegram Provider
+            ProviderCard(
+                icon = Icons.Rounded.Cloud,
+                title = "Telegram",
+                subtitle = "Stream from channels & chats",
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                iconColor = MaterialTheme.colorScheme.primary,
+                shape = cardShape,
+                onClick = {
+                    context.startActivity(Intent(context, TelegramLoginActivity::class.java))
+                    onDismissRequest()
+                }
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // Netease Cloud Music Provider
+            ProviderCard(
+                icon = Icons.Rounded.MusicNote,
+                title = "Netease Cloud Music",
+                subtitle = if (isNeteaseLoggedIn)
+                    "✓ Connected – Open dashboard"
+                else
+                    "网易云音乐 – Sign in to stream",
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                iconColor = MaterialTheme.colorScheme.tertiary,
+                shape = cardShape,
+                onClick = {
+                    if (isNeteaseLoggedIn) {
+                        onNavigateToNeteaseDashboard()
+                    } else {
+                        context.startActivity(Intent(context, NeteaseLoginActivity::class.java))
+                    }
+                    onDismissRequest()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProviderCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    containerColor: androidx.compose.ui.graphics.Color,
+    contentColor: androidx.compose.ui.graphics.Color,
+    iconColor: androidx.compose.ui.graphics.Color,
+    shape: AbsoluteSmoothCornerShape,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = containerColor
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(iconColor.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = iconColor
+                )
+            }
+
+            Spacer(Modifier.width(16.dp))
+
+            Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = GoogleSansRounded,
+                    fontWeight = FontWeight.Bold,
+                    color = contentColor
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = GoogleSansRounded,
+                    color = contentColor.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -487,6 +487,19 @@ fun AppNavigation(
                     )
                 }
             }
+            composable(
+                Screen.NeteaseDashboard.route,
+                enterTransition = { enterTransition() },
+                exitTransition = { exitTransition() },
+                popEnterTransition = { popEnterTransition() },
+                popExitTransition = { popExitTransition() },
+            ) {
+                ScreenWrapper(navController = navController) {
+                    com.theveloper.pixelplay.presentation.netease.dashboard.NeteaseDashboardScreen(
+                        onBack = { navController.popBackStack() }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
@@ -47,5 +47,6 @@ sealed class Screen(val route: String) {
     object DelimiterConfig : Screen("delimiter_config")
     object Equalizer : Screen("equalizer")
     object DeviceCapabilities : Screen("device_capabilities")
+    object NeteaseDashboard : Screen("netease_dashboard")
 
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginActivity.kt
@@ -1,0 +1,252 @@
+package com.theveloper.pixelplay.presentation.netease.auth
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import com.theveloper.pixelplay.ui.theme.PixelPlayTheme
+import dagger.hilt.android.AndroidEntryPoint
+import org.json.JSONObject
+
+/**
+ * WebView-based login for Netease Cloud Music.
+ * User logs in at music.163.com in the WebView, then taps "Done" to
+ * capture the MUSIC_U session cookie. Cookies are saved directly via
+ * the ViewModel/Repository — no activity result needed.
+ *
+ * Same approach as NeriPlayer.
+ */
+@AndroidEntryPoint
+class NeteaseLoginActivity : ComponentActivity() {
+
+    companion object {
+        const val TARGET_URL = "https://music.163.com/"
+        const val DESKTOP_UA =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+                    "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                    "Chrome/124.0.0.0 Safari/537.36"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            PixelPlayTheme {
+                NeteaseWebLoginScreen(onClose = { finish() })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NeteaseWebLoginScreen(
+    viewModel: NeteaseLoginViewModel = hiltViewModel(),
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+    var webView by remember { mutableStateOf<WebView?>(null) }
+    val loginState by viewModel.state.collectAsState()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Handle login state changes
+    LaunchedEffect(loginState) {
+        when (val state = loginState) {
+            is NeteaseLoginState.Success -> {
+                Toast.makeText(context, "Welcome, ${state.nickname}!", Toast.LENGTH_SHORT).show()
+                onClose()
+            }
+            is NeteaseLoginState.Error -> {
+                snackbarHostState.showSnackbar(state.message)
+            }
+            else -> {}
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Rounded.MusicNote,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            "Login to Netease",
+                            fontFamily = GoogleSansRounded,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        if (webView?.canGoBack() == true) {
+                            webView?.goBack()
+                        } else {
+                            onClose()
+                        }
+                    }) {
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    // Refresh button
+                    IconButton(onClick = { webView?.reload() }) {
+                        Icon(Icons.Rounded.Refresh, contentDescription = "Refresh")
+                    }
+                    // Done button: read cookies and process
+                    FilledTonalButton(
+                        onClick = {
+                            readAndProcessCookies(
+                                onSuccess = { cookieJson -> viewModel.processCookies(cookieJson) },
+                                onError = { msg ->
+                                    Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                                }
+                            )
+                        },
+                        enabled = loginState !is NeteaseLoginState.Loading,
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor = MaterialTheme.colorScheme.tertiary,
+                            contentColor = MaterialTheme.colorScheme.onTertiary
+                        )
+                    ) {
+                        if (loginState is NeteaseLoginState.Loading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onTertiary
+                            )
+                        } else {
+                            Icon(
+                                Icons.Rounded.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            if (loginState is NeteaseLoginState.Loading) "Saving…" else "Done",
+                            fontFamily = GoogleSansRounded,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        NeteaseWebView(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            onWebViewCreated = { webView = it }
+        )
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun NeteaseWebView(
+    modifier: Modifier = Modifier,
+    onWebViewCreated: (WebView) -> Unit
+) {
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            WebView(context).apply {
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                    userAgentString = NeteaseLoginActivity.DESKTOP_UA
+                    useWideViewPort = true
+                    loadWithOverviewMode = true
+                    setSupportZoom(true)
+                    builtInZoomControls = true
+                    displayZoomControls = false
+                }
+                webChromeClient = WebChromeClient()
+                webViewClient = WebViewClient()
+                loadUrl(NeteaseLoginActivity.TARGET_URL)
+                onWebViewCreated(this)
+            }
+        }
+    )
+}
+
+/**
+ * Read cookies from the WebView's CookieManager and pass them as JSON.
+ */
+private fun readAndProcessCookies(
+    onSuccess: (String) -> Unit,
+    onError: (String) -> Unit
+) {
+    try {
+        val cm = CookieManager.getInstance()
+        val main = cm.getCookie("https://music.163.com") ?: ""
+        val api = cm.getCookie("https://interface.music.163.com") ?: ""
+        val merged = listOf(main, api).filter { it.isNotBlank() }.joinToString("; ")
+
+        if (merged.isBlank()) {
+            onError("No cookies found. Please log in first.")
+            return
+        }
+
+        val map = cookieStringToMap(merged)
+        if (!map.containsKey("os")) map["os"] = "pc"
+        if (!map.containsKey("appver")) map["appver"] = "8.10.35"
+
+        if (!map.containsKey("MUSIC_U")) {
+            onError("Login not detected yet. Complete login and try again.")
+            return
+        }
+
+        val json = JSONObject(map as Map<*, *>).toString()
+        onSuccess(json)
+    } catch (e: Throwable) {
+        onError("Failed: ${e.message}")
+    }
+}
+
+private fun cookieStringToMap(raw: String): MutableMap<String, String> {
+    val map = linkedMapOf<String, String>()
+    raw.split(';')
+        .map { it.trim() }
+        .filter { it.isNotBlank() && it.contains('=') }
+        .forEach { part ->
+            val idx = part.indexOf('=')
+            val key = part.substring(0, idx).trim()
+            val value = part.substring(idx + 1).trim()
+            if (key.isNotEmpty()) map[key] = value
+        }
+    return map
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginViewModel.kt
@@ -1,0 +1,50 @@
+package com.theveloper.pixelplay.presentation.netease.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.theveloper.pixelplay.data.netease.NeteaseRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Simple ViewModel for WebView-based Netease login.
+ * The WebView handles the actual login, this just processes the cookies result.
+ */
+sealed class NeteaseLoginState {
+    object Idle : NeteaseLoginState()
+    object Loading : NeteaseLoginState()
+    data class Success(val nickname: String) : NeteaseLoginState()
+    data class Error(val message: String) : NeteaseLoginState()
+}
+
+@HiltViewModel
+class NeteaseLoginViewModel @Inject constructor(
+    private val repository: NeteaseRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<NeteaseLoginState>(NeteaseLoginState.Idle)
+    val state: StateFlow<NeteaseLoginState> = _state.asStateFlow()
+
+    /**
+     * Process cookies captured from the WebView login.
+     * Saves them and fetches user info.
+     */
+    fun processCookies(cookieJson: String) {
+        _state.value = NeteaseLoginState.Loading
+        viewModelScope.launch {
+            val result = repository.loginWithCookies(cookieJson)
+            result.fold(
+                onSuccess = { nickname ->
+                    _state.value = NeteaseLoginState.Success(nickname)
+                },
+                onFailure = { error ->
+                    _state.value = NeteaseLoginState.Error(error.message ?: "Login failed")
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardScreen.kt
@@ -1,0 +1,381 @@
+package com.theveloper.pixelplay.presentation.netease.dashboard
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.Logout
+import androidx.compose.material.icons.rounded.CloudSync
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Sync
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.theveloper.pixelplay.data.database.NeteasePlaylistEntity
+import com.theveloper.pixelplay.presentation.components.SmartImage
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun NeteaseDashboardScreen(
+    viewModel: NeteaseDashboardViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val playlists by viewModel.playlists.collectAsState()
+    val isSyncing by viewModel.isSyncing.collectAsState()
+    val syncMessage by viewModel.syncMessage.collectAsState()
+
+    val cardShape = AbsoluteSmoothCornerShape(
+        cornerRadiusTR = 20.dp, cornerRadiusTL = 20.dp,
+        cornerRadiusBR = 20.dp, cornerRadiusBL = 20.dp,
+        smoothnessAsPercentTR = 60, smoothnessAsPercentTL = 60,
+        smoothnessAsPercentBR = 60, smoothnessAsPercentBL = 60
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Netease Cloud Music",
+                        fontFamily = GoogleSansRounded,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    // Sync button
+                    IconButton(
+                        onClick = { viewModel.syncAllPlaylistsAndSongs() },
+                        enabled = !isSyncing
+                    ) {
+                        Icon(
+                            Icons.Rounded.CloudSync,
+                            contentDescription = "Sync All Playlists",
+                            tint = MaterialTheme.colorScheme.tertiary
+                        )
+                    }
+                    // Logout button
+                    IconButton(onClick = {
+                        viewModel.logout()
+                        onBack()
+                    }) {
+                        Icon(
+                            Icons.AutoMirrored.Rounded.Logout,
+                            contentDescription = "Logout"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // Sync status banner
+            AnimatedVisibility(
+                visible = syncMessage != null,
+                enter = slideInVertically(
+                    animationSpec = spring(stiffness = Spring.StiffnessMedium)
+                ) + fadeIn(),
+                exit = fadeOut()
+            ) {
+                syncMessage?.let { message ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        shape = cardShape,
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (message.contains("failed"))
+                                MaterialTheme.colorScheme.errorContainer
+                            else
+                                MaterialTheme.colorScheme.tertiaryContainer
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (isSyncing) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.tertiary
+                                )
+                                Spacer(Modifier.width(12.dp))
+                            }
+                            Text(
+                                text = message,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = GoogleSansRounded
+                            )
+                        }
+                    }
+                }
+            }
+
+            // User info header
+            viewModel.userNickname?.let { nickname ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    shape = cardShape,
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.tertiary),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (viewModel.userAvatar != null) {
+                                SmartImage(
+                                    model = viewModel.userAvatar,
+                                    contentDescription = nickname,
+                                    contentScale = ContentScale.Crop,
+                                    shape = CircleShape,
+                                    modifier = Modifier.fillMaxSize()
+                                )
+                            } else {
+                                Text(
+                                    text = nickname.firstOrNull()?.toString() ?: "N",
+                                    style = MaterialTheme.typography.titleLarge,
+                                    color = MaterialTheme.colorScheme.onTertiary,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                        Spacer(Modifier.width(16.dp))
+                        Column {
+                            Text(
+                                text = nickname,
+                                style = MaterialTheme.typography.titleMedium,
+                                fontFamily = GoogleSansRounded,
+                                fontWeight = FontWeight.Bold
+                            )
+                            Text(
+                                text = "${playlists.size} playlists synced",
+                                style = MaterialTheme.typography.bodySmall,
+                                fontFamily = GoogleSansRounded,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Playlists header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Playlists",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = GoogleSansRounded,
+                    fontWeight = FontWeight.Bold
+                )
+                if (playlists.isEmpty()) {
+                    TextButton(onClick = { viewModel.syncAllPlaylistsAndSongs() }) {
+                        Icon(
+                            Icons.Rounded.Sync,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text("Sync", fontFamily = GoogleSansRounded)
+                    }
+                }
+            }
+
+            // Playlist list
+            if (playlists.isEmpty() && !isSyncing) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            Icons.Rounded.MusicNote,
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                        )
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            text = "No playlists synced yet",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontFamily = GoogleSansRounded,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = "Tap sync to fetch your playlists",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontFamily = GoogleSansRounded,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(
+                        items = playlists,
+                        key = { it.id }
+                    ) { playlist ->
+                        PlaylistCard(
+                            playlist = playlist,
+                            onSyncClick = { viewModel.syncPlaylistSongs(playlist.id) },
+                            onDeleteClick = { viewModel.deletePlaylist(playlist.id) },
+                            onClick = { viewModel.loadPlaylistSongs(playlist.id) },
+                            cardShape = cardShape,
+                            isSyncing = isSyncing
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaylistCard(
+    playlist: NeteasePlaylistEntity,
+    onSyncClick: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onClick: () -> Unit,
+    cardShape: AbsoluteSmoothCornerShape,
+    isSyncing: Boolean
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = cardShape,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(12.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Playlist cover
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(MaterialTheme.colorScheme.tertiaryContainer),
+                contentAlignment = Alignment.Center
+            ) {
+                if (playlist.coverUrl != null) {
+                    SmartImage(
+                        model = playlist.coverUrl,
+                        contentDescription = playlist.name,
+                        contentScale = ContentScale.Crop,
+                        shape = RoundedCornerShape(12.dp),
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    Icon(
+                        Icons.Rounded.MusicNote,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                }
+            }
+
+            Spacer(Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = playlist.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontFamily = GoogleSansRounded,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = "${playlist.songCount} songs",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = GoogleSansRounded,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            // Sync button
+            IconButton(
+                onClick = onSyncClick,
+                enabled = !isSyncing
+            ) {
+                Icon(
+                    Icons.Rounded.Sync,
+                    contentDescription = "Sync",
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+
+            // Delete button
+            IconButton(onClick = onDeleteClick) {
+                Icon(
+                    Icons.Rounded.Delete,
+                    contentDescription = "Remove",
+                    tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardViewModel.kt
@@ -1,0 +1,112 @@
+package com.theveloper.pixelplay.presentation.netease.dashboard
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.theveloper.pixelplay.data.database.NeteasePlaylistEntity
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.netease.NeteaseRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NeteaseDashboardViewModel @Inject constructor(
+    private val repository: NeteaseRepository
+) : ViewModel() {
+
+    val playlists: StateFlow<List<NeteasePlaylistEntity>> = repository.getPlaylists()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val _isSyncing = MutableStateFlow(false)
+    val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
+
+    private val _syncMessage = MutableStateFlow<String?>(null)
+    val syncMessage: StateFlow<String?> = _syncMessage.asStateFlow()
+
+    private val _selectedPlaylistSongs = MutableStateFlow<List<Song>>(emptyList())
+    val selectedPlaylistSongs: StateFlow<List<Song>> = _selectedPlaylistSongs.asStateFlow()
+
+    val userNickname: String? get() = repository.userNickname
+    val userAvatar: String? get() = repository.userAvatar
+    
+    val isLoggedIn: StateFlow<Boolean> = repository.isLoggedInFlow
+
+    init {
+        // Auto-sync playlists when the dashboard opens
+        syncPlaylists()
+    }
+
+    fun syncAllPlaylistsAndSongs() {
+        viewModelScope.launch {
+            _isSyncing.value = true
+            _syncMessage.value = "Syncing all playlists and songs..."
+            val result = repository.syncAllPlaylistsAndSongs()
+            result.fold(
+                onSuccess = { summary ->
+                    _syncMessage.value = if (summary.failedPlaylistCount == 0) {
+                        "Synced ${summary.playlistCount} playlists, ${summary.syncedSongCount} songs"
+                    } else {
+                        "Synced ${summary.playlistCount} playlists, ${summary.syncedSongCount} songs (${summary.failedPlaylistCount} failed)"
+                    }
+                },
+                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
+            )
+            _isSyncing.value = false
+        }
+    }
+
+    fun syncPlaylists() {
+        viewModelScope.launch {
+            _isSyncing.value = true
+            _syncMessage.value = "Syncing playlists..."
+            val result = repository.syncUserPlaylists()
+            result.fold(
+                onSuccess = { _syncMessage.value = "Synced ${it.size} playlists" },
+                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
+            )
+            _isSyncing.value = false
+        }
+    }
+
+    fun syncPlaylistSongs(playlistId: Long) {
+        viewModelScope.launch {
+            _isSyncing.value = true
+            _syncMessage.value = "Syncing songs..."
+            val result = repository.syncPlaylistSongs(playlistId)
+            result.fold(
+                onSuccess = { _syncMessage.value = "Synced $it songs" },
+                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
+            )
+            _isSyncing.value = false
+        }
+    }
+
+    fun loadPlaylistSongs(playlistId: Long) {
+        viewModelScope.launch {
+            repository.getPlaylistSongs(playlistId).collect { songs ->
+                _selectedPlaylistSongs.value = songs
+            }
+        }
+    }
+
+    fun deletePlaylist(playlistId: Long) {
+        viewModelScope.launch {
+            repository.deletePlaylist(playlistId)
+        }
+    }
+
+    fun clearSyncMessage() {
+        _syncMessage.value = null
+    }
+
+    fun logout() {
+        viewModelScope.launch {
+            repository.logout()
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -64,6 +64,7 @@ import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.presentation.components.AlbumArtCollage
 import com.theveloper.pixelplay.presentation.components.BetaInfoBottomSheet
 import com.theveloper.pixelplay.presentation.components.ChangelogBottomSheet
+import com.theveloper.pixelplay.presentation.netease.dashboard.NeteaseDashboardViewModel
 import com.theveloper.pixelplay.presentation.components.DailyMixSection
 import com.theveloper.pixelplay.presentation.components.HomeGradientTopBar
 import com.theveloper.pixelplay.presentation.components.HomeOptionsBottomSheet
@@ -76,6 +77,7 @@ import com.theveloper.pixelplay.presentation.components.StatsOverviewCard
 import com.theveloper.pixelplay.presentation.model.mapRecentlyPlayedSongs
 import com.theveloper.pixelplay.presentation.components.subcomps.PlayingEqIcon
 import com.theveloper.pixelplay.presentation.navigation.Screen
+import com.theveloper.pixelplay.presentation.components.StreamingProviderSheet
 import com.theveloper.pixelplay.presentation.telegram.auth.TelegramLoginActivity
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
 import com.theveloper.pixelplay.presentation.viewmodel.SettingsViewModel
@@ -96,6 +98,7 @@ fun HomeScreen(
     paddingValuesParent: PaddingValues,
     playerViewModel: PlayerViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel(),
+    neteaseViewModel: NeteaseDashboardViewModel = hiltViewModel(),
     onOpenSidebar: () -> Unit
 ) {
     val context = LocalContext.current
@@ -153,6 +156,7 @@ fun HomeScreen(
     var showOptionsBottomSheet by remember { mutableStateOf(false) }
     var showChangelogBottomSheet by remember { mutableStateOf(false) }
     var showBetaInfoBottomSheet by remember { mutableStateOf(false) }
+    var showStreamingProviderSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
     val betaSheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
@@ -180,8 +184,7 @@ fun HomeScreen(
                         showBetaInfoBottomSheet = true
                     },
                     onTelegramClick = {
-                         val intent = Intent(context, TelegramLoginActivity::class.java)
-                         context.startActivity(intent)
+                         showStreamingProviderSheet = true
                     },
                     onMenuClick = {
                         // onOpenSidebar() // Disabled
@@ -329,6 +332,16 @@ fun HomeScreen(
         ) {
             BetaInfoBottomSheet()
         }
+    }
+    if (showStreamingProviderSheet) {
+        val isNeteaseLoggedIn by neteaseViewModel.isLoggedIn.collectAsState()
+        StreamingProviderSheet(
+            onDismissRequest = { showStreamingProviderSheet = false },
+            isNeteaseLoggedIn = isNeteaseLoggedIn,
+            onNavigateToNeteaseDashboard = {
+                navController.navigate(Screen.NeteaseDashboard.route)
+            }
+        )
     }
 }
 

--- a/app/src/test/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImplTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImplTest.kt
@@ -73,11 +73,11 @@ class MusicRepositoryImplTest {
             if (allowedParams.isEmpty()) flowOf(emptyList()) else flowOf(emptyList()) // Placeholder, can be improved if needed
         }
         every { mockMusicDao.getSongs(any(), eq(false)) } returns flowOf(emptyList()) // Placeholder
-        every { mockMusicDao.getAlbums(any(), eq(true)) } answers {
+        every { mockMusicDao.getAlbums(any(), eq(true), any()) } answers {
             val allowedParams = firstArg<List<String>>()
             if (allowedParams.isEmpty()) flowOf(emptyList()) else flowOf(emptyList())
         }
-        every { mockMusicDao.getAlbums(any(), eq(false)) } returns flowOf(emptyList())
+        every { mockMusicDao.getAlbums(any(), eq(false), any()) } returns flowOf(emptyList())
         
         every { mockMusicDao.getArtists(any(), eq(true)) } answers {
              val allowedParams = firstArg<List<String>>()
@@ -193,7 +193,7 @@ class MusicRepositoryImplTest {
                 else -> album
             }
         }.filter { it.id == 201L || it.id == 203L }
-        every { mockMusicDao.getAlbums(any(), eq(true)) } returns flowOf(expectedAlbums)
+        every { mockMusicDao.getAlbums(any(), eq(true), any()) } returns flowOf(expectedAlbums)
 
         every { mockUserPreferencesRepository.allowedDirectoriesFlow } returns flowOf(allowedDirs)
         every { mockUserPreferencesRepository.initialSetupDoneFlow } returns flowOf(true)


### PR DESCRIPTION
- add full Netease bulk sync flow (playlists + songs) from dashboard sync action
- repopulate Netease cloud songs into unified library after SyncWorker runs (including rebuild)
- include `netease://` sources in Library ONLINE/OFFLINE filtering logic
- prevent MediaStore deletion phase from removing cloud-backed songs
- fix Netease song overwrite across playlists by using composite song keys
- prune stale Netease playlists/songs that were removed remotely
- update unit tests for changed method signatures and newly observed flows
- keep `:app:compileDebugKotlin` and `:app:testDebugUnitTest` green