### PR TITLE
perf: eliminate blank-screen flash on startup & defer TDLib native library load off main thread

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -79,7 +79,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -155,6 +154,7 @@ private data class DismissUndoBarSlice(
 class MainActivity : ComponentActivity() {
 
     private val playerViewModel: PlayerViewModel by viewModels()
+    private val mainViewModel: MainViewModel by viewModels()
     private var mediaControllerFuture: ListenableFuture<MediaController>? = null
     @Inject
     lateinit var userPreferencesRepository: UserPreferencesRepository // Inject here
@@ -169,7 +169,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         LogUtils.d(this, "onCreate")
-        installSplashScreen()
+        val splashScreen = installSplashScreen()
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.auto(
                 android.graphics.Color.TRANSPARENT,
@@ -185,11 +185,14 @@ class MainActivity : ComponentActivity() {
         }
         super.onCreate(savedInstanceState)
 
+        // Keep splash screen visible until DataStore has emitted the initial setup state,
+        // preventing the blank-screen flash between splash and first frame.
+        splashScreen.setKeepOnScreenCondition { mainViewModel.isSetupComplete.value == null }
+
         // LEER SEÑAL DE BENCHMARK
         val isBenchmarkMode = intent.getBooleanExtra("is_benchmark", false)
 
         setContent {
-            val mainViewModel: MainViewModel = hiltViewModel()
             val systemDarkTheme = isSystemInDarkTheme()
             val appThemeMode by userPreferencesRepository.appThemeModeFlow.collectAsStateWithLifecycle(initialValue = AppThemeMode.FOLLOW_SYSTEM)
             val useDarkTheme = when (appThemeMode) {

--- a/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
@@ -25,17 +25,18 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
     @Inject
     lateinit var imageLoader: dagger.Lazy<ImageLoader>
 
+    // Use dagger.Lazy to defer construction (and TDLib native library loading) off the main thread.
     @Inject
-    lateinit var telegramStreamProxy: com.theveloper.pixelplay.data.telegram.TelegramStreamProxy
+    lateinit var telegramStreamProxy: dagger.Lazy<com.theveloper.pixelplay.data.telegram.TelegramStreamProxy>
 
     @Inject
     lateinit var neteaseStreamProxy: com.theveloper.pixelplay.data.netease.NeteaseStreamProxy
-    
+
     @Inject
-    lateinit var telegramCacheManager: com.theveloper.pixelplay.data.telegram.TelegramCacheManager
-    
+    lateinit var telegramCacheManager: dagger.Lazy<com.theveloper.pixelplay.data.telegram.TelegramCacheManager>
+
     @Inject
-    lateinit var telegramCoilFetcherFactory: com.theveloper.pixelplay.data.image.TelegramCoilFetcher.Factory
+    lateinit var telegramCoilFetcherFactory: dagger.Lazy<com.theveloper.pixelplay.data.image.TelegramCoilFetcher.Factory>
 
     // AÑADE EL COMPANION OBJECT
     companion object {
@@ -68,17 +69,22 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
             notificationManager.createNotificationChannel(channel)
         }
         
-        telegramStreamProxy.start()
+        // Start Netease proxy immediately (no heavy native deps)
         neteaseStreamProxy.start()
-        
-        // Trigger robust cache cleanup on startup to remove orphaned files from previous sessions
+
+        // Start Telegram proxy and schedule cache cleanup on IO thread to avoid blocking
+        // Application.onCreate() with TDLib native library loading (System.loadLibrary("tdjni")).
         kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+            // First .get() call constructs TelegramStreamProxy (and transitively TelegramClientManager),
+            // loading the tdjni native library here on the IO thread instead of the main thread.
+            telegramStreamProxy.get().start()
+
             try {
-                // Wait a bit for TDLib to initialize
+                // Wait a bit for TDLib to initialize before cleaning up
                 kotlinx.coroutines.delay(5000)
                 Timber.d("Performing startup Telegram cache cleanup...")
-                telegramCacheManager.clearTdLibCache()
-                telegramCacheManager.trimEmbeddedArtCache()
+                telegramCacheManager.get().clearTdLibCache()
+                telegramCacheManager.get().trimEmbeddedArtCache()
             } catch (e: Exception) {
                 Timber.e(e, "Error during startup cache cleanup")
             }
@@ -88,7 +94,7 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
     override fun newImageLoader(): ImageLoader {
         return imageLoader.get().newBuilder()
             .components {
-                add(telegramCoilFetcherFactory)
+                add(telegramCoilFetcherFactory.get())
             }
             .build()
     }


### PR DESCRIPTION
## Problem

Two performance bottlenecks slow down cold startup:

**1. Blank screen flash after Splash Screen dismisses**
`installSplashScreen()` returns immediately, but `isSetupComplete` starts as `null` while DataStore reads the preference asynchronously. During that window, `AnimatedContent` has nothing to render—producing a visible black frame between the splash and the first real UI frame.

**2. Main thread blocked by TDLib native library loading**
`TelegramClientManager`'s `companion object { init { System.loadLibrary("tdjni") } }` runs synchronously on the main thread inside `Application.onCreate()`, delaying the first UI frame.

---

## Fix

### Fix 1 — Keep splash visible until DataStore emits (`MainActivity.kt`)

- Promotes `mainViewModel` to an Activity-level field (`by viewModels()`) so it is instantiated before `setContent`.
- Captures the return value of `installSplashScreen()` and sets a keep-on-screen condition:
  ```kotlin
  splashScreen.setKeepOnScreenCondition { mainViewModel.isSetupComplete.value == null }
  ```
  The splash stays on screen until `isSetupComplete` has a non-null value, completely eliminating the blank-frame flash.

### Fix 2 — Move TDLib initialisation off the main thread (`PixelPlayApplication.kt`)

- Changes `telegramStreamProxy`, `telegramCacheManager`, and `telegramCoilFetcherFactory` injections from eager to `dagger.Lazy<T>`.
- The first `.get()` call is made inside an IO coroutine, so `TelegramClientManager` construction (including `System.loadLibrary("tdjni")`) happens on the IO thread rather than the main thread.
- `neteaseStreamProxy` (no TDLib dependency) keeps its existing eager startup.

---

## Files changed

| File | Change |
|------|--------|
| `MainActivity.kt` | Promote `mainViewModel` to class field; use `splashScreen.setKeepOnScreenCondition` |
| `PixelPlayApplication.kt` | Switch Telegram injections to `dagger.Lazy`; start proxy from IO coroutine |

---

## Testing

- Cold start: splash transitions smoothly to main UI with no black-screen flash
- Telegram playback: proxy becomes ready on the IO thread before any stream request is made
- All non-Telegram features unaffected