### PR TITLE
fix: Correct song ID format in Netease playlist sync

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
@@ -651,9 +651,10 @@ class NeteaseRepository @Inject constructor(
         neteaseEntities: List<NeteaseSongEntity>
     ) {
         try {
-            // Convert Netease song entities to unified song IDs
+            // Convert Netease song entities to unified song IDs (Long format, stored as String)
+            // These must match the IDs generated in syncUnifiedLibrarySongsFromNetease
             val unifiedSongIds = neteaseEntities.map { entity ->
-                "netease_${entity.neteaseId}"
+                toUnifiedSongId(entity.neteaseId).toString()
             }
 
             val appPlaylistId = getAppPlaylistIdForNetease(neteasePlaylistId)


### PR DESCRIPTION
## Bug Fix
Fixes empty playlists issue when syncing Netease Cloud playlists to app playlists.

## Root Cause
The previous implementation used incorrect song ID format when populating app playlists. Netease songs in the unified library use negative Long IDs (format: `-(NETEASE_SONG_ID_OFFSET + neteaseId)`), but the playlist sync was storing incompatible ID formats that couldn't match database records.

## Solution
Changed `updateAppPlaylistForNeteasePlaylist()` to use the correct unified song ID format:
- **Before (❌)**: `"netease_${entity.id}"` → Incompatible string format
- **After (✅)**: `toUnifiedSongId(entity.neteaseId).toString()` → Matches SongEntity IDs

This ensures playlist song IDs reference the same negative Long IDs stored in the unified library, allowing `getSongsByIds()` to correctly retrieve songs.

## Technical Details
- Modified ID generation in `updateAppPlaylistForNeteasePlaylist()`
- Song IDs now generated using `toUnifiedSongId()` method
- IDs converted to String to match `Playlist.songIds` type requirement
- Maintains consistency with `syncUnifiedLibrarySongsFromNetease()` logic

## Impact
✅ Netease playlist songs now display correctly in app playlists  
✅ All playlist operations (play, shuffle, etc.) work as expected  
✅ No changes to database schema or API contracts  

## Testing
1. Sync Netease playlists
2. Open any synced playlist in the Playlists tab
3. Verify songs are visible and playable
4. Verify song metadata (title, artist, album art) displays correctly

## Related to
Follows up on #[1182] - Netease playlist sync feature