### PR TITLE
feat(telegram): refine dashboard empty state and FAB visibility

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
@@ -201,8 +201,10 @@ fun TelegramDashboardScreen(
             if (isEmpty) {
                 ExpressiveEmptyState(
                     modifier = Modifier
+                        .align(Alignment.TopCenter)
                         .fillMaxSize()
-                        .padding(top = currentTopBarHeightDp + 8.dp),
+                        //.padding(top = currentTopBarHeightDp + 8.dp)
+                    ,
                     onAdd = onAddChannel
                 )
             } else {
@@ -252,27 +254,30 @@ fun TelegramDashboardScreen(
             label = "telegramFabScale"
         )
 
-        MediumExtendedFloatingActionButton(
-            onClick = onAddChannel,
-            text = {
-                Text(
-                    "Add Channel",
-                    fontFamily = GoogleSansRounded,
-                    fontWeight = FontWeight.SemiBold
-                )
-            },
-            icon = { Icon(Icons.Rounded.Add, contentDescription = null) },
-            shape = CircleShape,
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = 16.dp, bottom = fabBottomPadding)
-                .graphicsLayer {
-                    scaleX = fabScale
-                    scaleY = fabScale
+        if(channels.isNotEmpty()){
+            MediumExtendedFloatingActionButton(
+                onClick = onAddChannel,
+                text = {
+                    Text(
+                        "Add Channel",
+                        fontFamily = GoogleSansRounded,
+                        fontWeight = FontWeight.SemiBold
+                    )
                 },
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-        )
+                expanded = channels.isNotEmpty(),
+                icon = { Icon(Icons.Rounded.Add, contentDescription = null) },
+                shape = CircleShape,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 16.dp, bottom = fabBottomPadding)
+                    .graphicsLayer {
+                        scaleX = fabScale
+                        scaleY = fabScale
+                    },
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
 
         SnackbarHost(
             hostState = snackbarHostState,
@@ -713,7 +718,7 @@ private fun ExpressiveEmptyState(
                 imageVector = Icons.Rounded.CloudSync,
                 contentDescription = null,
                 modifier = Modifier.size(56.dp),
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
             )
         }
 


### PR DESCRIPTION
- **UI**:
    - Update `ExpressiveEmptyState` alignment and remove hardcoded top padding in `TelegramDashboardScreen`.
    - Conditionally hide the "Add Channel" Floating Action Button when the channel list is empty to prevent UI redundancy with the empty state action.
    - Set `expanded` state for `MediumExtendedFloatingActionButton` based on channel availability.
    - Adjust icon tint in `ExpressiveEmptyState` to use `onPrimaryContainer` for better contrast.