### PR TITLE
ui: update favorite button to outline for non-favorite song

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -2314,7 +2314,7 @@ private fun BottomToggleRow(
                 inactiveColor = inactiveBg,
                 inactiveContentColor = inactiveContentColor,
                 onClick = onFavoriteToggle,
-                iconId = R.drawable.round_favorite_24,
+                iconId = if (isFavorite) R.drawable.round_favorite_24 else R.drawable.rounded_favorite_24,
                 contentDesc = "Favorito"
             )
         }


### PR DESCRIPTION
Update favorite button to outline for non-favorite song, as discussed yesterday and based on #923
<img width="1080" height="274" alt="image" src="https://github.com/user-attachments/assets/affe3bce-7bcf-4443-8937-a9abd4b58997" />

<img width="1080" height="274" alt="image" src="https://github.com/user-attachments/assets/ccace949-ce67-4de3-8e5e-7e568250317f" />
