### PR TITLE
feat(ui): implement smooth height transitions for `CastBottomSheet` p…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -2,6 +2,7 @@ package com.theveloper.pixelplay.presentation.components
 
 import android.Manifest
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
@@ -11,6 +12,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -584,6 +586,13 @@ private fun CastSheetContent(
         pageCount = { 2 }
     )
     val scope = rememberCoroutineScope()
+    var heightAnimationEnabled by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        withFrameNanos { }
+        withFrameNanos { }
+        heightAnimationEnabled = true
+    }
 
     Column(
         modifier = Modifier
@@ -628,6 +637,14 @@ private fun CastSheetContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(max = maxPagerHeight)
+                .animateContentSize(
+                    animationSpec = if (heightAnimationEnabled) {
+                        tween(durationMillis = 280, easing = FastOutSlowInEasing)
+                    } else {
+                        snap()
+                    },
+                    alignment = Alignment.TopCenter
+                )
         ) {
             HorizontalPager(
                 state = pagerState,


### PR DESCRIPTION
…ager

- **UI & Animation**:
    - Add `animateContentSize` to the `HorizontalPager` container in `CastBottomSheet` to ensure smooth height transitions when switching between pages.
    - Implement a `heightAnimationEnabled` flag with a `LaunchedEffect` delay to prevent initial layout jumps when the bottom sheet is first presented.
    - Use a `FastOutSlowInEasing` tween for active transitions and `snap()` for the initial state.