### PR TITLE
ui: refine selection index display in selection mode

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
@@ -318,7 +318,7 @@ fun EnhancedSongListItem(
                             ) {
                                 if (selectionIndex != null && selectionIndex >= 0) {
                                     Text(
-                                        text = "${selectionIndex + 1}",
+                                        text = "$selectionIndex",
                                         style = MaterialTheme.typography.titleMedium,
                                         fontWeight = FontWeight.Bold,
                                         color = colors.onPrimary

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -1253,6 +1253,7 @@ fun LibraryScreen(
                                             selectedSongIds = selectedSongIds,
                                             onSongLongPress = onSongLongPress,
                                             onSongSelectionToggle = onSongSelectionToggle,
+                                            getSelectionIndex = playerViewModel.multiSelectionStateHolder::getSelectionIndex,
                                             onLocateCurrentSongVisibilityChanged = { songsShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { songsLocateAction = it },
                                             sortOption = playerUiState.currentSongSortOption,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -71,6 +71,7 @@ fun LibrarySongsTab(
     selectedSongIds: Set<String> = emptySet(),
     onSongLongPress: (Song) -> Unit = {},
     onSongSelectionToggle: (Song) -> Unit = {},
+    getSelectionIndex: (String) -> Int? = { null },
     onLocateCurrentSongVisibilityChanged: (Boolean) -> Unit = {},
     onRegisterLocateCurrentSongAction: ((() -> Unit)?) -> Unit = {},
     storageFilter: StorageFilter = StorageFilter.ALL
@@ -313,6 +314,7 @@ fun LibrarySongsTab(
                                         isLoading = false,
                                         isSelected = isSelected,
                                         isSelectionMode = isSelectionMode,
+                                        selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,
                                         onLongPress = rememberedOnLongPress,
                                         onMoreOptionsClick = rememberedOnMoreOptionsClick,
                                         onClick = rememberedOnClick


### PR DESCRIPTION
1. Fix selection order text to use index value directly in `EnhancedSongListItem.kt`. Previously we use index + 1, resulting the text start from "2" instead of from "1"
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/6efa310b-9a27-4216-8aed-b94325d7388e" />

2. Pass selection index to song tab so they display the selection order instead of show circle check icon
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/e0cae872-1960-45b1-b3ea-60060e0ad21e" />
