### PR TITLE
feat: optimize folder and genre loading performance

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/FolderSongRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/FolderSongRow.kt
@@ -1,0 +1,12 @@
+package com.theveloper.pixelplay.data.database
+
+import androidx.room.ColumnInfo
+
+/**
+ * Minimal projection used to build the folder tree without loading full song rows.
+ */
+data class FolderSongRow(
+    @ColumnInfo(name = "id") val id: Long,
+    @ColumnInfo(name = "parent_directory_path") val parentDirectoryPath: String,
+    @ColumnInfo(name = "title") val title: String
+)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -239,7 +239,14 @@ class PlaylistViewModel @Inject constructor(
                     val folder = findFolder(folderPath, folders)
 
                     if (folder != null) {
-                        val songsList = folder.collectAllSongs()
+                        val songsList = withContext(Dispatchers.IO) {
+                            val rawSongs = folder.collectAllSongs()
+                            if (rawSongs.any { it.contentUriString.isBlank() }) {
+                                musicRepository.getSongsByIds(rawSongs.map { it.id }).first()
+                            } else {
+                                rawSongs
+                            }
+                        }
                         val pseudoPlaylist = Playlist(
                             id = playlistId,
                             name = folder.name,


### PR DESCRIPTION
- **Database**:
    - Add `FolderSongRow` projection and `getFolderSongs` query to fetch minimal metadata (ID, path, title) for folder tree building instead of full song entities.
    - Implement directory-aware genre queries (`getUniqueGenres`, `hasUnknownGenre`, `getSongsByGenre`, `getSongsWithNullGenre`) to respect folder exclusion/inclusion rules at the database level.
- **Repository**:
    - Refactor `MusicRepositoryImpl` to use the new optimized DAO queries for genres and folder trees.
    - Update `FolderTreeBuilder` to work with `FolderSongRow` stubs, deferring full song hydration until playback or detailed view is requested.
    - Centralize folder filtering logic and improve reactive flow handling for music folders.
- **ViewModels**:
    - Implement "lazy hydration" in `PlayerViewModel` and `PlaylistViewModel` to fetch full song details by ID when playing from a folder or viewing song info.
    - Ensure folder navigation in the player UI correctly triggers metadata hydration for the current directory.
- **Performance**:
    - Reduce memory footprint and improve UI responsiveness by avoiding bulk loading of thousands of full `Song` objects during library indexing and folder browsing.