### PR TITLE
feat: implement customizable collage patterns for the Home screen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/CollagePattern.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/CollagePattern.kt
@@ -1,0 +1,20 @@
+package com.theveloper.pixelplay.data.preferences
+
+enum class CollagePattern(
+    val storageKey: String,
+    val label: String
+) {
+    COSMIC_SWIRL("cosmic_swirl", "Cosmic Swirl"),
+    HONEYCOMB_GROOVE("honeycomb_groove", "Honeycomb Groove"),
+    VINYL_STACK("vinyl_stack", "Vinyl Stack"),
+    PIXEL_MOSAIC("pixel_mosaic", "Pixel Mosaic"),
+    STARDUST_SCATTER("stardust_scatter", "Stardust Scatter");
+
+    companion object {
+        val default: CollagePattern = COSMIC_SWIRL
+
+        fun fromStorageKey(value: String?): CollagePattern {
+            return entries.firstOrNull { it.storageKey == value } ?: default
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -197,6 +197,10 @@ constructor(
         // Album View Preference
         val IS_ALBUMS_LIST_VIEW = booleanPreferencesKey("is_albums_list_view")
 
+        // Collage Pattern
+        val COLLAGE_PATTERN = stringPreferencesKey("collage_pattern")
+        val COLLAGE_AUTO_ROTATE = booleanPreferencesKey("collage_auto_rotate")
+
         // Quick Settings / Last Playlist
         val LAST_PLAYLIST_ID = stringPreferencesKey("last_playlist_id")
         val LAST_PLAYLIST_NAME = stringPreferencesKey("last_playlist_name")
@@ -1930,6 +1934,30 @@ constructor(
                     }
                 }
             }
+        }
+    }
+
+    // --- Collage Pattern ---
+
+    val collagePatternFlow: Flow<CollagePattern> =
+        dataStore.data.map { preferences ->
+            CollagePattern.fromStorageKey(preferences[PreferencesKeys.COLLAGE_PATTERN])
+        }
+
+    suspend fun setCollagePattern(pattern: CollagePattern) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.COLLAGE_PATTERN] = pattern.storageKey
+        }
+    }
+
+    val collageAutoRotateFlow: Flow<Boolean> =
+        dataStore.data.map { preferences ->
+            preferences[PreferencesKeys.COLLAGE_AUTO_ROTATE] ?: false
+        }
+
+    suspend fun setCollageAutoRotate(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.COLLAGE_AUTO_ROTATE] = enabled
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -26,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import coil.request.ImageRequest
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Song
-import com.theveloper.pixelplay.utils.shapes.RoundedStarShape
+import com.theveloper.pixelplay.data.preferences.CollagePattern
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
@@ -48,6 +46,7 @@ fun AlbumArtCollage(
     modifier: Modifier = Modifier,
     height: Dp = 400.dp,
     padding: Dp = 0.dp,
+    pattern: CollagePattern = CollagePattern.default,
     onSongClick: (Song) -> Unit,
 ) {
     val context = LocalContext.current
@@ -76,16 +75,10 @@ fun AlbumArtCollage(
             .padding(padding)
     ) {
         val boxMaxHeight = maxHeight
-        val shapeConfigs by produceState<List<Config>>(initialValue = emptyList(), songsToShow, boxMaxHeight) {
+        val shapeConfigs by produceState<List<Config>>(initialValue = emptyList(), songsToShow, boxMaxHeight, pattern) {
             value = withContext(Dispatchers.Default) {
                 val min = minOf(300.dp, height)
-                listOf(
-                    Config(size = min * 0.8f, width = min * 0.48f, height = min * 0.8f, align = Alignment.Center, rot = 45f, shape = RoundedCornerShape(percent = 50), offsetX = 0.dp, offsetY = 0.dp),
-                    Config(size = min * 0.4f, width = min * 0.24f, height = min * 0.24f, align = Alignment.TopStart, rot = 0f, shape = CircleShape, offsetX = (300.dp * 0.05f), offsetY = (boxMaxHeight * 0.05f)),
-                    Config(size = min * 0.4f, width = min * 0.24f, height = min * 0.24f, align = Alignment.BottomEnd, rot = 0f, shape = CircleShape, offsetX = -(300.dp * 0.05f), offsetY = -(boxMaxHeight * 0.05f)),
-                    Config(size = min * 0.6f, width = min * 0.35f, height = min * 0.35f, align = Alignment.TopStart, rot = -20f, shape = RoundedCornerShape(20.dp), offsetX = (300.dp * 0.1f), offsetY = (boxMaxHeight * 0.1f)),
-                    Config(size = min * 0.9f, width = min * 0.9f, height = min * 0.9f, align = Alignment.BottomEnd, rot = 0f, shape = RoundedStarShape(sides = 6, curve = 0.09, rotation = 45f), offsetX = (42).dp, offsetY = 0.dp)
-                )
+                buildCollageConfigs(pattern, min, boxMaxHeight)
             }
         }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CollagePatterns.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CollagePatterns.kt
@@ -1,0 +1,78 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.data.preferences.CollagePattern
+import com.theveloper.pixelplay.utils.shapes.RoundedStarShape
+
+@Stable
+fun buildCollageConfigs(
+    pattern: CollagePattern,
+    min: Dp,
+    boxMaxHeight: Dp
+): List<Config> = when (pattern) {
+    CollagePattern.COSMIC_SWIRL -> cosmicSwirlConfigs(min, boxMaxHeight)
+    CollagePattern.HONEYCOMB_GROOVE -> honeycombGrooveConfigs(min, boxMaxHeight)
+    CollagePattern.VINYL_STACK -> vinylStackConfigs(min, boxMaxHeight)
+    CollagePattern.PIXEL_MOSAIC -> pixelMosaicConfigs(min, boxMaxHeight)
+    CollagePattern.STARDUST_SCATTER -> stardustScatterConfigs(min, boxMaxHeight)
+}
+
+/** Original pattern — preserved exactly as-is. */
+private fun cosmicSwirlConfigs(min: Dp, boxMaxHeight: Dp): List<Config> = listOf(
+    // Top section
+    Config(size = min * 0.8f, width = min * 0.48f, height = min * 0.8f, align = Alignment.Center, rot = 45f, shape = RoundedCornerShape(percent = 50), offsetX = 0.dp, offsetY = 0.dp),
+    Config(size = min * 0.4f, width = min * 0.24f, height = min * 0.24f, align = Alignment.TopStart, rot = 0f, shape = CircleShape, offsetX = (300.dp * 0.05f), offsetY = (boxMaxHeight * 0.05f)),
+    Config(size = min * 0.4f, width = min * 0.24f, height = min * 0.24f, align = Alignment.BottomEnd, rot = 0f, shape = CircleShape, offsetX = -(300.dp * 0.05f), offsetY = -(boxMaxHeight * 0.05f)),
+    // Bottom section
+    Config(size = min * 0.6f, width = min * 0.35f, height = min * 0.35f, align = Alignment.TopStart, rot = -20f, shape = RoundedCornerShape(20.dp), offsetX = (300.dp * 0.1f), offsetY = (boxMaxHeight * 0.1f)),
+    Config(size = min * 0.9f, width = min * 0.9f, height = min * 0.9f, align = Alignment.BottomEnd, rot = 0f, shape = RoundedStarShape(sides = 6, curve = 0.09, rotation = 45f), offsetX = 42.dp, offsetY = 0.dp)
+)
+
+/** Hexagon-themed organic layout with rounded stars and mixed shapes. */
+private fun honeycombGrooveConfigs(min: Dp, boxMaxHeight: Dp): List<Config> = listOf(
+    // Top section
+    Config(size = min * 0.7f, width = min * 0.7f, height = min * 0.7f, align = Alignment.Center, rot = 0f, shape = RoundedStarShape(sides = 6, curve = 0.05, rotation = 0f), offsetX = 0.dp, offsetY = 0.dp),
+    Config(size = min * 0.35f, width = min * 0.22f, height = min * 0.22f, align = Alignment.TopEnd, rot = 15f, shape = RoundedCornerShape(16.dp), offsetX = -(300.dp * 0.03f), offsetY = (boxMaxHeight * 0.04f)),
+    Config(size = min * 0.3f, width = min * 0.18f, height = min * 0.18f, align = Alignment.BottomStart, rot = 0f, shape = CircleShape, offsetX = (300.dp * 0.04f), offsetY = -(boxMaxHeight * 0.04f)),
+    // Bottom section
+    Config(size = min * 0.55f, width = min * 0.55f, height = min * 0.55f, align = Alignment.BottomStart, rot = -10f, shape = RoundedStarShape(sides = 6, curve = 0.05, rotation = 30f), offsetX = (300.dp * 0.02f), offsetY = -(boxMaxHeight * 0.02f)),
+    Config(size = min * 0.55f, width = min * 0.42f, height = min * 0.55f, align = Alignment.TopEnd, rot = 30f, shape = RoundedCornerShape(percent = 50), offsetX = -(300.dp * 0.06f), offsetY = (boxMaxHeight * 0.03f))
+)
+
+/** Cascading discs / record-inspired circles. */
+private fun vinylStackConfigs(min: Dp, boxMaxHeight: Dp): List<Config> = listOf(
+    // Top section
+    Config(size = min * 0.55f, width = min * 0.55f, height = min * 0.55f, align = Alignment.CenterStart, rot = 0f, shape = CircleShape, offsetX = (300.dp * 0.02f), offsetY = 0.dp),
+    Config(size = min * 0.38f, width = min * 0.38f, height = min * 0.38f, align = Alignment.CenterEnd, rot = 0f, shape = CircleShape, offsetX = -(300.dp * 0.04f), offsetY = -(boxMaxHeight * 0.08f)),
+    Config(size = min * 0.0f, width = min * 0.15f, height = min * 0.15f, align = Alignment.TopEnd, rot = -45f, shape = RoundedCornerShape(percent = 50), offsetX = -(300.dp * 0.02f), offsetY = (boxMaxHeight * 0.43f)),
+    // Bottom section
+    Config(size = min * 0.5f, width = min * 0.5f, height = min * 0.5f, align = Alignment.Center, rot = 0f, shape = CircleShape, offsetX = 70.dp, offsetY = -(boxMaxHeight * 0.02f)),
+    Config(size = min * 0.35f, width = min * 0.35f, height = min * 0.35f, align = Alignment.BottomStart, rot = 0f, shape = RoundedStarShape(sides = 8, curve = 0.06, rotation = 22f), offsetX = (300.dp * 0.05f), offsetY = -(boxMaxHeight * 0.03f))
+)
+
+/** Grid-like arrangement of tilted rounded rectangles. */
+private fun pixelMosaicConfigs(min: Dp, boxMaxHeight: Dp): List<Config> = listOf(
+    // Top section
+    Config(size = min * 0.65f, width = min * 0.42f, height = min * 0.65f, align = Alignment.TopStart, rot = 0f, shape = RoundedCornerShape(24.dp), offsetX = (300.dp * 0.03f), offsetY = (boxMaxHeight * 0.02f)),
+    Config(size = min * 0.45f, width = min * 0.52f, height = min * 0.42f, align = Alignment.TopEnd, rot = 8f, shape = RoundedCornerShape(20.dp), offsetX = -(300.dp * 0.04f), offsetY = (boxMaxHeight * 0.06f)),
+    Config(size = min * 0.1f, width = min * 0.52f, height = min * 0.12f, align = Alignment.BottomEnd, rot = -5f, shape = RoundedCornerShape(12.dp), offsetX = -(300.dp * 0.06f), offsetY = -(boxMaxHeight * 0.05f)),
+    // Bottom section
+    Config(size = min * 0.55f, width = min * 0.42f, height = min * 0.52f, align = Alignment.BottomEnd, rot = -12f, shape = RoundedCornerShape(28.dp), offsetX = -(300.dp * 0.02f), offsetY = -(boxMaxHeight * 0.02f)),
+    Config(size = min * 0.4f, width = min * 0.50f, height = min * 0.48f, align = Alignment.TopStart, rot = 5f, shape = RoundedCornerShape(16.dp), offsetX = (300.dp * 0.04f), offsetY = (boxMaxHeight * 0.04f))
+)
+
+/** Star-heavy whimsical arrangement with mixed star variants. */
+private fun stardustScatterConfigs(min: Dp, boxMaxHeight: Dp): List<Config> = listOf(
+    // Top section
+    Config(size = min * 0.65f, width = min * 0.65f, height = min * 0.65f, align = Alignment.Center, rot = 10f, shape = RoundedStarShape(sides = 5, curve = 0.12, rotation = 0f), offsetX = 0.dp, offsetY = 0.dp),
+    Config(size = min * 0.37f, width = min * 0.22f, height = min * 0.22f, align = Alignment.TopStart, rot = 0f, shape = CircleShape, offsetX = (300.dp * 0.04f), offsetY = (boxMaxHeight * 0.03f)),
+    Config(size = min * 0.36f, width = min * 0.26f, height = min * 0.26f, align = Alignment.BottomEnd, rot = 0f, shape = RoundedStarShape(sides = 4, curve = 0.18, rotation = 45f), offsetX = -(300.dp * 0.06f), offsetY = (boxMaxHeight * 0.00f)),
+    // Bottom section
+    Config(size = min * 0.5f, width = min * 0.5f, height = min * 0.5f, align = Alignment.CenterEnd, rot = -15f, shape = RoundedStarShape(sides = 8, curve = 0.04, rotation = 0f), offsetX = -(300.dp * 0.04f), offsetY = 0.dp),
+    Config(size = min * 0.5f, width = min * 0.5f, height = min * 0.42f, align = Alignment.BottomStart, rot = 25f, shape = RoundedCornerShape(percent = 50), offsetX = (300.dp * 0.06f), offsetY = -(boxMaxHeight * 0.03f))
+)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -33,11 +33,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,6 +64,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.preferences.CollagePattern
 import com.theveloper.pixelplay.presentation.components.AlbumArtCollage
 import com.theveloper.pixelplay.presentation.components.BetaInfoBottomSheet
 import com.theveloper.pixelplay.presentation.components.ChangelogBottomSheet
@@ -223,11 +227,26 @@ fun HomeScreen(
                 // Collage
                 if (yourMixSongs.isNotEmpty()) {
                     item(key = "album_art_collage") {
+                        val basePattern = settingsUiState.collagePattern
+                        val isAutoRotate = settingsUiState.collageAutoRotate
+                        val patterns = remember { CollagePattern.entries }
+
+                        val activePattern = if (isAutoRotate) {
+                            var rotationIndex by rememberSaveable { mutableIntStateOf(-1) }
+                            LaunchedEffect(Unit) { rotationIndex++ }
+                            remember(rotationIndex) {
+                                patterns[rotationIndex.coerceAtLeast(0) % patterns.size]
+                            }
+                        } else {
+                            basePattern
+                        }
+
                         AlbumArtCollage(
                             modifier = Modifier.fillMaxWidth(),
                             songs = yourMixSongs,
                             padding = 14.dp,
                             height = 400.dp,
+                            pattern = activePattern,
                             onSongClick = { song ->
                                 playerViewModel.showAndPlaySong(song, yourMixSongs, "Your Mix")
                             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
@@ -137,6 +137,7 @@ import com.theveloper.pixelplay.data.backup.model.BackupTransferProgressUpdate
 import com.theveloper.pixelplay.data.backup.model.ModuleRestoreDetail
 import com.theveloper.pixelplay.data.backup.model.RestorePlan
 import com.theveloper.pixelplay.data.preferences.AppThemeMode
+import com.theveloper.pixelplay.data.preferences.CollagePattern
 import com.theveloper.pixelplay.data.preferences.CarouselStyle
 import com.theveloper.pixelplay.data.preferences.LaunchTab
 import com.theveloper.pixelplay.data.preferences.LibraryNavigationMode
@@ -520,6 +521,26 @@ fun SettingsCategoryScreen(
                                     selectedKey = uiState.carouselStyle,
                                     onSelectionChanged = { settingsViewModel.setCarouselStyle(it) },
                                     leadingIcon = { Icon(painterResource(R.drawable.rounded_view_carousel_24), null, tint = MaterialTheme.colorScheme.secondary) }
+                                )
+                            }
+
+                            SettingsSubsection(title = "Home Collage") {
+                                ThemeSelectorItem(
+                                    label = "Collage Pattern",
+                                    description = "Choose the shape arrangement for the Your Mix collage.",
+                                    options = CollagePattern.entries.associate { it.storageKey to it.label },
+                                    selectedKey = uiState.collagePattern.storageKey,
+                                    onSelectionChanged = { key ->
+                                        settingsViewModel.setCollagePattern(CollagePattern.fromStorageKey(key))
+                                    },
+                                    leadingIcon = { Icon(painterResource(R.drawable.rounded_view_column_24), null, tint = MaterialTheme.colorScheme.secondary) }
+                                )
+                                SwitchSettingItem(
+                                    title = "Auto-Rotate Patterns",
+                                    subtitle = "Cycle through collage patterns each time you visit Home.",
+                                    checked = uiState.collageAutoRotate,
+                                    onCheckedChange = { settingsViewModel.setCollageAutoRotate(it) },
+                                    leadingIcon = { Icon(painterResource(R.drawable.rounded_shuffle_on_24), null, tint = MaterialTheme.colorScheme.secondary) }
                                 )
                             }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -19,6 +19,7 @@ import com.theveloper.pixelplay.data.preferences.ThemePreference
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.preferences.AlbumArtQuality
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
+import com.theveloper.pixelplay.data.preferences.CollagePattern
 import com.theveloper.pixelplay.data.preferences.FullPlayerLoadingTweaks
 import com.theveloper.pixelplay.data.repository.LyricsRepository
 import com.theveloper.pixelplay.data.repository.MusicRepository
@@ -80,7 +81,9 @@ data class SettingsUiState(
     val restorePlan: RestorePlan? = null,
     val backupHistory: List<BackupHistoryEntry> = emptyList(),
     val backupValidationErrors: List<ValidationError> = emptyList(),
-    val isInspectingBackup: Boolean = false
+    val isInspectingBackup: Boolean = false,
+    val collagePattern: CollagePattern = CollagePattern.default,
+    val collageAutoRotate: Boolean = false
 )
 
 data class FailedSongInfo(
@@ -193,6 +196,18 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             backupManager.getBackupHistory().collect { history ->
                 _uiState.update { it.copy(backupHistory = history) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.collagePatternFlow.collect { pattern ->
+                _uiState.update { it.copy(collagePattern = pattern) }
+            }
+        }
+
+        viewModelScope.launch {
+            userPreferencesRepository.collageAutoRotateFlow.collect { autoRotate ->
+                _uiState.update { it.copy(collageAutoRotate = autoRotate) }
             }
         }
     }
@@ -409,6 +424,18 @@ class SettingsViewModel @Inject constructor(
     fun setAlbumArtPaletteStyle(style: AlbumArtPaletteStyle) {
         viewModelScope.launch {
             userPreferencesRepository.setAlbumArtPaletteStyle(style)
+        }
+    }
+
+    fun setCollagePattern(pattern: CollagePattern) {
+        viewModelScope.launch {
+            userPreferencesRepository.setCollagePattern(pattern)
+        }
+    }
+
+    fun setCollageAutoRotate(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setCollageAutoRotate(enabled)
         }
     }
 


### PR DESCRIPTION
- **Data & Preferences**:
    - Introduce `CollagePattern` enum with five distinct layout styles: Cosmic Swirl, Honeycomb Groove, Vinyl Stack, Pixel Mosaic, and Stardust Scatter.
    - Add `collage_pattern` and `collage_auto_rotate` keys to `UserPreferencesRepository` with associated flows and update methods.
- **UI & Components**:
    - Implement `buildCollageConfigs` to generate shape, size, and alignment configurations for each `CollagePattern`.
    - Update `AlbumArtCollage` to accept a `pattern` parameter and dynamically render the selected layout.
    - Add "Home Collage" section to Settings, allowing users to select a specific pattern or enable "Auto-Rotate" to cycle through patterns on each visit.
- **ViewModel & Integration**:
    - Update `SettingsViewModel` to manage collage pattern and rotation state.
    - Enhance `HomeScreen` to handle pattern selection logic, respecting the auto-rotation preference using `rememberSaveable`.