### PR TITLE
fix(netease): resolve unified netease:// playback URIs via NeteaseStreamProxy

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
@@ -25,6 +25,9 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
 
     @Inject
     lateinit var telegramStreamProxy: com.theveloper.pixelplay.data.telegram.TelegramStreamProxy
+
+    @Inject
+    lateinit var neteaseStreamProxy: com.theveloper.pixelplay.data.netease.NeteaseStreamProxy
     
     @Inject
     lateinit var telegramCacheManager: com.theveloper.pixelplay.data.telegram.TelegramCacheManager
@@ -64,6 +67,7 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
         }
         
         telegramStreamProxy.start()
+        neteaseStreamProxy.start()
         
         // Trigger robust cache cleanup on startup to remove orphaned files from previous sessions
         kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -38,6 +38,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.resume
 
 import com.theveloper.pixelplay.data.telegram.TelegramRepository
+import com.theveloper.pixelplay.data.netease.NeteaseStreamProxy
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DataSpec
@@ -58,6 +59,7 @@ class DualPlayerEngine @Inject constructor(
     @ApplicationContext private val context: Context,
     private val telegramRepository: TelegramRepository,
     private val telegramStreamProxy: com.theveloper.pixelplay.data.telegram.TelegramStreamProxy,
+    private val neteaseStreamProxy: NeteaseStreamProxy,
     private val telegramCacheManager: com.theveloper.pixelplay.data.telegram.TelegramCacheManager,
     private val connectivityStateHolder: com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
 ) {
@@ -369,6 +371,16 @@ class DualPlayerEngine @Inject constructor(
                          if (proxyUrl.isNotEmpty()) {
                              return dataSpec.buildUpon().setUri(android.net.Uri.parse(proxyUrl)).build()
                          }
+                     }
+                 } else if (dataSpec.uri.scheme == "netease") {
+                     val neteaseSongId = dataSpec.uri.host?.toLongOrNull()
+                     if (neteaseSongId != null) {
+                         val proxyUrl = neteaseStreamProxy.getProxyUrl(neteaseSongId)
+                         if (proxyUrl.isNotEmpty()) {
+                             Timber.tag("DualPlayerEngine").d("Resolving Netease URI for songId: $neteaseSongId")
+                             return dataSpec.buildUpon().setUri(android.net.Uri.parse(proxyUrl)).build()
+                         }
+                         Timber.tag("DualPlayerEngine").w("Netease proxy not ready for songId=$neteaseSongId; playback may fail")
                      }
                  }
                  return dataSpec


### PR DESCRIPTION
### Motivation
- Netease tracks synced into the unified library were stored with `netease://{id}` URIs but the playback resolver only handled `telegram://` URIs, causing discoverable but unplayable tracks at runtime. 
- The change aims to ensure `netease://` items are rewritten to a local HTTP proxy URL so ExoPlayer can stream them. 
- The proxy must be available at app startup so resolution succeeds when playback begins.

### Description
- Inject `NeteaseStreamProxy` into `DualPlayerEngine` and add `import`/constructor wiring to make the proxy available to the resolver. 
- Extend `ResolvingDataSource.Resolver.resolveDataSpec` to handle `netease` scheme URIs by rewriting `netease://{songId}` to the local proxy URL returned by `NeteaseStreamProxy.getProxyUrl` and log when the proxy is not ready. 
- Start `NeteaseStreamProxy` during application startup in `PixelPlayApplication.onCreate()` so the proxy is spun up alongside the Telegram proxy.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin` to validate the Kotlin compile, but the Gradle wrapper download failed in this environment with a proxy error (`HTTP/1.1 403 Forbidden`), so compilation could not be completed here. 
- No additional automated tests were run in this environment due to network limitations preventing Gradle operations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69937d1fc8ac8324b7ed6db89a7fc385)