### PR TITLE
fix: resolve Sleep Timer UI bugs (repeat mode flicker, EOT timer, Play Count)

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -1891,9 +1891,10 @@ class MusicService : MediaLibraryService() {
             }
 
             override fun onRepeatModeChanged(repeatMode: Int) {
-                // Prevent user from disabling repeat-one
+                // User explicitly changed repeat mode while counted play is active:
+                // cancel counted play and accept the new mode instead of fighting back.
                 if (countedPlayActive && repeatMode != Player.REPEAT_MODE_ONE) {
-                    player.repeatMode = Player.REPEAT_MODE_ONE
+                    stopCountedPlay(restoreRepeatMode = false)
                 }
             }
         }
@@ -1902,7 +1903,7 @@ class MusicService : MediaLibraryService() {
         player.addListener(listener)
     }
 
-    fun stopCountedPlay() {
+    fun stopCountedPlay(restoreRepeatMode: Boolean = true) {
         if (!countedPlayActive) return
 
         countedPlayActive = false
@@ -1915,8 +1916,10 @@ class MusicService : MediaLibraryService() {
         }
         countedPlayListener = null
 
-        // Restore normal repeat mode (OFF)
-        engine.masterPlayer.repeatMode = Player.REPEAT_MODE_OFF
+        // Restore normal repeat mode (OFF) only when not triggered by a user repeat-mode change
+        if (restoreRepeatMode) {
+            engine.masterPlayer.repeatMode = Player.REPEAT_MODE_OFF
+        }
     }
 
     /**

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/TimerOptionsBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/TimerOptionsBottomSheet.kt
@@ -89,7 +89,7 @@ fun TimerOptionsBottomSheet(
         label = "boxCornerRadiusAnimation"
     )
 
-    LaunchedEffect(activeTimerValueDisplay) {
+    LaunchedEffect(activeTimerValueDisplay, playCount) {
         timerSliderPosition = when {
             activeTimerValueDisplay == null -> 0f // Off
             activeTimerValueDisplay == "End of Track" -> 0f // Slider shows 'Off' as EOT is a separate control
@@ -102,6 +102,10 @@ fun TimerOptionsBottomSheet(
             }
         }
         counterSliderPosition = playCount
+        // Restore counter mode if play count was previously set
+        if (playCount > 1f) {
+            isTimerMode = false
+        }
     }
 
     ModalBottomSheet(
@@ -283,6 +287,7 @@ fun TimerOptionsBottomSheet(
                     ) // Apply animated corner radius for clipping
                     .background(color = boxBackgroundColor)   // Apply animated background color
                     .clickable(
+                        enabled = isTimerMode || counterSliderPosition == 1f,
                         onClick = {
                             onSetEndOfTrackTimer(!isSwitchEnabled)
                         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -157,6 +158,7 @@ class SleepTimerStateHolder @Inject constructor(
      * Start counted play mode - play N more tracks.
      */
     fun playCounted(count: Int) {
+        _playCount.value = count.toFloat()
         val args = Bundle().apply { putInt("count", count) }
         mediaControllerProvider?.invoke()?.sendCustomCommand(
             SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_COUNTED_PLAY, Bundle.EMPTY),
@@ -198,7 +200,9 @@ class SleepTimerStateHolder @Inject constructor(
             // Monitor for song changes
             eotSongMonitorJob?.cancel()
             eotSongMonitorJob = scope.launch {
-                currentSongIdProvider?.invoke()?.collect { newSongId ->
+                currentSongIdProvider?.invoke()
+                    ?.filterNotNull() // skip initial null emission from stateIn initialValue
+                    ?.collect { newSongId ->
                     if (_isEndOfTrackTimerActive.value &&
                         EotStateHolder.eotTargetSongId.value != null &&
                         newSongId != EotStateHolder.eotTargetSongId.value) {


### PR DESCRIPTION
## Summary

This PR fixes three distinct bugs in the Sleep Timer bottom sheet.

---

### Bug 1: Repeat mode button flickers when Play Count is active

**Root cause** (`MusicService.kt`): The `onRepeatModeChanged` callback inside `startCountedPlay` was forcibly resetting `repeatMode` back to `REPEAT_MODE_ONE` every time the user tapped the repeat button. This caused a feedback loop: user tap → ViewModel optimistic update → forced revert → listener fires again → UI flickers.

**Fix**: Instead of fighting back, cancel counted play and accept the new repeat mode the user explicitly chose. Added a `restoreRepeatMode: Boolean = true` parameter to `stopCountedPlay()` so repeat mode is not reset when cancellation was triggered by the user changing the repeat mode themselves.

---

### Bug 2: "End of current track" switch could not be toggled

**Root cause** (`TimerOptionsBottomSheet.kt`): The Switch had `enabled = isTimerMode || counterSliderPosition == 1f`, which correctly disabled it when Play Count was active. However, the parent Box had no matching `enabled` guard on its `.clickable`. A disabled Switch in Compose consumes touch events without firing, so taps on the Box were silently swallowed by the Switch — even when the Switch was enabled.

**Fix**: Added the same `enabled = isTimerMode || counterSliderPosition == 1f` condition to the Box's `.clickable`, so both the Box and the Switch are either interactive or non-interactive together.

---

### Bug 3: EOT timer is silently cancelled immediately after being enabled

**Root cause** (`SleepTimerStateHolder.kt`): `setEndOfTrackTimer()` launches a coroutine to monitor song changes using `currentSongIdProvider?.invoke()`, which internally creates a new StateFlow via `stateIn(initialValue = null)`. The very first emission collected is `null`; at that point `eotTargetSongId` is already set to the current song ID, so the condition `null != currentSongId` evaluates to `true` and `cancelSleepTimer()` fires immediately — cancelling the EOT timer the instant it is enabled.

**Fix**: Added `.filterNotNull()` to the collect chain to skip the synthetic `null` initial value emitted by `stateIn`.

---

### Bonus fix: Play Count slider resets to 1 after reopening the sheet

**Root cause** (`SleepTimerStateHolder.kt`): `playCounted()` sent the command to the service but never updated `_playCount`, so the `playCount` StateFlow remained at `1f`. On next sheet open, `LaunchedEffect` restored `counterSliderPosition = 1f` and `isTimerMode = true`, hiding the active counted-play session.

**Fix**: `playCounted()` now updates `_playCount.value` before sending the command. `LaunchedEffect` key also includes `playCount` and restores `isTimerMode = false` when `playCount > 1f`.

---

### Files changed
- `app/.../data/service/MusicService.kt`
- `app/.../presentation/components/TimerOptionsBottomSheet.kt`
- `app/.../presentation/viewmodel/SleepTimerStateHolder.kt`
