### PR TITLE
perf: optimize player sheet by reducing recompositions during gestures

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -264,11 +264,9 @@ fun UnifiedPlayerSheet(
     )
 
     val fullPlayerVisualState = rememberFullPlayerVisualState(
-        expansionFraction = playerContentExpansionFraction.value,
+        expansionFraction = playerContentExpansionFraction,
         initialOffsetY = initialFullPlayerOffsetY
     )
-    val fullPlayerContentAlpha = fullPlayerVisualState.contentAlpha
-    val fullPlayerTranslationY = fullPlayerVisualState.translationY
 
     suspend fun animatePlayerSheet(
         targetExpanded: Boolean,
@@ -469,7 +467,6 @@ fun UnifiedPlayerSheet(
         currentSong = currentSong,
         themedAlbumArtUri = themedAlbumArtUri,
         preparingSongId = preparingSongId,
-        playerContentExpansionFraction = playerContentExpansionFraction,
         systemColorScheme = MaterialTheme.colorScheme
     )
     val albumColorScheme = sheetThemeState.albumColorScheme
@@ -478,17 +475,10 @@ fun UnifiedPlayerSheet(
     val miniReadyAlpha = sheetThemeState.miniReadyAlpha
     val miniAppearScale = sheetThemeState.miniAppearScale
     val playerAreaBackground = sheetThemeState.playerAreaBackground
-    val effectivePlayerAreaElevation = sheetThemeState.effectivePlayerAreaElevation
-    val miniAlpha = sheetThemeState.miniAlpha
-    val visualCardShadowElevation by remember(
-        effectivePlayerAreaElevation,
-        showQueueSheet,
-        playerContentExpansionFraction
-    ) {
+    val visualCardShadowElevation by remember(showQueueSheet, miniReadyAlpha) {
         derivedStateOf {
-            // Keep rich shadow in mini/collapsing states, but drop expensive blur when full player/queue are active.
             if (showQueueSheet || playerContentExpansionFraction.value > 0.18f) 0.dp
-            else effectivePlayerAreaElevation
+            else (3f * miniReadyAlpha).dp
         }
     }
 
@@ -598,12 +588,10 @@ fun UnifiedPlayerSheet(
                                 infrequentPlayerState = infrequentPlayerState,
                                 isCastConnecting = isCastConnecting,
                                 isPreparingPlayback = isPreparingPlayback,
-                                miniAlpha = miniAlpha,
                                 playerContentExpansionFraction = playerContentExpansionFraction,
                                 albumColorScheme = albumColorScheme,
                                 bottomSheetOpenFraction = bottomSheetOpenFraction,
-                                fullPlayerContentAlpha = fullPlayerContentAlpha,
-                                fullPlayerTranslationY = fullPlayerTranslationY,
+                                fullPlayerVisualState = fullPlayerVisualState,
                                 currentPlaybackQueue = currentPlaybackQueue,
                                 currentQueueSourceName = currentQueueSourceName,
                                 currentSheetContentState = currentSheetContentState,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/FullPlayerVisualState.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/FullPlayerVisualState.kt
@@ -1,35 +1,41 @@
 package com.theveloper.pixelplay.presentation.components.scoped
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.util.lerp
 
-internal data class FullPlayerVisualState(
-    val contentAlpha: Float,
+/**
+ * Holds references needed to compute full-player visual properties lazily.
+ *
+ * **Key design**: [contentAlpha] and [translationY] are computed on-demand via getters
+ * that read [Animatable.value]. When called inside `graphicsLayer { }`, these reads
+ * happen during the draw phase and trigger **re-draw only** — not recomposition.
+ * This eliminates per-frame recomposition of the parent composable during gestures.
+ */
+internal class FullPlayerVisualState(
+    private val expansionFraction: Animatable<Float, AnimationVector1D>,
+    private val initialOffsetY: Float
+) {
+    /** Full-player fade-in: invisible until 25 % expanded, fully opaque at 100 %. */
+    val contentAlpha: Float
+        get() {
+            val f = expansionFraction.value
+            return (f - 0.25f).coerceIn(0f, 0.75f) / 0.75f
+        }
+
+    /** Slide-up entrance driven by [contentAlpha]. */
     val translationY: Float
-)
+        get() = lerp(initialOffsetY, 0f, contentAlpha)
+}
 
 @Composable
 internal fun rememberFullPlayerVisualState(
-    expansionFraction: Float,
+    expansionFraction: Animatable<Float, AnimationVector1D>,
     initialOffsetY: Float
 ): FullPlayerVisualState {
-    val fullPlayerContentAlpha by remember(expansionFraction) {
-        derivedStateOf {
-            (expansionFraction - 0.25f).coerceIn(0f, 0.75f) / 0.75f
-        }
+    return remember(expansionFraction, initialOffsetY) {
+        FullPlayerVisualState(expansionFraction, initialOffsetY)
     }
-
-    val fullPlayerTranslationY by remember(fullPlayerContentAlpha, initialOffsetY) {
-        derivedStateOf {
-            lerp(initialOffsetY, 0f, fullPlayerContentAlpha)
-        }
-    }
-
-    return FullPlayerVisualState(
-        contentAlpha = fullPlayerContentAlpha,
-        translationY = fullPlayerTranslationY
-    )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -770,10 +770,10 @@ class PlayerViewModel @Inject constructor(
     val favoriteSongIds: StateFlow<Set<String>> = userPreferencesRepository.favoriteSongIdsFlow.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
 
     val isCurrentSongFavorite: StateFlow<Boolean> = combine(
-        stablePlayerState,
+        stablePlayerState.map { it.currentSong?.id }.distinctUntilChanged(),
         favoriteSongIds
-    ) { state, ids ->
-        state.currentSong?.id?.let { ids.contains(it) } ?: false
+    ) { songId, ids ->
+        songId?.let { ids.contains(it) } ?: false
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     // Library State - delegated to LibraryStateHolder


### PR DESCRIPTION
- **UI/Animation Performance**:
    - Refactor `UnifiedPlayerSheet` and its layers to use `graphicsLayer` for expansion-dependent properties (alpha, translation, scale).
    - Shift calculation of `miniAlpha`, `contentAlpha`, and `translationY` to the draw phase by reading `Animatable` values directly within `graphicsLayer` blocks.
    - Replace `Transition`-based animations in `SheetThemeState` with inline calculations to prevent per-frame recomposition during drag gestures.
    - Update `FullPlayerVisualState` to provide lazy getters for visual properties, ensuring property reads happen during the draw phase.
- **Composition Policies**:
    - Refactor `FullPlayerCompositionPolicy` and `FullPlayerRuntimePolicy` to accept `Animatable` instead of raw `Float` values.
    - Use `derivedStateOf` and `snapshotFlow` within these policies to gate updates behind specific thresholds, ensuring they only trigger recomposition when necessary.
- **ViewModels**:
    - Optimize `isCurrentSongFavorite` in `PlayerViewModel` by mapping to `songId` and using `distinctUntilChanged` to avoid unnecessary state emissions when the player state changes but the song remains the same.
- **Visuals**:
    - Simplify `visualCardShadowElevation` logic to toggle based on expansion thresholds rather than interpolating on every frame.