### PR TITLE
feat(ui): implement back press handling for multi-selection in Library

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -548,6 +548,7 @@ fun LibraryScreen(
     val playlistMultiSelectionState = playerViewModel.playlistSelectionStateHolder
     val selectedPlaylists by playlistMultiSelectionState.selectedPlaylists.collectAsStateWithLifecycle()
     val selectedPlaylistIds by playlistMultiSelectionState.selectedPlaylistIds.collectAsStateWithLifecycle()
+    val isPlaylistSelectionMode by playlistMultiSelectionState.isSelectionMode.collectAsStateWithLifecycle()
     var showPlaylistMultiSelectionSheet by remember { mutableStateOf(false) }
     var showMergePlaylistDialog by remember { mutableStateOf(false) }
     var pendingMergePlaylistIds by remember { mutableStateOf(emptyList<String>()) }
@@ -603,13 +604,50 @@ fun LibraryScreen(
         }
     }
 
-    BackHandler(
-        enabled =
-            currentTabId == LibraryTabId.FOLDERS &&
-                    canNavigateBackInFolders &&
-                    !isSortSheetVisible
-    ) {
-        playerViewModel.navigateBackFolder()
+    val hasSelectionInCurrentTab = when (currentTabId) {
+        LibraryTabId.PLAYLISTS -> isPlaylistSelectionMode
+        LibraryTabId.ALBUMS -> isAlbumSelectionMode
+        LibraryTabId.SONGS,
+        LibraryTabId.LIKED,
+        LibraryTabId.FOLDERS -> isSelectionMode
+        LibraryTabId.ARTISTS -> false
+    }
+    val canHandleFolderBack =
+        currentTabId == LibraryTabId.FOLDERS &&
+            canNavigateBackInFolders &&
+            !isSortSheetVisible
+
+    BackHandler(enabled = hasSelectionInCurrentTab || canHandleFolderBack) {
+        when {
+            hasSelectionInCurrentTab -> {
+                when (currentTabId) {
+                    LibraryTabId.PLAYLISTS -> {
+                        playlistMultiSelectionState.clearSelection()
+                        showPlaylistMultiSelectionSheet = false
+                        showMergePlaylistDialog = false
+                        pendingMergePlaylistIds = emptyList()
+                    }
+
+                    LibraryTabId.ALBUMS -> {
+                        selectedAlbums = emptyList()
+                        showAlbumMultiSelectionSheet = false
+                    }
+
+                    LibraryTabId.SONGS,
+                    LibraryTabId.LIKED,
+                    LibraryTabId.FOLDERS -> {
+                        multiSelectionState.clearSelection()
+                        showMultiSelectionSheet = false
+                    }
+
+                    LibraryTabId.ARTISTS -> Unit
+                }
+            }
+
+            canHandleFolderBack -> {
+                playerViewModel.navigateBackFolder()
+            }
+        }
     }
 
     // Feedback for Playlist Creation
@@ -944,8 +982,6 @@ fun LibraryScreen(
 
                         val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
                         val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
-                        val isPlaylistSelectionMode by playlistMultiSelectionState.isSelectionMode.collectAsStateWithLifecycle()
-
                         val favoritePagingItems = libraryViewModel.favoritesPagingFlow.collectAsLazyPagingItems()
 
                         val currentSelectedSortOption: SortOption? = when (currentTabId) {


### PR DESCRIPTION
- **Library Screen**:
    - Update `BackHandler` logic to prioritize clearing active selections over folder navigation when the back button is pressed.
    - Implement tab-specific selection clearing for Playlists, Albums, Songs, Liked, and Folders.
    - Ensure multi-selection sheets and pending dialog states are reset upon exiting selection mode via back press.
    - Refactor `isPlaylistSelectionMode` state observation to a higher scope to support the enhanced back navigation logic.