### PR TITLE
ui: standardize favorite button styling

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/MultiSelectionBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/MultiSelectionBottomSheet.kt
@@ -1,7 +1,9 @@
 package com.theveloper.pixelplay.presentation.components
 
 import android.app.Activity
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -114,6 +116,27 @@ fun MultiSelectionBottomSheet(
         cornerRadiusTL = evenCornerRadius, smoothnessAsPercentBL = 60,
         cornerRadiusBL = evenCornerRadius, smoothnessAsPercentTR = 60
     )
+
+    val favoriteButtonCornerRadius by animateDpAsState(
+        targetValue = if (allAreLiked) evenCornerRadius else 60.dp,
+        animationSpec = tween(durationMillis = 300), label = "FavoriteCornerAnimation"
+    )
+    val favoriteButtonContainerColor by animateColorAsState(
+        targetValue = if (allAreLiked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+        animationSpec = tween(durationMillis = 300), label = "FavoriteContainerColorAnimation"
+    )
+    val favoriteButtonContentColor by animateColorAsState(
+        targetValue = if (allAreLiked) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(durationMillis = 300), label = "FavoriteContentColorAnimation"
+    )
+
+    val favoriteButtonShape = remember(favoriteButtonCornerRadius) {
+        AbsoluteSmoothCornerShape(
+            cornerRadiusTR = favoriteButtonCornerRadius, smoothnessAsPercentBR = 60, cornerRadiusBR = favoriteButtonCornerRadius,
+            smoothnessAsPercentTL = 60, cornerRadiusTL = favoriteButtonCornerRadius, smoothnessAsPercentBL = 60,
+            cornerRadiusBL = favoriteButtonCornerRadius, smoothnessAsPercentTR = 60
+        )
+    }
     
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -228,24 +251,18 @@ fun MultiSelectionBottomSheet(
                                     onToggleLikeAll(!allAreLiked) // true = like all, false = unlike all
                                     onDismiss()
                                 },
-                                shape = buttonShape,
+                                shape = favoriteButtonShape,
                                 colors = IconButtonDefaults.filledIconButtonColors(
-                                    containerColor = if (allAreLiked) 
-                                        MaterialTheme.colorScheme.surfaceContainerHigh 
-                                    else 
-                                        MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = if (allAreLiked) 
-                                        MaterialTheme.colorScheme.onSurfaceVariant 
-                                    else 
-                                        MaterialTheme.colorScheme.onSecondaryContainer
+                                    containerColor = favoriteButtonContainerColor,
+                                    contentColor = favoriteButtonContentColor
                                 )
                             ) {
                                 Icon(
                                     modifier = Modifier.size(FloatingActionButtonDefaults.LargeIconSize),
                                     imageVector = if (allAreLiked) 
                                         Icons.Rounded.HeartBroken 
-                                    else 
-                                        Icons.Rounded.Favorite,
+                                    else
+                                        Icons.Rounded.FavoriteBorder,
                                     contentDescription = if (allAreLiked) "Unlike all" else "Like all"
                                 )
                             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/BottomToggleRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/BottomToggleRow.kt
@@ -113,7 +113,7 @@ fun BottomToggleRow(
                 inactiveColor = inactiveColor,
                 inactiveContentColor = inactiveContentColor,
                 onClick = onFavoriteToggle,
-                iconId = R.drawable.round_favorite_24,
+                iconId = if (isFavorite) R.drawable.round_favorite_24 else R.drawable.rounded_favorite_24,
                 contentDesc = "Favorite"
             )
         }


### PR DESCRIPTION
## Summary
Change favorite button visuals in lyrics sheet inside bottom toggle row, and in multi selection bottom sheet

---

### Lyrics Sheet
Update non-favorited state button to outline, matching player button
<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/aa554fc7-cd11-4678-a070-28274e56d73c" />

---

### Multi Selection Bottom Sheet
Single song (not changed, for reference only)
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/a8a08215-2595-4674-95dd-7c1720c59a85" />

non-favorited state
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/e2ad91af-9c9e-44f9-8b63-4aa14022a0b6" />

favorited state
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/036722e5-bdd9-4cea-b1a8-a0251da63968" />
