### PR TITLE
fix: handle multi-song deletion UI update and parse track numbers correctly

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/paging/MediaStorePagingSource.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/paging/MediaStorePagingSource.kt
@@ -148,7 +148,7 @@ class MediaStorePagingSource(
                     genre = songIdToGenreMap[id],
                     lyrics = null,
                     isFavorite = false, // Not critical for paging source display usually, or passed in?
-                    trackNumber = cursor.getInt(trackCol),
+                    trackNumber = cursor.getInt(trackCol) % 1000,
                     year = cursor.getInt(yearCol),
                     dateAdded = cursor.getLong(dateAddedCol),
                     dateModified = cursor.getLong(dateModifiedCol),

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
@@ -189,7 +189,7 @@ class MediaStoreSongRepository @Inject constructor(
                         genre = songIdToGenreMap[id],
                         lyrics = null,
                         isFavorite = favoriteIds.contains(id),
-                        trackNumber = cursor.getInt(trackCol),
+                        trackNumber = cursor.getInt(trackCol) % 1000,
                         year = cursor.getInt(yearCol),
                         dateAdded = cursor.getLong(dateAddedCol),
                         dateModified = cursor.getLong(dateModifiedCol),

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -861,7 +861,7 @@ constructor(
                                                                 ?.takeIf { it.isNotBlank() }
                                                 else null,
                                         duration = cursor.getLong(durationCol),
-                                        trackNumber = cursor.getInt(trackCol),
+                                        trackNumber = cursor.getInt(trackCol) % 1000,
                                         year = cursor.getInt(yearCol),
                                         dateModified = cursor.getLong(dateModifiedCol)
                                 )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2891,6 +2891,7 @@ class PlayerViewModel @Inject constructor(
                 val success = metadataEditStateHolder.deleteSong(song)
                 if (success) {
                     removeFromMediaControllerQueue(song.id)
+                    removeSong(song)
                     successCount++
                 }
             }


### PR DESCRIPTION
1. **Multi-song deletion:** Ensures that songs are immediately removed from the library view after a multi-selection delete action.
2. **Track number parsing:** Extracts only the precise track number from `MediaStore.Audio.Media.TRACK`. Previously, if a song had both Disc and Track numbers metadata, MediaStore would combine them (e.g., Disc 1 + Track 2 = 1002). This PR applies a modulo 1000 to filter out the disc number prefix so that `1002` correctly becomes `2`.
