### PR TITLE
perf: optimize detail screens (Genre, Album, Artist) performance

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/GenreSortBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/GenreSortBottomSheet.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.theveloper.pixelplay.presentation.screens.SortOption
+import com.theveloper.pixelplay.presentation.viewmodel.SortOption
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/GenreDetailViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/GenreDetailViewModel.kt
@@ -12,19 +12,86 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
-// Define Item Types for LazyColumn
-sealed interface GroupedSongListItem {
-    data class ArtistHeader(val name: String) : GroupedSongListItem
-    data class AlbumHeader(val name: String, val artistName: String, val albumArtUri: String?) : GroupedSongListItem
-    data class SongItem(val song: Song) : GroupedSongListItem
+// --- Model Types for Sectioned Display ---
+
+enum class SortOption { ARTIST, ALBUM, TITLE }
+
+data class AlbumData(
+    val name: String,
+    val artUri: String?,
+    val songs: List<Song>
+)
+
+sealed class SectionData {
+    abstract val id: String
+
+    data class ArtistSection(
+        override val id: String,
+        val artistName: String,
+        val albums: List<AlbumData>
+    ) : SectionData()
+
+    data class AlbumSection(
+        override val id: String,
+        val album: AlbumData
+    ) : SectionData()
+
+    data class FlatList(
+        val songs: List<Song>
+    ) : SectionData() {
+        override val id = "flat_list"
+    }
+}
+
+/**
+ * Representa un elemento visual en la lista aplanada para mejorar el rendimiento de LazyColumn.
+ */
+sealed class GenreDetailListItem {
+    abstract val key: String
+
+    data class ArtistHeader(
+        override val key: String,
+        val artistName: String,
+        val artistImageUrl: String? = null
+    ) : GenreDetailListItem()
+
+    data class AlbumHeader(
+        override val key: String,
+        val album: AlbumData,
+        val useArtistStyle: Boolean
+    ) : GenreDetailListItem()
+
+    data class SongItem(
+        override val key: String,
+        val song: Song,
+        val isFirstInAlbum: Boolean,
+        val isLastInAlbum: Boolean,
+        val isLastAlbumInSection: Boolean,
+        val useArtistStyle: Boolean
+    ) : GenreDetailListItem()
+
+    data class Spacer(
+        override val key: String,
+        val heightDp: Int,
+        val useSurfaceBackground: Boolean = false
+    ) : GenreDetailListItem()
+
+    data class Divider(
+        override val key: String
+    ) : GenreDetailListItem()
 }
 
 data class GenreDetailUiState(
     val genre: Genre? = null,
     val songs: List<Song> = emptyList(),
-    val groupedSongs: List<GroupedSongListItem> = emptyList(),
+    val sortedSongs: List<Song> = emptyList(), // 为播放逻辑预留的已排序副本
+    val displaySections: List<SectionData> = emptyList(),
+    val flattenedItems: List<GenreDetailListItem> = emptyList(),
+    val sortOption: SortOption = SortOption.ARTIST,
     val isLoadingGenreName: Boolean = false,
     val isLoadingSongs: Boolean = false,
     val error: String? = null
@@ -39,6 +106,8 @@ class GenreDetailViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(GenreDetailUiState())
     val uiState: StateFlow<GenreDetailUiState> = _uiState.asStateFlow()
 
+    private var artistMap: Map<String, String?> = emptyMap()
+
     init {
         savedStateHandle.get<String>("genreId")?.let { genreId ->
             val decodedGenreId = java.net.URLDecoder.decode(genreId, "UTF-8")
@@ -48,32 +117,59 @@ class GenreDetailViewModel @Inject constructor(
         }
     }
 
+    private data class ProcessingResult(
+        val genre: Genre,
+        val songs: List<Song>,
+        val sortedSongs: List<Song>,
+        val sections: List<SectionData>,
+        val flattened: List<GenreDetailListItem>
+    )
+
     private fun loadGenreDetails(genreId: String) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoadingGenreName = true, error = null)
+            _uiState.value = _uiState.value.copy(isLoadingGenreName = true, isLoadingSongs = true, error = null)
 
             try {
-                // Step 1: Find the genre object by its ID.
-                val genres = musicRepository.getGenres().first()
-                val foundGenre = genres.find { it.id.equals(genreId, ignoreCase = true) }
-                    ?: Genre(
-                        id = genreId,
-                        name = genreId.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }, // Fallback name from ID
-                        lightColorHex = "#9E9E9E", onLightColorHex = "#000000",
-                        darkColorHex = "#616161", onDarkColorHex = "#FFFFFF"
-                    )
+                // Step 1: Fast load of the Genre object to stabilize the UI theme as early as possible.
+                // This prevents a major recomposition (theme switch) mid-animation.
+                val initialGenre = withContext(Dispatchers.Default) {
+                    val genres = musicRepository.getGenres().first()
+                    genres.find { it.id.equals(genreId, ignoreCase = true) }
+                }
+                
+                if (initialGenre != null) {
+                    _uiState.value = _uiState.value.copy(genre = initialGenre, isLoadingGenreName = false)
+                }
 
-                _uiState.value = _uiState.value.copy(genre = foundGenre, isLoadingGenreName = false, isLoadingSongs = true)
+                // Step 2: Heavy data processing for songs and sections
+                val result = withContext(Dispatchers.Default) {
+                    val genres = musicRepository.getGenres().first()
+                    val genre = initialGenre ?: genres.find { it.id.equals(genreId, ignoreCase = true) }
+                        ?: Genre(
+                            id = genreId,
+                            name = genreId.replace("_", " ").replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }, 
+                            lightColorHex = "#9E9E9E", onLightColorHex = "#000000",
+                            darkColorHex = "#616161", onDarkColorHex = "#FFFFFF"
+                        )
 
-                // Step 2: Fetch songs using the genre's NAME.
-                val listOfSongs = musicRepository.getMusicByGenre(foundGenre.name).first()
+                    val songs = musicRepository.getMusicByGenre(genre.name).first()
+                    val artists = musicRepository.getArtists().first()
+                    artistMap = artists.associate { it.name.trim().lowercase() to it.imageUrl }
 
-                // Step 3: Group the songs for display.
-                val groupedSongs = groupSongs(listOfSongs)
+                    val sections = buildDisplaySections(songs, SortOption.ARTIST)
+                    val flattened = flattenSections(sections, artistMap)
+                    val sorted = songs.sortedBy { it.artist ?: "Unknown Artist" }
+                    
+                    ProcessingResult(genre, songs, sorted, sections, flattened)
+                }
 
                 _uiState.value = _uiState.value.copy(
-                    songs = listOfSongs,
-                    groupedSongs = groupedSongs,
+                    genre = result.genre,
+                    songs = result.songs,
+                    sortedSongs = result.sortedSongs,
+                    displaySections = result.sections,
+                    flattenedItems = result.flattened,
+                    isLoadingGenreName = false,
                     isLoadingSongs = false
                 )
             } catch (e: Exception) {
@@ -86,20 +182,125 @@ class GenreDetailViewModel @Inject constructor(
         }
     }
 
-    private fun groupSongs(songs: List<Song>): List<GroupedSongListItem> {
-        val newGroupedList = mutableListOf<GroupedSongListItem>()
-        songs.groupBy { it.artist }
-            .forEach { (artistName, artistSongs) ->
-                newGroupedList.add(GroupedSongListItem.ArtistHeader(artistName))
-                artistSongs.groupBy { it.album }
-                    .forEach { (albumName, albumSongs) ->
-                        val albumArtUri = albumSongs.firstOrNull()?.albumArtUriString
-                        newGroupedList.add(GroupedSongListItem.AlbumHeader(albumName, artistName, albumArtUri))
-                        albumSongs.forEach { song ->
-                            newGroupedList.add(GroupedSongListItem.SongItem(song))
+    /**
+     * Updates the sort option and re-groups the songs.
+     */
+    fun updateSortOption(newSort: SortOption) {
+        val currentState = _uiState.value
+        if (currentState.sortOption == newSort) return
+
+        viewModelScope.launch {
+            _uiState.value = currentState.copy(isLoadingSongs = true)
+            val (updatedSections, updatedFlattened, updatedSorted) = withContext(Dispatchers.Default) {
+                val sections = buildDisplaySections(currentState.songs, newSort)
+                val flattened = flattenSections(sections, artistMap)
+                val sorted = when (newSort) {
+                    SortOption.ARTIST -> currentState.songs.sortedBy { it.artist ?: "Unknown Artist" }
+                    SortOption.ALBUM -> currentState.songs.sortedBy { it.album ?: "Unknown Album" }
+                    SortOption.TITLE -> currentState.songs.sortedBy { it.title }
+                }
+                Triple(sections, flattened, sorted)
+            }
+            _uiState.value = currentState.copy(
+                sortOption = newSort,
+                displaySections = updatedSections,
+                flattenedItems = updatedFlattened,
+                sortedSongs = updatedSorted,
+                isLoadingSongs = false
+            )
+        }
+    }
+
+    private fun flattenSections(sections: List<SectionData>, artistMap: Map<String, String?> = emptyMap()): List<GenreDetailListItem> {
+        val items = mutableListOf<GenreDetailListItem>()
+        sections.forEach { section ->
+            when (section) {
+                is SectionData.ArtistSection -> {
+                    items.add(GenreDetailListItem.ArtistHeader(
+                        key = "header_${section.id}", 
+                        artistName = section.artistName,
+                        artistImageUrl = artistMap[section.artistName.trim().lowercase()]
+                    ))
+                    section.albums.forEachIndexed { albumIndex, album ->
+                        if (albumIndex > 0) {
+                            items.add(GenreDetailListItem.Divider("divider_${section.id}_$albumIndex"))
+                        }
+                        
+                        items.add(GenreDetailListItem.AlbumHeader("${section.id}_album_header_${album.name}", album, true))
+                        items.add(GenreDetailListItem.Spacer("${section.id}_album_spacer_${album.name}", 10, true))
+                        
+                        album.songs.forEachIndexed { songIndex, song ->
+                            items.add(GenreDetailListItem.SongItem(
+                                key = "${section.id}_${album.name}_${song.id}",
+                                song = song,
+                                isFirstInAlbum = songIndex == 0,
+                                isLastInAlbum = songIndex == album.songs.lastIndex,
+                                isLastAlbumInSection = albumIndex == section.albums.lastIndex,
+                                useArtistStyle = true
+                            ))
                         }
                     }
+                }
+                is SectionData.AlbumSection -> {
+                    val album = section.album
+                    items.add(GenreDetailListItem.AlbumHeader("${section.id}_album_header_${album.name}", album, false))
+                    items.add(GenreDetailListItem.Spacer("${section.id}_album_spacer_${album.name}", 10, true))
+                    
+                    album.songs.forEachIndexed { songIndex, song ->
+                        items.add(GenreDetailListItem.SongItem(
+                            key = "${section.id}_${song.id}",
+                            song = song,
+                            isFirstInAlbum = songIndex == 0,
+                            isLastInAlbum = songIndex == album.songs.lastIndex,
+                            isLastAlbumInSection = true,
+                            useArtistStyle = false
+                        ))
+                    }
+                }
+                is SectionData.FlatList -> {
+                    section.songs.forEach { song ->
+                        items.add(GenreDetailListItem.SongItem(
+                            key = "flat_${song.id}",
+                            song = song,
+                            isFirstInAlbum = false,
+                            isLastInAlbum = false,
+                            isLastAlbumInSection = false,
+                            useArtistStyle = false
+                        ))
+                    }
+                }
             }
-        return newGroupedList
+            items.add(GenreDetailListItem.Spacer("section_spacer_${section.id}", 16))
+        }
+        return items
+    }
+
+    private fun buildDisplaySections(songs: List<Song>, sort: SortOption): List<SectionData> {
+        return when (sort) {
+            SortOption.ARTIST -> {
+                val sorted = songs.sortedBy { it.artist ?: "Unknown Artist" }
+                val grouped = sorted.groupBy { it.artist ?: "Unknown Artist" }
+                grouped.map { (artist, artistSongs) ->
+                    val albums = artistSongs.groupBy { it.album ?: "Unknown Album" }.map { (albumName, albumSongs) ->
+                        AlbumData(albumName, albumSongs.firstOrNull()?.albumArtUriString, albumSongs)
+                    }
+                    SectionData.ArtistSection("artist_$artist", artist, albums)
+                }
+            }
+            SortOption.ALBUM -> {
+                val sorted = songs.sortedBy { it.album ?: "Unknown Album" }
+                val grouped = sorted.groupBy { it.album ?: "Unknown Album" }
+                grouped.map { (album, albumSongs) ->
+                    SectionData.AlbumSection(
+                        "album_$album",
+                        AlbumData(album, albumSongs.firstOrNull()?.albumArtUriString, albumSongs)
+                    )
+                }
+            }
+            SortOption.TITLE -> {
+                listOf(SectionData.FlatList(songs.sortedBy { it.title }))
+            }
+        }
     }
 }
+


### PR DESCRIPTION
### Detailed Changes
- **Navigation Smoothness**: Implemented deferred rendering (using `isTransitionFinished`) for large track lists in Genre, Album, and Artist screens to ensure 60 FPS slide-in animations.
- **Scrolling Performance**: Migrated `LazyColumn` from dynamic `contentPadding` to draw-phase `Modifier.offset` to avoid expensive layout re-measurements.
- **Hardware Acceleration**: Optimized `ScreenWrapper` with `graphicsLayer` for hardware-accelerated composite clipping and shared transitions.
- **Large List Handling**: Refactored `GenreDetailViewModel` and added title placeholders to eliminate UI freezing and 'jumping' when opening genres with thousands of songs.