### PR TITLE
perf: Optimize bottom navigation bar responsiveness and transition speed

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayerInternalNavigationBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlayerInternalNavigationBar.kt
@@ -109,10 +109,13 @@ private fun PlayerInternalNavigationItemsRow(
                         lastSearchTapTimestamp = now
 
                         if (!isAlreadySelected) {
-                            navController.navigateSafely(itemRoute) {
-                                popUpTo(navController.graph.id) { inclusive = true; saveState = false }
+                            // Direct navigation for bottom bar - no lifecycle check needed
+                            navController.navigate(itemRoute) {
+                                popUpTo(navController.graph.startDestinationId) { 
+                                    saveState = true 
+                                }
                                 launchSingleTop = true
-                                restoreState = false
+                                restoreState = true
                             }
                         }
 
@@ -129,10 +132,13 @@ private fun PlayerInternalNavigationItemsRow(
                         }
                     } else if (!isAlreadySelected) {
                         lastSearchTapTimestamp = 0L
-                        navController.navigateSafely(itemRoute) {
-                            popUpTo(navController.graph.id) { inclusive = true; saveState = false }
+                        // Direct navigation for bottom bar - no lifecycle check needed
+                        navController.navigate(itemRoute) {
+                            popUpTo(navController.graph.startDestinationId) { 
+                                saveState = true 
+                            }
                             launchSingleTop = true
-                            restoreState = false
+                            restoreState = true
                         }
                     } else {
                         lastSearchTapTimestamp = 0L

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -532,11 +532,14 @@ private enum class MainRootDirection {
     BACKWARD
 }
 
+// Faster transitions for bottom navigation bar switching
+private const val BOTTOM_NAV_TRANSITION_DURATION = 250
+
 private val MAIN_ROOT_TRANSITION_SPEC =
-    tween<IntOffset>(durationMillis = TRANSITION_DURATION, easing = FastOutSlowInEasing)
+    tween<IntOffset>(durationMillis = BOTTOM_NAV_TRANSITION_DURATION, easing = FastOutSlowInEasing)
 
 private val MAIN_ROOT_FADE_SPEC =
-    tween<Float>(durationMillis = TRANSITION_DURATION, easing = FastOutSlowInEasing)
+    tween<Float>(durationMillis = BOTTOM_NAV_TRANSITION_DURATION, easing = FastOutSlowInEasing)
 
 private fun mainRootDirection(
     fromRoute: String?,


### PR DESCRIPTION
## Summary
This PR significantly improves the bottom navigation bar's responsiveness and eliminates lag when switching between tabs (Home, Search, Library).

## Changes Made
- **Enable state save/restore**: Bottom nav tabs now preserve screen state during navigation, avoiding expensive re-initialization (especially for the Library screen)
- **Faster transitions**: Reduced transition duration from 500ms to 250ms for quicker tab switching
- **Remove lifecycle check**: Replaced `navigateSafely()` with direct `navigate()` to allow rapid consecutive taps without being blocked by lifecycle state checks
- **Fix rapid tap issue**: Resolved the bug where quick taps (e.g., Home→Search→Home) would ignore the second tap

## Performance Impact
- ✅ Instant response to tab switches
- ✅ ~50% faster transition animations
- ✅ No more lag when switching to/from Library tab
- ✅ Supports rapid consecutive taps without dropped inputs

## Testing
- Manually tested rapid tab switching across all three bottom nav tabs
- Verified state preservation when navigating between tabs
- Confirmed no regressions in navigation behavior

## Files Changed
- `PlayerInternalNavigationBar.kt`: Updated navigation logic to use direct navigation and enable state saving
- `AppNavigation.kt`: Reduced bottom nav transition duration to 250ms

Fixes the reported issue of unresponsive tab switching and lag when accessing the Library.