### PR TITLE
ui: adjust header height and title padding on Equalizer screen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
@@ -228,7 +228,7 @@ fun EqualizerScreen(
     
     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val minTopBarHeight = 64.dp + statusBarHeight
-    val maxTopBarHeight = 160.dp
+    val maxTopBarHeight = 180.dp
     
     val minTopBarHeightPx = with(density) { minTopBarHeight.toPx() }
     val maxTopBarHeightPx = with(density) { maxTopBarHeight.toPx() }
@@ -378,8 +378,8 @@ fun EqualizerScreen(
             collapseFraction = collapseFraction,
             headerHeight = currentTopBarHeightDp,
             onBackClick = { navController.popBackStack() },
-            expandedTitleStartPadding = 18.dp, // Matches original 18.dp
-            collapsedTitleStartPadding = 68.dp,
+            expandedTitleStartPadding = 20.dp,
+            collapsedTitleStartPadding = 72.dp,
             actions = {
                 // View Mode Toggle
                 FilledIconButton(


### PR DESCRIPTION
- **Layout**:
    - Increase `maxTopBarHeight` from 160.dp to 180.dp to provide more vertical space for the expanded header.
- **Styling**:
    - Update title horizontal padding for better alignment: - Increase `expandedTitleStartPadding` from 18.dp to 20.dp. - Increase `collapsedTitleStartPadding` from 68.dp to 72.dp.