### PR TITLE
fix: resolve state synchronization in `ReorderTabsSheet`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
@@ -72,6 +72,11 @@ fun ReorderTabsSheet(
     onDismiss: () -> Unit
 ) {
     var showResetDialog by remember { mutableStateOf(false) }
+    var localTabs by remember { mutableStateOf(tabs) }
+
+    LaunchedEffect(tabs) {
+        localTabs = tabs
+    }
 
     if (showResetDialog) {
         AlertDialog(
@@ -82,6 +87,7 @@ fun ReorderTabsSheet(
                 TextButton(
                     onClick = {
                         onReset()
+                        localTabs = tabs
                         showResetDialog = false
                     }
                 ) {
@@ -99,7 +105,6 @@ fun ReorderTabsSheet(
     }
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var localTabs by remember { mutableStateOf(tabs) }
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
     val view = LocalView.current


### PR DESCRIPTION
Ensure Library Tab order immediately updated when the reset button is clicked by adding LaunchedEffect

Before
![before](https://github.com/user-attachments/assets/87482d89-f53d-4ed5-b342-7d94aeb5b907)

After
![after](https://github.com/user-attachments/assets/64445b09-6413-46f9-9a81-8ea1518a31b6)
