### PR TITLE
feat: implement remote-controlled Play Store announcement dialog

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -5,6 +5,7 @@ import com.theveloper.pixelplay.presentation.navigation.navigateSafely
 // import androidx.compose.ui.platform.LocalView // No longer needed for this
 // import androidx.core.view.WindowInsetsCompat // No longer needed for this
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Intent
 import android.os.Build
@@ -74,7 +75,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.core.net.toUri
@@ -90,6 +90,8 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
+import com.theveloper.pixelplay.data.github.GitHubAnnouncementPropertiesService
+import com.theveloper.pixelplay.data.github.PlayStoreAnnouncementRemoteConfig
 import com.theveloper.pixelplay.data.preferences.AppThemeMode
 import com.theveloper.pixelplay.data.preferences.NavBarStyle
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
@@ -106,6 +108,9 @@ import com.theveloper.pixelplay.presentation.components.MiniPlayerHeight
 import com.theveloper.pixelplay.presentation.components.NavBarContentHeight
 import com.theveloper.pixelplay.presentation.components.NavBarContentHeightFullWidth
 import com.theveloper.pixelplay.presentation.components.PlayerInternalNavigationBar
+import com.theveloper.pixelplay.presentation.components.PlayStoreAnnouncementDefaults
+import com.theveloper.pixelplay.presentation.components.PlayStoreAnnouncementDialog
+import com.theveloper.pixelplay.presentation.components.PlayStoreAnnouncementUiModel
 import com.theveloper.pixelplay.presentation.components.UnifiedPlayerSheet
 import com.theveloper.pixelplay.presentation.components.UnifiedPlayerSheetV2
 import com.theveloper.pixelplay.presentation.navigation.AppNavigation
@@ -399,6 +404,28 @@ class MainActivity : ComponentActivity() {
         intent.removeExtra(android.content.Intent.EXTRA_STREAM)
     }
 
+    private fun openExternalUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+        try {
+            startActivity(intent)
+        } catch (_: ActivityNotFoundException) {
+            LogUtils.w(this, "No activity available to open URL: $url")
+        }
+    }
+
+    private fun PlayStoreAnnouncementRemoteConfig.toUiModel(): PlayStoreAnnouncementUiModel {
+        val fallback = PlayStoreAnnouncementDefaults.Template
+        return fallback.copy(
+            enabled = enabled,
+            playStoreUrl = playStoreUrl ?: fallback.playStoreUrl,
+            title = title ?: fallback.title,
+            body = body ?: fallback.body,
+            primaryActionLabel = primaryActionLabel ?: fallback.primaryActionLabel,
+            dismissActionLabel = dismissActionLabel ?: fallback.dismissActionLabel,
+            linkPendingMessage = linkPendingMessage ?: fallback.linkPendingMessage,
+        )
+    }
+
     @androidx.annotation.OptIn(UnstableApi::class)
     @Composable
     private fun MainAppContent(playerViewModel: PlayerViewModel, mainViewModel: MainViewModel) {
@@ -573,6 +600,30 @@ class MainActivity : ComponentActivity() {
 
         val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
         val scope = rememberCoroutineScope()
+        val announcementService = remember { GitHubAnnouncementPropertiesService() }
+        var playStoreAnnouncement by remember { mutableStateOf(PlayStoreAnnouncementDefaults.Template) }
+        var showPlayStoreAnnouncement by remember { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            if (PlayStoreAnnouncementDefaults.LOCAL_PREVIEW_ENABLED) {
+                playStoreAnnouncement = PlayStoreAnnouncementDefaults.HardcodedPreview
+                showPlayStoreAnnouncement = true
+                return@LaunchedEffect
+            }
+
+            announcementService.fetchPlayStoreAnnouncement()
+                .onSuccess { remoteConfig ->
+                    val resolvedAnnouncement = remoteConfig.toUiModel()
+                    playStoreAnnouncement = resolvedAnnouncement
+                    showPlayStoreAnnouncement = resolvedAnnouncement.enabled
+                }
+                .onFailure { throwable ->
+                    LogUtils.w(
+                        this@MainActivity,
+                        "Remote announcement unavailable. Keeping popup disabled. ${throwable.message ?: ""}",
+                    )
+                }
+        }
 
         CompositionLocalProvider(
             LocalAppHapticsConfig provides appHapticsConfig,
@@ -813,6 +864,17 @@ class MainActivity : ComponentActivity() {
                                 onUndo = onUndoDismissPlaylist,
                                 onClose = onCloseDismissUndoBar,
                                 durationMillis = dismissUndoBarSlice.durationMillis
+                            )
+                        }
+
+                        if (showPlayStoreAnnouncement) {
+                            PlayStoreAnnouncementDialog(
+                                announcement = playStoreAnnouncement,
+                                onDismiss = { showPlayStoreAnnouncement = false },
+                                onOpenPlayStore = { url ->
+                                    showPlayStoreAnnouncement = false
+                                    openExternalUrl(url)
+                                }
                             )
                         }
                     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubAnnouncementPropertiesService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/github/GitHubAnnouncementPropertiesService.kt
@@ -1,0 +1,99 @@
+package com.theveloper.pixelplay.data.github
+
+import java.io.StringReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Properties
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+data class PlayStoreAnnouncementRemoteConfig(
+    val enabled: Boolean = false,
+    val playStoreUrl: String? = null,
+    val title: String? = null,
+    val body: String? = null,
+    val primaryActionLabel: String? = null,
+    val dismissActionLabel: String? = null,
+    val linkPendingMessage: String? = null,
+)
+
+@Singleton
+class GitHubAnnouncementPropertiesService @Inject constructor() {
+
+    /**
+     * Reads announcement flags from a raw properties file in GitHub.
+     *
+     * Expected keys:
+     * - play_store_announcement_enabled
+     * - play_store_url
+     * - play_store_announcement_title
+     * - play_store_announcement_body
+     * - play_store_primary_action
+     * - play_store_dismiss_action
+     * - play_store_link_pending_message
+     */
+    suspend fun fetchPlayStoreAnnouncement(
+        owner: String = "theovilardo",
+        repo: String = "PixelPlay",
+        branch: String = "master",
+        configPath: String = "remote-config/app-announcements.properties",
+    ): Result<PlayStoreAnnouncementRemoteConfig> {
+        return withContext(Dispatchers.IO) {
+            var connection: HttpURLConnection? = null
+            try {
+                val rawUrl = "https://raw.githubusercontent.com/$owner/$repo/$branch/$configPath"
+                connection = (URL(rawUrl).openConnection() as HttpURLConnection).apply {
+                    requestMethod = "GET"
+                    connectTimeout = 10_000
+                    readTimeout = 10_000
+                    addRequestProperty("Accept", "text/plain")
+                }
+
+                when (val code = connection.responseCode) {
+                    HttpURLConnection.HTTP_OK -> {
+                        val response = connection.inputStream.bufferedReader().use { it.readText() }
+                        val props = Properties().apply { load(StringReader(response)) }
+                        val config = PlayStoreAnnouncementRemoteConfig(
+                            enabled = props.booleanFlag("play_store_announcement_enabled"),
+                            playStoreUrl = props.stringValue("play_store_url"),
+                            title = props.stringValue("play_store_announcement_title"),
+                            body = props.stringValue("play_store_announcement_body"),
+                            primaryActionLabel = props.stringValue("play_store_primary_action"),
+                            dismissActionLabel = props.stringValue("play_store_dismiss_action"),
+                            linkPendingMessage = props.stringValue("play_store_link_pending_message"),
+                        )
+                        Result.success(config)
+                    }
+                    HttpURLConnection.HTTP_NOT_FOUND -> {
+                        Timber.i("Remote announcement properties file not found. Keeping announcement disabled.")
+                        Result.success(PlayStoreAnnouncementRemoteConfig())
+                    }
+                    else -> {
+                        val errorMessage = connection.errorStream?.bufferedReader()?.use { it.readText() }
+                        Result.failure(
+                            IllegalStateException("Failed to fetch remote announcement properties: $code - $errorMessage"),
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            } finally {
+                connection?.disconnect()
+            }
+        }
+    }
+}
+
+private fun Properties.stringValue(key: String): String? {
+    return getProperty(key)?.trim()?.takeIf { it.isNotEmpty() }
+}
+
+private fun Properties.booleanFlag(key: String): Boolean {
+    return when (getProperty(key)?.trim()?.lowercase()) {
+        "true", "1", "yes", "on" -> true
+        else -> false
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayStoreAnnouncementDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayStoreAnnouncementDialog.kt
@@ -1,0 +1,205 @@
+package com.theveloper.pixelplay.presentation.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+data class PlayStoreAnnouncementUiModel(
+    val enabled: Boolean,
+    val title: String,
+    val body: String,
+    val playStoreUrl: String?,
+    val primaryActionLabel: String = "Open Play Store",
+    val dismissActionLabel: String = "Continue beta",
+    val linkPendingMessage: String = "The Play Store link will be enabled from GitHub config.",
+)
+
+object PlayStoreAnnouncementDefaults {
+    const val LOCAL_PREVIEW_ENABLED = false
+
+    val Template = PlayStoreAnnouncementUiModel(
+        enabled = false,
+        title = "PixelPlay is now available on Google Play",
+        body = "Use the stable channel on Google Play for release updates while we keep beta builds active.",
+        playStoreUrl = null,
+    )
+
+    val HardcodedPreview = Template.copy(enabled = true)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlayStoreAnnouncementDialog(
+    announcement: PlayStoreAnnouncementUiModel,
+    onDismiss: () -> Unit,
+    onOpenPlayStore: (String) -> Unit,
+) {
+    val cardShape = AbsoluteSmoothCornerShape(
+        cornerRadiusTL = 30.dp,
+        cornerRadiusTR = 30.dp,
+        cornerRadiusBL = 30.dp,
+        cornerRadiusBR = 30.dp,
+        smoothnessAsPercentTL = 60,
+        smoothnessAsPercentTR = 60,
+        smoothnessAsPercentBL = 60,
+        smoothnessAsPercentBR = 60,
+    )
+    val actionShape = AbsoluteSmoothCornerShape(18.dp, 60)
+    val hasPlayStoreLink = !announcement.playStoreUrl.isNullOrBlank()
+
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            shape = cardShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 8.dp,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            listOf(
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.42f),
+                                MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.20f),
+                                MaterialTheme.colorScheme.surfaceContainerHigh,
+                            ),
+                        ),
+                    )
+                    .padding(horizontal = 20.dp, vertical = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.pixelplay_base_monochrome),
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier
+                                .padding(10.dp)
+                                .size(26.dp),
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = "PixelPlay",
+                            fontFamily = GoogleSansRounded,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Text(
+                            text = "Release announcement",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                Text(
+                    text = announcement.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+
+                Text(
+                    text = announcement.body,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                if (!hasPlayStoreLink) {
+                    Text(
+                        text = announcement.linkPendingMessage,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    FilledTonalButton(
+                        onClick = onDismiss,
+                        shape = actionShape,
+                        //modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            text = announcement.dismissActionLabel,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+
+                    Button(
+                        onClick = {
+                            announcement.playStoreUrl?.let(onOpenPlayStore)
+                        },
+                        enabled = hasPlayStoreLink,
+                        shape = actionShape,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
+                        //modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.rounded_arrow_forward_24),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = if (hasPlayStoreLink) {
+                                announcement.primaryActionLabel
+                            } else {
+                                "Coming soon"
+                            },
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/remote-config/app-announcements.properties
+++ b/remote-config/app-announcements.properties
@@ -1,0 +1,15 @@
+# PixelPlay remote announcement toggles.
+# Update this file in GitHub to control app announcements without shipping a new APK.
+
+# Keep disabled until the Play Store listing is live.
+play_store_announcement_enabled=false
+
+# Add the real Play Store URL when published.
+play_store_url=
+
+# Optional copy overrides (defaults are used when values are empty).
+play_store_announcement_title=PixelPlay is now available on Google Play
+play_store_announcement_body=Use the stable channel on Google Play for release updates while we keep beta builds active.
+play_store_primary_action=Open Play Store
+play_store_dismiss_action=Continue beta
+play_store_link_pending_message=The Play Store link will be enabled from GitHub config.


### PR DESCRIPTION
- **Remote Config**:
    - Add `remote-config/app-announcements.properties` to manage Play Store announcement visibility, URLs, and localized copy via GitHub.
- **Data**:
    - Implement `GitHubAnnouncementPropertiesService` to fetch and parse the remote properties file.
    - Define `PlayStoreAnnouncementRemoteConfig` and `PlayStoreAnnouncementUiModel` to handle remote and UI state.
- **UI & Components**:
    - Create `PlayStoreAnnouncementDialog` using Material 3 `BasicAlertDialog` with a custom expressive design, including gradient backgrounds and smooth corner shapes.
    - Support dynamic action labels and a "link pending" state for when the store URL is not yet available.
- **Integration**:
    - Update `MainActivity` to fetch the announcement configuration on launch.
    - Add logic to display the dialog based on the remote `enabled` flag.
    - Implement `openExternalUrl` helper to handle Play Store navigation.