### PR TITLE
fix: refine UI components and slider behavior

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -91,6 +91,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import com.theveloper.pixelplay.utils.resolvePlaylistCoverContentColor
 import kotlin.collections.set
 
+@androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PlaylistContainer(
@@ -278,7 +279,7 @@ fun PlaylistItems(
         else 
             bottomBarHeight + 16.dp
 
-        com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar(
+        ExpressiveScrollBar(
             modifier = Modifier
                 .align(Alignment.CenterEnd)
                 .padding(end = 4.dp, top = 16.dp, bottom = bottomPadding),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/WavySliderExpressive.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/WavySliderExpressive.kt
@@ -58,6 +58,7 @@ fun WavySliderExpressive(
     isPlaying: Boolean = true,
     strokeWidth: Dp = 5.dp,
     thumbRadius: Dp = 8.dp,
+    trackEdgePadding: Dp = thumbRadius,
     wavelength: Dp = WavyProgressIndicatorDefaults.LinearDeterminateWavelength,
     waveSpeed: Dp = WavyProgressIndicatorDefaults.LinearDeterminateWavelength / 2f, // Slower wave as requested
 
@@ -69,6 +70,7 @@ fun WavySliderExpressive(
     val density = LocalDensity.current
     val strokeWidthPx = with(density) { strokeWidth.toPx() }
     val thumbRadiusPx = with(density) { thumbRadius.toPx() }
+    val trackEdgePaddingPx = with(density) { trackEdgePadding.coerceAtLeast(0.dp).toPx() }
     val thumbLineHeightPx = with(density) { thumbLineHeightWhenInteracting.toPx() }
 
     val stroke = remember(strokeWidthPx) {
@@ -154,7 +156,7 @@ fun WavySliderExpressive(
             progress = { normalizedValue },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = thumbRadius)
+                .padding(horizontal = trackEdgePadding.coerceAtLeast(0.dp))
                 // Decorative layer: avoid duplicate semantics updates from the visual track.
                 .clearAndSetSemantics { },
             color = activeTrackColor,
@@ -169,10 +171,10 @@ fun WavySliderExpressive(
         )
 
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val trackStart = thumbRadiusPx
-            val trackEnd = size.width - thumbRadiusPx
+            val edgePaddingPx = trackEdgePaddingPx.coerceIn(0f, size.width / 2f)
+            val trackStart = edgePaddingPx
+            val trackEnd = size.width - edgePaddingPx
             val trackWidth = (trackEnd - trackStart).coerceAtLeast(0f)
-            val thumbX = trackStart + (trackWidth * normalizedValue)
             val thumbY = size.height / 2
 
             fun lerp(start: Float, stop: Float, fraction: Float): Float {
@@ -181,6 +183,10 @@ fun WavySliderExpressive(
 
             val currentWidth = lerp(thumbRadiusPx * 2f, strokeWidthPx * 1.2f, thumbInteractionFraction)
             val currentHeight = lerp(thumbRadiusPx * 2f, thumbLineHeightPx, thumbInteractionFraction)
+            val rawThumbX = trackStart + (trackWidth * normalizedValue)
+            val minThumbCenter = (currentWidth / 2f).coerceAtMost(size.width / 2f)
+            val maxThumbCenter = (size.width - currentWidth / 2f).coerceAtLeast(minThumbCenter)
+            val thumbX = rawThumbX.coerceIn(minThumbCenter, maxThumbCenter)
             
             drawRoundRect(
                 color = thumbColor,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1197,6 +1197,7 @@ private fun PlayerProgressBarSection(
     loadingTweaks: FullPlayerLoadingTweaks? = null,
     modifier: Modifier = Modifier
 ) {
+    val progressSectionHorizontalInset = 0.dp
     val expansionFraction = expansionFractionProvider()
     val isVisible = expansionFraction > 0.01f
     val isExpanded = currentSheetState == PlayerSheetState.EXPANDED && expansionFraction >= 0.995f
@@ -1357,7 +1358,8 @@ private fun PlayerProgressBarSection(
                 activeTrackColor = activeTrackColor,
                 inactiveTrackColor = inactiveTrackColor,
                 interactionSource = interactionSource,
-                isPlaying = shouldAnimateWavyProgress
+                isPlaying = shouldAnimateWavyProgress,
+                trackEdgePadding = progressSectionHorizontalInset
             )
 
             // Isolated Time Labels
@@ -1366,7 +1368,8 @@ private fun PlayerProgressBarSection(
                 duration = displayDurationValue,
                 isVisible = isVisible,
                 textColor = timeTextColor,
-                audioMetaLabel = displayAudioMetaLabel
+                audioMetaLabel = displayAudioMetaLabel,
+                horizontalTrackInset = progressSectionHorizontalInset
             )
         }
     }
@@ -1381,7 +1384,8 @@ private fun EfficientSlider(
     activeTrackColor: Color,
     inactiveTrackColor: Color,
     interactionSource: MutableInteractionSource,
-    isPlaying: Boolean // Added parameter
+    isPlaying: Boolean,
+    trackEdgePadding: Dp
 ) {
     WavySliderExpressive(
         value = valueState.value,
@@ -1391,6 +1395,7 @@ private fun EfficientSlider(
         inactiveTrackColor = inactiveTrackColor,
         thumbColor = thumbColor,
         isPlaying = isPlaying,
+        trackEdgePadding = trackEdgePadding,
         semanticsLabel = "Playback position",
         modifier = Modifier
             .fillMaxWidth()
@@ -1404,7 +1409,8 @@ private fun EfficientTimeLabels(
     duration: Long,
     isVisible: Boolean,
     textColor: Color,
-    audioMetaLabel: String?
+    audioMetaLabel: String?,
+    horizontalTrackInset: Dp
 ) {
     val coarsePositionMs by remember(isVisible, positionState) {
         derivedStateOf {
@@ -1422,7 +1428,7 @@ private fun EfficientTimeLabels(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 4.dp)
+            .padding(horizontal = horizontalTrackInset)
     ) {
         Row(
             modifier = Modifier
@@ -1882,7 +1888,7 @@ private fun ProgressPlaceholder(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp)
+                .padding(horizontal = 0.dp)
         ) {
             Row(
                 modifier = Modifier


### PR DESCRIPTION
- **PlaylistContainer**:
    - Add `UnstableApi` opt-in annotation.
    - Use shortened reference for `ExpressiveScrollBar`.
- **WavySliderExpressive**:
    - Add `trackEdgePadding` parameter to control horizontal track insets independently of thumb radius.
    - Implement thumb position clamping to ensure the thumb remains within canvas bounds regardless of its dynamic width/height during interaction.
- **FullPlayerContent**:
    - Standardize horizontal insets for the player's progress section (slider and time labels).
    - Pass `trackEdgePadding` and `horizontalTrackInset` through the player UI hierarchy to ensure alignment between the wavy slider and time display.