### PR TITLE
feat: refactor lyrics storage and optimize song metadata management

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/LyricsDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/LyricsDao.kt
@@ -24,4 +24,7 @@ interface LyricsDao {
 
     @Query("SELECT * FROM lyrics")
     suspend fun getAll(): List<LyricsEntity>
+
+    @Query("SELECT songId FROM lyrics WHERE songId IN (:songIds) AND content != ''")
+    suspend fun getSongIdsWithLyrics(songIds: List<Long>): List<Long>
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -11,6 +11,32 @@ import androidx.sqlite.db.SimpleSQLiteQuery
 import com.theveloper.pixelplay.utils.AudioMeta
 import kotlinx.coroutines.flow.Flow
 
+private const val SONG_DETAIL_PROJECTION = """
+    songs.id AS id,
+    songs.title AS title,
+    songs.artist_name AS artist_name,
+    songs.artist_id AS artist_id,
+    songs.album_artist AS album_artist,
+    songs.album_name AS album_name,
+    songs.album_id AS album_id,
+    songs.content_uri_string AS content_uri_string,
+    songs.album_art_uri_string AS album_art_uri_string,
+    songs.duration AS duration,
+    songs.genre AS genre,
+    songs.file_path AS file_path,
+    songs.parent_directory_path AS parent_directory_path,
+    songs.is_favorite AS is_favorite,
+    COALESCE(song_lyrics.content, songs.lyrics) AS lyrics,
+    songs.track_number AS track_number,
+    songs.year AS year,
+    songs.date_added AS date_added,
+    songs.mime_type AS mime_type,
+    songs.bitrate AS bitrate,
+    songs.sample_rate AS sample_rate,
+    songs.telegram_chat_id AS telegram_chat_id,
+    songs.telegram_file_id AS telegram_file_id
+"""
+
 @Dao
 interface MusicDao {
 
@@ -242,13 +268,32 @@ interface MusicDao {
     @Query("SELECT * FROM songs WHERE id IN (:songIds)")
     suspend fun getSongsByIdsListSimple(songIds: List<Long>): List<SongEntity>
 
-    @Query("SELECT * FROM songs WHERE id = :songId")
+    @Query(
+        "SELECT " + SONG_DETAIL_PROJECTION + """
+        FROM songs
+        LEFT JOIN lyrics AS song_lyrics ON song_lyrics.songId = songs.id
+        WHERE songs.id = :songId
+        """
+    )
     fun getSongById(songId: Long): Flow<SongEntity?>
 
-    @Query("SELECT * FROM songs WHERE id = :songId")
+    @Query(
+        "SELECT " + SONG_DETAIL_PROJECTION + """
+        FROM songs
+        LEFT JOIN lyrics AS song_lyrics ON song_lyrics.songId = songs.id
+        WHERE songs.id = :songId
+        """
+    )
     suspend fun getSongByIdOnce(songId: Long): SongEntity?
     
-    @Query("SELECT * FROM songs WHERE file_path = :path LIMIT 1")
+    @Query(
+        "SELECT " + SONG_DETAIL_PROJECTION + """
+        FROM songs
+        LEFT JOIN lyrics AS song_lyrics ON song_lyrics.songId = songs.id
+        WHERE songs.file_path = :path
+        LIMIT 1
+        """
+    )
     suspend fun getSongByPath(path: String): SongEntity?
 
     //@Query("SELECT * FROM songs WHERE id IN (:songIds)")
@@ -795,14 +840,13 @@ interface MusicDao {
         return newStatus
     }
 
-    @Query("UPDATE songs SET title = :title, artist_name = :artist, album_name = :album, genre = :genre, lyrics = :lyrics, track_number = :trackNumber WHERE id = :songId")
+    @Query("UPDATE songs SET title = :title, artist_name = :artist, album_name = :album, genre = :genre, track_number = :trackNumber WHERE id = :songId")
     suspend fun updateSongMetadata(
         songId: Long,
         title: String,
         artist: String,
         album: String,
         genre: String?,
-        lyrics: String?,
         trackNumber: Int
     )
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -24,7 +24,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         GDriveSongEntity::class,
         GDriveFolderEntity::class
     ],
-    version = 24, // Incremented for query performance indexes
+    version = 25, // Clear duplicated lyrics payloads from songs rows
 
     exportSchema = false
 )
@@ -457,6 +457,14 @@ abstract class PixelPlayDatabase : RoomDatabase() {
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_songs_duration ON songs(duration)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_favorites_timestamp ON favorites(timestamp)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_song_engagements_play_count ON song_engagements(play_count)")
+            }
+        }
+
+        val MIGRATION_24_25 = object : Migration(24, 25) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Lyrics are already persisted in the dedicated lyrics table. Keeping a duplicate
+                // copy in songs rows makes broad SELECTs vulnerable to CursorWindow overflows.
+                db.execSQL("UPDATE songs SET lyrics = NULL WHERE lyrics IS NOT NULL AND lyrics != ''")
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -120,7 +120,6 @@ class SongMetadataEditor(
             val trimmedLyrics = newLyrics.trim()
             val trimmedGenre = newGenre.trim()
             val normalizedGenre = trimmedGenre.takeIf { it.isNotBlank() }
-            val normalizedLyrics = trimmedLyrics.takeIf { it.isNotBlank() }
 
             // 1. FIRST: Get file path (Handle both MediaStore and Telegram/Negative IDs)
             val isTelegramSong = songId < 0
@@ -244,7 +243,6 @@ class SongMetadataEditor(
                     newArtist,
                     newAlbum,
                     normalizedGenre,
-                    normalizedLyrics,
                     newTrackNumber
                 )
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
@@ -1152,9 +1152,18 @@ class LyricsRepositoryImpl @Inject constructor(
         val updatedCount = AtomicInteger(0)
         val processedCount = AtomicInteger(0)
         val total = songs.size
-        
-        // Only scan songs that don't have lyrics
-        val songsToScan = songs.filter { it.lyrics.isNullOrBlank() }
+
+        val idsWithPersistedLyrics = songs
+            .mapNotNull { it.id.toLongOrNull() }
+            .chunked(900)
+            .flatMap { chunk -> lyricsDao.getSongIdsWithLyrics(chunk) }
+            .toHashSet()
+
+        // Only scan songs that don't already have persisted lyrics.
+        val songsToScan = songs.filter { song ->
+            val songId = song.id.toLongOrNull()
+            song.lyrics.isNullOrBlank() && (songId == null || songId !in idsWithPersistedLyrics)
+        }
         val skippedCount = total - songsToScan.size
         processedCount.addAndGet(skippedCount)
         

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -124,7 +124,8 @@ object AppModule {
             PixelPlayDatabase.MIGRATION_20_21,
             PixelPlayDatabase.MIGRATION_21_22,
             PixelPlayDatabase.MIGRATION_22_23,
-            PixelPlayDatabase.MIGRATION_23_24
+            PixelPlayDatabase.MIGRATION_23_24,
+            PixelPlayDatabase.MIGRATION_24_25
         )
             .fallbackToDestructiveMigration(dropAllTables = true)
             .build()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -110,6 +110,7 @@ fun DailyMixScreen(
     var showPlaylistBottomSheet by remember { mutableStateOf(false) }
     val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
+    val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
 
     val showAiSheet by playerViewModel.showAiPlaylistSheet.collectAsStateWithLifecycle()
     val isGeneratingAiPlaylist by playerViewModel.isGeneratingAiPlaylist.collectAsStateWithLifecycle()
@@ -117,7 +118,6 @@ fun DailyMixScreen(
     val lazyListState = rememberLazyListState()
 
     var showSongInfoSheet by remember { mutableStateOf(false) }
-    var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
     var showDailyMixMenu by remember { mutableStateOf(false) }
 
     if (showDailyMixMenu) {
@@ -310,7 +310,7 @@ fun DailyMixScreen(
                         isPlaying = currentSongId == song.id && isPlaying,
                         onClick = { playerViewModel.showAndPlaySong(song, dailyMixSongs, "Daily Mix", isVoluntaryPlay = false) },
                         onMoreOptionsClick = {
-                            selectedSongForInfo = song
+                            playerViewModel.selectSongForInfo(song)
                             showSongInfoSheet = true
                         }
                     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
@@ -114,13 +114,13 @@ fun RecentlyPlayedScreen(
         playerViewModel.stablePlayerState.map { it.isPlaying }.distinctUntilChanged()
     }.collectAsStateWithLifecycle(initialValue = false)
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
+    val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
     val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
 
     var selectedRange by rememberSaveable { mutableStateOf(StatsTimeRange.WEEK) }
     val lazyListState = rememberLazyListState()
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }
     var showPlaylistBottomSheet by remember { mutableStateOf(false) }
-    var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
     val bottomBarHeightDp = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
 
     val recentlyPlayedSongs = remember(playbackHistory, allSongs, selectedRange) {
@@ -239,7 +239,7 @@ fun RecentlyPlayedScreen(
                                     )
                                 },
                                 onMoreOptionsClick = { song ->
-                                    selectedSongForInfo = song
+                                    playerViewModel.selectSongForInfo(song)
                                     showSongInfoBottomSheet = true
                                 }
                             )
@@ -260,7 +260,6 @@ fun RecentlyPlayedScreen(
                 onDismiss = {
                     showSongInfoBottomSheet = false
                     showPlaylistBottomSheet = false
-                    selectedSongForInfo = null
                 },
                 onPlaySong = {
                     if (queueSongs.isNotEmpty()) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -139,8 +139,8 @@ fun SearchScreen(
     val genres by playerViewModel.genres.collectAsStateWithLifecycle()
     val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
+    val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
     var showSongInfoBottomSheet by remember { mutableStateOf(false) }
-    var selectedSongForInfo by remember { mutableStateOf<Song?>(null) }
     val keyboardController = LocalSoftwareKeyboardController.current
     val searchInputFocusRequester = remember { FocusRequester() }
 
@@ -162,7 +162,6 @@ fun SearchScreen(
     }
     val searchResults = uiState.searchResults
     val handleSongMoreOptionsClick: (Song) -> Unit = { song ->
-        selectedSongForInfo = song
         playerViewModel.selectSongForInfo(song)
         showSongInfoBottomSheet = true
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -3793,9 +3793,10 @@ class PlayerViewModel @Inject constructor(
 
     fun selectSongForInfo(song: Song) {
         _selectedSongForInfo.value = song
-        if (!song.requiresHydration()) return
         viewModelScope.launch {
-            val hydrated = musicRepository.getSongsByIds(listOf(song.id)).first().firstOrNull() ?: return@launch
+            val hydrated = withContext(Dispatchers.IO) {
+                musicRepository.getSong(song.id).first()
+            } ?: return@launch
             if (_selectedSongForInfo.value?.id == song.id) {
                 _selectedSongForInfo.value = hydrated
             }
@@ -4069,14 +4070,22 @@ class PlayerViewModel @Inject constructor(
             var failCount = 0
 
             songs.forEach { song ->
+                val sourceSong = if (song.lyrics != null) {
+                    song
+                } else {
+                    withContext(Dispatchers.IO) {
+                        musicRepository.getSong(song.id).first()
+                    } ?: song
+                }
+
                 val result = metadataEditStateHolder.saveMetadata(
-                    song = song,
-                    newTitle = song.title,
-                    newArtist = song.artist,
-                    newAlbum = song.album,
+                    song = sourceSong,
+                    newTitle = sourceSong.title,
+                    newArtist = sourceSong.artist,
+                    newAlbum = sourceSong.album,
                     newGenre = newGenre,
-                    newLyrics = (song.lyrics ?: ""), // Ensure lyrics are string
-                    newTrackNumber = song.trackNumber,
+                    newLyrics = sourceSong.lyrics ?: "",
+                    newTrackNumber = sourceSong.trackNumber,
                     coverArtUpdate = null
                 )
 


### PR DESCRIPTION
This commit migrates lyrics storage to a dedicated table to improve query performance and prevent `CursorWindow` overflows. It also centralizes the "selected song for info" state within the `PlayerViewModel` to ensure UI consistency across different screens.

- **Database & Persistence**:
    - Increment `PixelPlayDatabase` version to 25.
    - Implement `MIGRATION_24_25` to nullify duplicated lyrics in the `songs` table, favoring the dedicated `lyrics` table.
    - Update `MusicDao` with a `SONG_DETAIL_PROJECTION` that performs a `LEFT JOIN` on the `lyrics` table to fetch content seamlessly.
    - Update `updateSongMetadata` and `SongMetadataEditor` to stop saving lyrics directly into the `songs` row.
- **Lyrics Management**:
    - Add `getSongIdsWithLyrics` to `LyricsDao` to efficiently check for existing lyrics in bulk.
    - Refactor `LyricsRepositoryImpl` to skip scanning for songs that already have persisted lyrics in the new table.
- **State Management**:
    - Move `selectedSongForInfo` from local `@Composable` state to `PlayerViewModel` to share selection state across `DailyMixScreen`, `RecentlyPlayedScreen`, and `SearchScreen`.
    - Update `selectSongForInfo` in `PlayerViewModel` to automatically hydrate song data (including lyrics) from the repository when a song is selected for details.
- **Bug Fixes & Refinement**:
    - Fix a potential metadata loss issue in `PlayerViewModel` where bulk genre updates could overwrite existing lyrics with empty strings if the song wasn't fully hydrated.
    - Ensure database operations in `PlayerViewModel` use `Dispatchers.IO` for thread safety.
    - Clean up redundant "more options" state handling in various feature screens.