### PR TITLE
refactor: replace QuickJS with WebView-based signer for QQ Music sign…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,6 @@ ksp {
 }
 
 dependencies {
-    implementation(libs.quickjs)
     implementation(libs.androidx.profileinstaller)
     implementation(libs.androidx.paging.common)
     "baselineProfile"(project(":baselineprofile"))

--- a/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQMusicEncryptInterceptor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQMusicEncryptInterceptor.kt
@@ -36,7 +36,7 @@ class QQMusicEncryptInterceptor(
         val plaintextJson = requestBuffer.readUtf8()
         Timber.d("QQMusicEncryptInterceptor: Plain request json: $plaintextJson")
 
-        // 2. Generate sign using QuickJS
+        // 2. Generate sign using the shared WebView-based signer
         val sign = signGenerator.generateSign(plaintextJson) ?: ""
         Timber.d("QQMusicEncryptInterceptor: Generated sign: $sign")
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQSignGenerator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQSignGenerator.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Android implementation of QQ Music Signature (sign) generation.
- * Uses QuickJS to execute the obfuscated logic from Assets.
+ * Uses an off-screen WebView to execute the obfuscated logic from Assets.
  */
 class QQSignGenerator(private val context: Context) {
     private val appContext = context.applicationContext

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ constraintlayoutCompose = "1.1.1"
 coreSplashscreen = "1.0.1"
 desugarJdkLibs = "2.1.4"
 duktapeAndroid = "1.3.0"
-quickjs = "0.9.2"
 foundation = "1.10.4"
 glance = "1.2.0-rc01"
 graphicsShapes = "1.1.0"
@@ -149,7 +148,6 @@ androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "ro
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
-quickjs = { module = "app.cash.quickjs:quickjs-android", version.ref = "quickjs" }
 capturable = { module = "dev.shreyaspatil:capturable", version.ref = "capturable" }
 codeview = { module = "io.github.amrdeveloper:codeview", version.ref = "codeview" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }


### PR DESCRIPTION
…atures

- **Core**:
    - Update `QQSignGenerator` to use an off-screen `WebView` instead of `QuickJS` to execute obfuscated signature logic from assets.
    - Update `QQMusicEncryptInterceptor` to utilize the new shared WebView-based signer.
- **Dependencies**:
    - Remove `QuickJS` library from `app/build.gradle.kts` and `gradle/libs.versions.toml`.