### PR TITLE
feat(Telegram): implement app playlist management for Telegram channels

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/TelegramDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/TelegramDao.kt
@@ -17,6 +17,9 @@ interface TelegramDao {
     @Query("SELECT * FROM telegram_songs WHERE id IN (:ids)")
     fun getSongsByIds(ids: List<String>): Flow<List<TelegramSongEntity>>
 
+    @Query("SELECT * FROM telegram_songs WHERE chat_id = :chatId ORDER BY date_added DESC")
+    suspend fun getSongsByChatId(chatId: Long): List<TelegramSongEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSongs(songs: List<TelegramSongEntity>)
     

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/PlayList.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/PlayList.kt
@@ -22,7 +22,7 @@ data class Playlist(
     val coverShapeDetail2: Float? = null, // e.g., Smoothness / StarRotation
     val coverShapeDetail3: Float? = null, // e.g., StarScale
     val coverShapeDetail4: Float? = null, // e.g., Star Sides (Int)
-    val source: String = "LOCAL" // Source: "LOCAL", "NETEASE", "AI", etc.
+    val source: String = "LOCAL" // Source: "LOCAL", "NETEASE", "TELEGRAM", "AI", etc.
 )
 
 enum class PlaylistShapeType {

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
@@ -236,6 +236,8 @@ interface MusicRepository {
 
     suspend fun deleteById(id: Long)
     suspend fun saveTelegramSongs(songs: List<Song>)
+
+    suspend fun replaceTelegramSongsForChannel(chatId: Long, songs: List<Song>)
     
     suspend fun clearTelegramData()
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -413,7 +413,16 @@ fun PlaylistItem(
                         Icon(
                             painter = painterResource(R.drawable.netease_cloud_music_logo_icon_206716__1_),
                             contentDescription = "Netease Cloud Music",
-                            tint = Color.Unspecified,
+                            tint = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.size(18.dp)
+                        )
+                    }
+                    if (playlist.source == "TELEGRAM") {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Icon(
+                            painter = painterResource(R.drawable.telegram),
+                            contentDescription = "Telegram",
+                            tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(18.dp)
                         )
                     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
@@ -94,7 +94,7 @@ class TelegramChannelSearchViewModel @Inject constructor(
             val fetchedSongs = telegramRepository.getAudioMessages(chatId)
 
             if (fetchedSongs.isNotEmpty()) {
-                musicRepository.saveTelegramSongs(fetchedSongs)
+                musicRepository.replaceTelegramSongsForChannel(chatId, fetchedSongs)
 
                 // Save Channel Entity
                 val chat = _foundChat.value

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
@@ -44,16 +44,16 @@ class TelegramDashboardViewModel @Inject constructor(
                 // Fetch latest songs (getAudioMessages implements pagination and fetches ALL)
                 val songs = telegramRepository.getAudioMessages(channel.chatId)
                 
+                musicRepository.replaceTelegramSongsForChannel(channel.chatId, songs)
+
+                // Update metadata
+                val updatedChannel = channel.copy(
+                    songCount = songs.size,
+                    lastSyncTime = System.currentTimeMillis()
+                )
+                musicRepository.saveTelegramChannel(updatedChannel)
+
                 if (songs.isNotEmpty()) {
-                    musicRepository.saveTelegramSongs(songs)
-                    
-                    // Update metadata
-                    val updatedChannel = channel.copy(
-                        songCount = songs.size,
-                        lastSyncTime = System.currentTimeMillis()
-                    )
-                    musicRepository.saveTelegramChannel(updatedChannel)
-                    
                     _statusMessage.value = "Synced ${songs.size} songs from ${channel.title}"
                 } else {
                     _statusMessage.value = "No songs found in ${channel.title}"


### PR DESCRIPTION
- Add UserPreferencesRepository and TelegramDao dependency injection to TelegramRepository
- Implement updateAppPlaylistForTelegramChannel() to create/update playlists
- Implement deleteAppPlaylistForTelegramChannel() to clean up playlists
- Add getSongsByChatId() query method in TelegramDao
- Integrate playlist sync in saveTelegramChannel() and deleteTelegramChannel()
- Auto-create app playlists when syncing Telegram channels
- Auto-delete playlists when removing channels or clearing data

Similar to Netease implementation (commit 3c7eaa7d2ae0f226f7c31bb4d4f210c24fbe2598)