### PR TITLE
feat: implement Telegram Cloud playlist visibility toggle in Library

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
@@ -37,6 +37,8 @@ class PlaylistPreferencesRepository @Inject constructor(
     val playlistSongOrderModesFlow: Flow<Map<String, String>> =
         userPreferencesRepository.playlistSongOrderModesFlow
     val playlistsSortOptionFlow: Flow<String> = userPreferencesRepository.playlistsSortOptionFlow
+    val showTelegramCloudPlaylistsFlow: Flow<Boolean> =
+        userPreferencesRepository.showTelegramCloudPlaylistsFlow
 
     suspend fun createPlaylist(
         name: String,
@@ -153,6 +155,9 @@ class PlaylistPreferencesRepository @Inject constructor(
 
     suspend fun setPlaylistsSortOption(optionKey: String) =
         userPreferencesRepository.setPlaylistsSortOption(optionKey)
+
+    suspend fun setShowTelegramCloudPlaylists(show: Boolean) =
+        userPreferencesRepository.setShowTelegramCloudPlaylists(show)
 
     suspend fun getPlaylistsOnce(): List<Playlist> {
         ensureMigratedIfNeeded()

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -108,6 +108,7 @@ constructor(
         val LIBRARY_TABS_ORDER = stringPreferencesKey("library_tabs_order")
         val IS_FOLDER_FILTER_ACTIVE = booleanPreferencesKey("is_folder_filter_active")
         val IS_FOLDERS_PLAYLIST_VIEW = booleanPreferencesKey("is_folders_playlist_view")
+        val SHOW_TELEGRAM_CLOUD_PLAYLISTS = booleanPreferencesKey("show_telegram_cloud_playlists")
         val FOLDERS_SOURCE = stringPreferencesKey("folders_source")
         val FOLDER_BACK_GESTURE_NAVIGATION = booleanPreferencesKey("folder_back_gesture_navigation")
         val USE_SMOOTH_CORNERS = booleanPreferencesKey("use_smooth_corners")
@@ -1291,6 +1292,11 @@ constructor(
             preferences[PreferencesKeys.IS_FOLDERS_PLAYLIST_VIEW] ?: false
         }
 
+    val showTelegramCloudPlaylistsFlow: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.SHOW_TELEGRAM_CLOUD_PLAYLISTS] ?: true
+        }
+
     val foldersSourceFlow: Flow<FolderSource> = dataStore.data
         .map { preferences ->
             FolderSource.fromStorageKey(preferences[PreferencesKeys.FOLDERS_SOURCE])
@@ -1315,6 +1321,12 @@ constructor(
     suspend fun setFoldersPlaylistView(isPlaylistView: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.IS_FOLDERS_PLAYLIST_VIEW] = isPlaylistView
+        }
+    }
+
+    suspend fun setShowTelegramCloudPlaylists(show: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.SHOW_TELEGRAM_CLOUD_PLAYLISTS] = show
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
@@ -54,6 +54,8 @@ fun LibrarySortBottomSheet(
     onDismiss: () -> Unit,
     onOptionSelected: (SortOption) -> Unit,
     showViewToggle: Boolean = false,
+    viewSectionTitle: String = "View",
+    viewToggleLabel: String = "Playlist View",
     viewToggleChecked: Boolean = false,
     onViewToggleChange: (Boolean) -> Unit = {},
     viewToggleContent: (@Composable () -> Unit)? = null,
@@ -164,94 +166,25 @@ fun LibrarySortBottomSheet(
             }
 
             if (showViewToggle || viewToggleContent != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = viewSectionTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontFamily = GoogleSansRounded,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 2.dp, top = 8.dp, bottom = 8.dp)
+                )
+
                 if (viewToggleContent != null) {
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Text(
-                        text = "View",
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontFamily = GoogleSansRounded,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(start = 2.dp, top = 8.dp, bottom = 8.dp)
-                    )
-                    
                     viewToggleContent()
                 } else {
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Text(
-                        text = "View",
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontFamily = GoogleSansRounded,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(start = 2.dp, top = 8.dp, bottom = 8.dp)
+                    LibrarySheetToggleCard(
+                        label = viewToggleLabel,
+                        checked = viewToggleChecked,
+                        boxBackgroundColor = boxBackgroundColor,
+                        boxCornerRadius = boxCornerRadius,
+                        onCheckedChange = onViewToggleChange
                     )
-
-                    val viewContainerColor = remember(viewToggleChecked) {
-                        if (viewToggleChecked) selectedColor else unselectedColor
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 0.dp)
-                            .clip(
-                                AbsoluteSmoothCornerShape(
-                                    cornerRadiusBL = boxCornerRadius,
-                                    smoothnessAsPercentBR = 60,
-                                    cornerRadiusTR = boxCornerRadius,
-                                    smoothnessAsPercentTL = 60,
-                                    cornerRadiusTL = boxCornerRadius,
-                                    smoothnessAsPercentBL = 60,
-                                    cornerRadiusBR = boxCornerRadius,
-                                    smoothnessAsPercentTR = 60
-                                )
-                            ) // Apply animated corner radius for clipping
-                            .background(color = boxBackgroundColor)   // Apply animated background color
-                            .clickable(
-                                onClick = {
-                                    onViewToggleChange(!viewToggleChecked)
-                                }
-                            )
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp, horizontal = 16.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "Playlist View",
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(start = 6.dp, end = 8.dp),
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = if (viewToggleChecked) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onSurface // Adjust text color for contrast
-                            )
-                            Switch(
-                                checked = viewToggleChecked,
-                                onCheckedChange = {
-                                    onViewToggleChange(it)
-                                },
-                                colors = SwitchDefaults.colors(
-                                    checkedThumbColor = MaterialTheme.colorScheme.tertiary,
-                                    checkedTrackColor = MaterialTheme.colorScheme.tertiaryContainer,
-                                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant
-                                ),
-                                thumbContent = if (viewToggleChecked) {
-                                    {
-                                        Icon(
-                                            imageVector = Icons.Rounded.Check,
-                                            contentDescription = "Switch is on",
-                                            tint = MaterialTheme.colorScheme.tertiaryContainer,
-                                            modifier = Modifier.size(SwitchDefaults.IconSize),
-                                        )
-                                    }
-                                } else {
-                                    null
-                                }
-                            )
-                        }
-                    }
                 }
             }
 
@@ -268,6 +201,73 @@ fun LibrarySortBottomSheet(
             }
 
             Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun LibrarySheetToggleCard(
+    label: String,
+    checked: Boolean,
+    boxBackgroundColor: Color,
+    boxCornerRadius: androidx.compose.ui.unit.Dp,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 0.dp)
+            .clip(
+                AbsoluteSmoothCornerShape(
+                    cornerRadiusBL = boxCornerRadius,
+                    smoothnessAsPercentBR = 60,
+                    cornerRadiusTR = boxCornerRadius,
+                    smoothnessAsPercentTL = 60,
+                    cornerRadiusTL = boxCornerRadius,
+                    smoothnessAsPercentBL = 60,
+                    cornerRadiusBR = boxCornerRadius,
+                    smoothnessAsPercentTR = 60
+                )
+            )
+            .background(color = boxBackgroundColor)
+            .clickable(onClick = { onCheckedChange(!checked) })
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp, horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 6.dp, end = 8.dp),
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (checked) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onSurface
+            )
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = MaterialTheme.colorScheme.tertiary,
+                    checkedTrackColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                ),
+                thumbContent = if (checked) {
+                    {
+                        Icon(
+                            imageVector = Icons.Rounded.Check,
+                            contentDescription = "Switch is on",
+                            tint = MaterialTheme.colorScheme.tertiaryContainer,
+                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                        )
+                    }
+                } else {
+                    null
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
@@ -486,6 +486,7 @@ fun LibraryArtistsTab(
 @Composable
 fun LibraryPlaylistsTab(
     playlistUiState: PlaylistUiState,
+    filteredPlaylists: List<com.theveloper.pixelplay.data.model.Playlist> = playlistUiState.playlists,
     navController: NavController,
     playerViewModel: PlayerViewModel,
     bottomBarHeight: Dp,
@@ -499,6 +500,7 @@ fun LibraryPlaylistsTab(
 ) {
     PlaylistContainer(
         playlistUiState = playlistUiState,
+        filteredPlaylists = filteredPlaylists,
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
         bottomBarHeight = bottomBarHeight,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -981,8 +981,31 @@ fun LibraryScreen(
                         }
 
                         val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
+                        val visiblePlaylists = remember(
+                            playlistUiState.playlists,
+                            playlistUiState.showTelegramCloudPlaylists
+                        ) {
+                            if (playlistUiState.showTelegramCloudPlaylists) {
+                                playlistUiState.playlists
+                            } else {
+                                playlistUiState.playlists.filterNot { it.source == "TELEGRAM" }
+                            }
+                        }
                         val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
                         val favoritePagingItems = libraryViewModel.favoritesPagingFlow.collectAsLazyPagingItems()
+
+                        LaunchedEffect(
+                            playlistUiState.showTelegramCloudPlaylists,
+                            selectedPlaylists
+                        ) {
+                            if (playlistUiState.showTelegramCloudPlaylists) return@LaunchedEffect
+
+                            selectedPlaylists
+                                .filter { it.source == "TELEGRAM" }
+                                .forEach { playlist ->
+                                    playlistMultiSelectionState.removeFromSelection(playlist.id)
+                                }
+                        }
 
                         val currentSelectedSortOption: SortOption? = when (currentTabId) {
                             LibraryTabId.SONGS -> playerUiState.currentSongSortOption
@@ -1041,7 +1064,7 @@ fun LibraryScreen(
                                     SelectionActionRow(
                                         selectedCount = selectedPlaylists.size,
                                         onSelectAll = {
-                                            playerViewModel.playlistSelectionStateHolder.selectAll(playlistUiState.playlists)
+                                            playerViewModel.playlistSelectionStateHolder.selectAll(visiblePlaylists)
                                         },
                                         onDeselect = { playerViewModel.playlistSelectionStateHolder.clearSelection() },
                                         onOptionsClick = { showPlaylistMultiSelectionSheet = true }
@@ -1144,6 +1167,7 @@ fun LibraryScreen(
 
                             val isAlbumTab = currentTabId == LibraryTabId.ALBUMS
                             val isFoldersTab = currentTabId == LibraryTabId.FOLDERS
+                            val isPlaylistsTab = currentTabId == LibraryTabId.PLAYLISTS
 
                             LibrarySortBottomSheet(
                                 title = "Sort by",
@@ -1154,10 +1178,24 @@ fun LibraryScreen(
                                     onSortOptionChanged(option)
                                     playerViewModel.hideSortingSheet()
                                 },
-                                showViewToggle = isFoldersTab,
-                                viewToggleChecked = playerUiState.isFoldersPlaylistView,
+                                showViewToggle = isFoldersTab || isPlaylistsTab,
+                                viewSectionTitle = if (isPlaylistsTab) "Cloud" else "View",
+                                viewToggleLabel = if (isPlaylistsTab) {
+                                    "Telegram Cloud Channels"
+                                } else {
+                                    "Playlist View"
+                                },
+                                viewToggleChecked = if (isPlaylistsTab) {
+                                    playlistUiState.showTelegramCloudPlaylists
+                                } else {
+                                    playerUiState.isFoldersPlaylistView
+                                },
                                 onViewToggleChange = { isChecked ->
-                                    playerViewModel.setFoldersPlaylistView(isChecked)
+                                    if (isPlaylistsTab) {
+                                        playlistViewModel.setShowTelegramCloudPlaylists(isChecked)
+                                    } else {
+                                        playerViewModel.setFoldersPlaylistView(isChecked)
+                                    }
                                 },
                                 viewToggleContent = if (isAlbumTab) {
                                     {
@@ -1344,9 +1382,9 @@ fun LibraryScreen(
                                     }
 
                                     LibraryTabId.PLAYLISTS -> {
-                                        val currentPlaylistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
                                         LibraryPlaylistsTab(
-                                            playlistUiState = currentPlaylistUiState,
+                                            playlistUiState = playlistUiState,
+                                            filteredPlaylists = visiblePlaylists,
                                             navController = navController,
                                             playerViewModel = playerViewModel,
                                             bottomBarHeight = bottomBarHeightDp,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -39,6 +39,7 @@ import javax.inject.Inject
 
 data class PlaylistUiState(
     val playlists: List<Playlist> = emptyList(),
+    val showTelegramCloudPlaylists: Boolean = true,
     val currentPlaylistSongs: List<Song> = emptyList(),
     val currentPlaylistDetails: Playlist? = null,
     val isLoading: Boolean = false,
@@ -102,6 +103,7 @@ class PlaylistViewModel @Inject constructor(
 
     init {
         loadPlaylistsAndInitialSortOption()
+        observeTelegramCloudPlaylistVisibility()
         loadMoreSongsForSelection(isInitialLoad = true)
         observePlaylistOrderModes()
     }
@@ -145,6 +147,14 @@ class PlaylistViewModel @Inject constructor(
                     // If the option from preferences is different, re-sort the current list
                     sortPlaylists(newSortOption)
                 }
+            }
+        }
+    }
+
+    private fun observeTelegramCloudPlaylistVisibility() {
+        viewModelScope.launch {
+            playlistPreferencesRepository.showTelegramCloudPlaylistsFlow.collect { show ->
+                _uiState.update { it.copy(showTelegramCloudPlaylists = show) }
             }
         }
     }
@@ -706,6 +716,15 @@ class PlaylistViewModel @Inject constructor(
 
         viewModelScope.launch {
             playlistPreferencesRepository.setPlaylistsSortOption(sortOption.storageKey)
+        }
+    }
+
+    fun setShowTelegramCloudPlaylists(show: Boolean) {
+        if (_uiState.value.showTelegramCloudPlaylists == show) return
+
+        _uiState.update { it.copy(showTelegramCloudPlaylists = show) }
+        viewModelScope.launch {
+            playlistPreferencesRepository.setShowTelegramCloudPlaylists(show)
         }
     }
 


### PR DESCRIPTION
- **Preferences & Data**:
    - Add `SHOW_TELEGRAM_CLOUD_PLAYLISTS` key to `UserPreferencesRepository` to persist the visibility state of cloud-sourced playlists.
    - Expose `showTelegramCloudPlaylistsFlow` and corresponding setter in `PlaylistPreferencesRepository`.
- **ViewModel**:
    - Update `PlaylistUiState` to include `showTelegramCloudPlaylists`.
    - Implement `observeTelegramCloudPlaylistVisibility` in `PlaylistViewModel` to reactively update UI state from preferences.
- **Library UI**:
    - Update `LibraryScreen` to filter playlists based on the `TELEGRAM` source tag when the cloud visibility toggle is disabled.
    - Implement a `LaunchedEffect` to automatically deselect any filtered-out Telegram playlists during multi-selection.
    - Refactor `LibrarySortBottomSheet` to support a dynamic "Cloud" view section with a toggle for "Telegram Cloud Channels" when on the Playlists tab.
    - Extract `LibrarySheetToggleCard` as a reusable component within the sort bottom sheet for consistent styling.
- **Components**:
    - Update `LibraryPlaylistsTab` and `PlaylistContainer` to support an optional `filteredPlaylists` list for displaying filtered content while maintaining the full state for other operations.