### PR TITLE
perf: eliminate blocking coroutine anti-patterns and reduce CPU overhead

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/AiPlaylistGenerator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/AiPlaylistGenerator.kt
@@ -65,9 +65,9 @@ class AiPlaylistGenerator @Inject constructor(
             val sampleSize = max(minLength, 80).coerceAtMost(200)
             val songSample = samplingPool.shuffled().take(sampleSize)
 
+            val songScores = songSample.associate { it.id to dailyMixManager.getScore(it.id) }
             val availableSongsJson = songSample.joinToString(separator = ",\n") { song ->
-                // Calculate score for each song. This might be slow if it's a real-time calculation.
-                val score = dailyMixManager.getScore(song.id)
+                val score = songScores[song.id] ?: 0.0
                 """
                 {
                     "id": "${song.id}",

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -424,7 +424,6 @@ class MusicService : MediaLibraryService() {
 
         mediaSession = MediaLibrarySession.Builder(this, engine.masterPlayer, callback)
             .setSessionActivity(getOpenAppPendingIntent())
-            .setCallback(callback)
             .setBitmapLoader(CoilBitmapLoader(this, serviceScope))
             .build()
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DismissUndoBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DismissUndoBar.kt
@@ -1,5 +1,8 @@
 package com.theveloper.pixelplay.presentation.components
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,14 +25,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
-import kotlinx.coroutines.delay
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
 @Composable
@@ -39,16 +39,17 @@ fun DismissUndoBar(
     onClose: () -> Unit,
     durationMillis: Long
 ) {
-    var progress by remember { mutableFloatStateOf(1f) }
+    val progress = remember { Animatable(1f) }
 
     LaunchedEffect(key1 = onUndo) {
-        progress = 1f // Reset progress when the bar appears
-        val startTime = System.currentTimeMillis()
-        while (System.currentTimeMillis() < startTime + durationMillis && progress > 0f) {
-            progress = 1f - (System.currentTimeMillis() - startTime).toFloat() / durationMillis
-            delay(16)
-        }
-        progress = 0f
+        progress.snapTo(1f)
+        progress.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(
+                durationMillis = durationMillis.toInt(),
+                easing = LinearEasing
+            )
+        )
     }
 
     Surface(
@@ -102,7 +103,7 @@ fun DismissUndoBar(
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .fillMaxWidth(fraction = progress.coerceIn(0f, 1f))
+                    .fillMaxWidth(fraction = progress.value.coerceIn(0f, 1f))
                     .fillMaxHeight()
                     .background(
                         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.22f),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -36,7 +36,7 @@ class PlaybackStateHolder @Inject constructor(
     companion object {
         private const val TAG = "PlaybackStateHolder"
         private const val DURATION_MISMATCH_TOLERANCE_MS = 1500L
-        private const val PROGRESS_TICK_MS = 100L
+        private const val PROGRESS_TICK_MS = 250L
         /**
          * Threshold above which we skip per-item moveMediaItem calls and use
          * a single setMediaItems call instead. moveMediaItem triggers an IPC


### PR DESCRIPTION
## Summary

This PR fixes several coroutine/performance anti-patterns found during a lifecycle audit of the app. No functional behavior changes are introduced.

---

## Changes

### DailyMixManager
- Converted 9 `runBlocking`-wrapped database methods to `suspend fun`
- Removes thread-blocking on the IO dispatcher, which could cause unnecessary thread starvation under load
- Affected methods: `readEngagements`, `recordPlay`, `incrementScore`, `getScore`, `getEngagementStats`, `getAllEngagementStats`, `computeRankedSongs`, `generateDailyMix`, `generateYourMix`

### ThemeStateHolder
- Replaced orphaned `CoroutineScope(Dispatchers.Default)` used as a `stateIn` scope with `SharingStarted.Eagerly` — a scope that was created but never cancelled
- `activePlayerColorSchemePair` is now a `MutableStateFlow` driven by `combine(...).collect {}` inside the caller-provided `initialize(scope)`, properly tied to a managed lifecycle

### PlaybackStateHolder
- Reduced `PROGRESS_TICK_MS` from `100L` to `250L`
- Cuts CPU wakeups and `listeningStatsTracker.onProgress()` calls by 60% during playback with no perceptible UX difference

### DismissUndoBar
- Replaced manual `delay(16)` polling loop driving a `mutableFloatStateOf` with `Animatable.animateTo(tween(durationMillis, LinearEasing))`
- Delegates frame timing to the Choreographer instead of spinning a coroutine at ~60 fps

### AiPlaylistGenerator
- Pre-compute all song scores via `associate { id to getScore(id) }` before `joinToString`
- Fixes compilation error: `getScore` is now `suspend` and cannot be called from a non-suspending `joinToString` lambda

### MusicService
- Remove duplicate `setCallback(callback)` call on `MediaLibrarySession.Builder`; the callback is already passed as a constructor argument, making the extra `setCallback` redundant