### PR TITLE
fix: Restore search query on back navigation and show artist images in search results

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -119,7 +119,7 @@ fun SearchScreen(
     navController: NavHostController,
     onSearchBarActiveChange: (Boolean) -> Unit = {}
 ) {
-    var searchQuery by remember { mutableStateOf("") }
+    var searchQuery by remember { mutableStateOf(playerViewModel.searchQuery) }
     var active by remember { mutableStateOf(false) }
     val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val bottomBarHeightDp = NavBarContentHeight + systemNavBarInset
@@ -227,7 +227,10 @@ fun SearchScreen(
             ) {
                 SearchBar(
                     query = searchQuery,
-                    onQueryChange = { searchQuery = it },
+                    onQueryChange = {
+                        searchQuery = it
+                        playerViewModel.updateSearchQuery(it)
+                    },
                     onSearch = {
                         if (searchQuery.isNotBlank()) {
                             playerViewModel.onSearchQuerySubmitted(searchQuery)
@@ -943,15 +946,26 @@ fun SearchResultArtistItem(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                painter = painterResource(id = R.drawable.rounded_artist_24),
-                contentDescription = "Artist",
-                modifier = Modifier
-                    .size(56.dp)
-                    .background(MaterialTheme.colorScheme.tertiaryContainer, CircleShape)
-                    .padding(12.dp),
-                tint = MaterialTheme.colorScheme.onTertiaryContainer
-            )
+            // Show artist image if available, fall back to icon
+            if (!artist.effectiveImageUrl.isNullOrBlank()) {
+                SmartImage(
+                    model = artist.effectiveImageUrl,
+                    contentDescription = "Artist: ${artist.name}",
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(CircleShape)
+                )
+            } else {
+                Icon(
+                    painter = painterResource(id = R.drawable.rounded_artist_24),
+                    contentDescription = "Artist",
+                    modifier = Modifier
+                        .size(56.dp)
+                        .background(MaterialTheme.colorScheme.tertiaryContainer, CircleShape)
+                        .padding(12.dp),
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+            }
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
                 Text(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -25,6 +25,9 @@ import androidx.media3.session.MediaController
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.media3.common.Timeline
 import androidx.media3.session.SessionCommand
@@ -682,9 +685,12 @@ class PlayerViewModel @Inject constructor(
     val albumsFlow: StateFlow<ImmutableList<Album>> = libraryStateHolder.albums
     val artistsFlow: StateFlow<ImmutableList<Artist>> = libraryStateHolder.artists
 
+    var searchQuery by mutableStateOf("")
+        private set
 
-
-
+    fun updateSearchQuery(query: String) {
+        searchQuery = query
+    }
 
     private var mediaController: MediaController? = null
     private val _isMediaControllerReady = MutableStateFlow(false)


### PR DESCRIPTION
- Store searchQuery in PlayerViewModel (mutableStateOf) so it persists across navigation

- Add updateSearchQuery() to sync local state back to ViewModel

- Use artist.effectiveImageUrl in SearchResultArtistItem with SmartImage

- Fall back to placeholder icon when no artist image is available
![IMG_20260220_233637](https://github.com/user-attachments/assets/ad62fb81-6f2b-4995-8923-057b1a077818)