### PR TITLE
Add discrete steps to crossfade slider

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
@@ -678,6 +678,7 @@ fun SettingsCategoryScreen(
                                         label = "Crossfade Duration",
                                         value = uiState.crossfadeDuration.toFloat(),
                                         valueRange = 1000f..12000f,
+                                        steps= 10,
                                         onValueChange = { settingsViewModel.setCrossfadeDuration(it.toInt()) },
                                         valueText = { value -> "${(value / 1000).toInt()}s" }
                                     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
@@ -368,6 +368,7 @@ fun SliderSettingsItem(
         label: String,
         value: Float,
         valueRange: ClosedFloatingPointRange<Float>,
+        steps: Int,
         onValueChange: (Float) -> Unit,
         valueText: (Float) -> String
 ) {
@@ -392,7 +393,7 @@ fun SliderSettingsItem(
                         fontWeight = FontWeight.Bold
                 )
             }
-            Slider(value = value, onValueChange = onValueChange, valueRange = valueRange)
+            Slider(value = value, onValueChange = onValueChange, valueRange = valueRange, steps = steps)
         }
     }
 }


### PR DESCRIPTION
Inspired by transition duration slider in Playlist Rules
<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/6d7d68d6-da35-444d-8538-52a4716f4e92" />

Now global setting for **crossfade** has steps
- Add steps parameter to SliderSettingsItem for auto snap-like behavior
- Crossfade duration now snaps to whole-second increments (1s–12s)
<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/a65a7a3b-dac1-4a85-a671-8b79fd720c77" />
