### PR TITLE
fix: player not pausing on audio output change

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -361,7 +361,7 @@ class DualPlayerEngine @Inject constructor(
                     .setAudioOffloadPreferences(offloadDisabledPrefs)
                     .build()
             )
-            setHandleAudioBecomingNoisy(handleAudioFocus)
+            setHandleAudioBecomingNoisy(true) // Force player to pause automatically when audio is rerouted from a headset to device speakers
             setWakeMode(C.WAKE_MODE_LOCAL) // Use CPU lock only. WiFi lock unused as we proxy via localhost. Saves battery.
             // Explicitly keep both players live so they can overlap without affecting each other
             playWhenReady = false


### PR DESCRIPTION
## What’s changed

Restore handling for audio output changes so player pauses when headphones or earbuds are disconnected.

## Why

I was fixing this behaviour on #852, but this issue appears again after later changes. Currently, player may continue through device speakers when audio output changes, which is unexpected.

This PR ensures `setHandleAudioBecomingNoisy(true)` is properly applied again by force it to true since `handleAudioFocus` value always false in `DualPlayerEngine.kt`.

Fixed #845, #691
