### PR TITLE
feat: enhance Daily Mix section with song actions and improved UI

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
@@ -7,13 +7,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,6 +26,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,14 +38,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Song
-import com.theveloper.pixelplay.presentation.screens.SongListItemFavsWrapper
+import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
+import com.theveloper.pixelplay.presentation.viewmodel.PlaylistViewModel
 import com.theveloper.pixelplay.utils.shapes.RoundedStarShape
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -50,15 +67,102 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 fun DailyMixSection(
     songs: ImmutableList<Song>,
     playerViewModel: PlayerViewModel,
-    onClickOpen: () -> Unit = {}
+    onClickOpen: () -> Unit = {},
+    onNavigateToAlbum: (Song) -> Unit = {},
+    onNavigateToArtist: (Song) -> Unit = {},
 ) {
+    val playlistViewModel: PlaylistViewModel = hiltViewModel()
+    val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
+    val selectedSongForInfo by playerViewModel.selectedSongForInfo.collectAsStateWithLifecycle()
+    val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
+    val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val bottomBarHeightDp = NavBarContentHeight + systemNavBarInset
+    var showSongInfoSheet by remember { mutableStateOf(false) }
+    var showPlaylistBottomSheet by remember { mutableStateOf(false) }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
     ) {
         Spacer(Modifier.height(16.dp))
-        DailyMixCard(songs = songs, playerViewModel = playerViewModel, onClickOpen =  onClickOpen)
+        DailyMixCard(
+            songs = songs,
+            playerViewModel = playerViewModel,
+            onClickOpen = onClickOpen,
+            onMoreOptionsClick = { song ->
+                playerViewModel.selectSongForInfo(song)
+                showSongInfoSheet = true
+            }
+        )
+    }
+
+    if (showSongInfoSheet && selectedSongForInfo != null) {
+        val song = selectedSongForInfo!!
+        SongInfoBottomSheet(
+            song = song,
+            isFavorite = favoriteSongIds.contains(song.id),
+            onToggleFavorite = { playerViewModel.toggleFavoriteSpecificSong(song) },
+            onDismiss = {
+                showSongInfoSheet = false
+                showPlaylistBottomSheet = false
+            },
+            onPlaySong = {
+                playerViewModel.showAndPlaySong(
+                    song = song,
+                    contextSongs = songs,
+                    queueName = "Daily Mix",
+                    isVoluntaryPlay = false
+                )
+                showSongInfoSheet = false
+            },
+            onAddToQueue = {
+                playerViewModel.addSongToQueue(song)
+                showSongInfoSheet = false
+            },
+            onAddNextToQueue = {
+                playerViewModel.addSongNextToQueue(song)
+                showSongInfoSheet = false
+            },
+            onAddToPlayList = {
+                showPlaylistBottomSheet = true
+            },
+            onDeleteFromDevice = playerViewModel::deleteFromDevice,
+            onNavigateToAlbum = {
+                onNavigateToAlbum(song)
+                showSongInfoSheet = false
+            },
+            onNavigateToArtist = {
+                onNavigateToArtist(song)
+                showSongInfoSheet = false
+            },
+            onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, coverArtUpdate ->
+                playerViewModel.editSongMetadata(
+                    song,
+                    newTitle,
+                    newArtist,
+                    newAlbum,
+                    newGenre,
+                    newLyrics,
+                    newTrackNumber,
+                    coverArtUpdate
+                )
+            },
+            generateAiMetadata = { fields ->
+                playerViewModel.generateAiMetadata(song, fields)
+            },
+            removeFromListTrigger = {}
+        )
+
+        if (showPlaylistBottomSheet) {
+            PlaylistBottomSheet(
+                playlistUiState = playlistUiState,
+                songs = listOf(song),
+                onDismiss = { showPlaylistBottomSheet = false },
+                bottomBarHeight = bottomBarHeightDp,
+                playerViewModel = playerViewModel,
+            )
+        }
     }
 }
 
@@ -67,7 +171,8 @@ fun DailyMixSection(
 private fun DailyMixCard(
     songs: ImmutableList<Song>,
     onClickOpen: () -> Unit,
-    playerViewModel: PlayerViewModel
+    playerViewModel: PlayerViewModel,
+    onMoreOptionsClick: (Song) -> Unit
 ) {
     val headerSongs = songs.take(3).toImmutableList()
     val visibleSongs = songs.take(4).toImmutableList()
@@ -83,7 +188,7 @@ private fun DailyMixCard(
             cornerRadiusTL = cornerRadius,
             smoothnessAsPercentBR = 60
         ),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
         elevation = CardDefaults.elevatedCardElevation(0.dp),
         modifier = Modifier.fillMaxWidth()
     ) {
@@ -92,7 +197,8 @@ private fun DailyMixCard(
             DailyMixSongList(
                 songs = visibleSongs,
                 playbackQueue = songs,
-                playerViewModel = playerViewModel
+                playerViewModel = playerViewModel,
+                onMoreOptionsClick = onMoreOptionsClick
             )
             ViewAllDailyMixButton(
                 modifier = Modifier
@@ -113,6 +219,7 @@ private fun DailyMixCard(
 
 @Composable
 fun DailyMixHeader(thumbnails: ImmutableList<Song>) {
+    val titleStyle = rememberDailyMixTitleStyle()
 
     fun shapeConditionalModifier(index: Int): Modifier {
         if (index == 0){
@@ -142,18 +249,18 @@ fun DailyMixHeader(thumbnails: ImmutableList<Song>) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 26.dp, end = 16.dp),
+                .padding(start = 22.dp, end = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Absolute.SpaceBetween
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = "DAILY MIX",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.ExtraBold,
+                    style = titleStyle,
                     color = MaterialTheme.colorScheme.onPrimary
                 )
                 Text(
+                    modifier = Modifier.padding(start = 1.dp),
                     text = "Based on History",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Normal,
@@ -212,21 +319,34 @@ fun threeShapeSwitch(index: Int, thirdShapeCornerRadius: Dp = 16.dp): Shape { //
 private fun DailyMixSongList(
     songs: ImmutableList<Song>,
     playbackQueue: ImmutableList<Song>,
-    playerViewModel: PlayerViewModel
+    playerViewModel: PlayerViewModel,
+    onMoreOptionsClick: (Song) -> Unit
 ) {
+    val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
+    val itemContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
+
     Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp, start = 8.dp, end = 8.dp)
+            .clip(RoundedCornerShape(24.dp)),
+        verticalArrangement = Arrangement.spacedBy(3.dp)
     ) {
         songs.forEach { song ->
-            SongListItemFavsWrapper(
+            EnhancedSongListItem(
                 song = song,
-                playerViewModel = playerViewModel,
+                isCurrentSong = stablePlayerState.currentSong?.id == song.id,
+                isPlaying = stablePlayerState.isPlaying && stablePlayerState.currentSong?.id == song.id,
+                containerColorOverride = itemContainerColor,
+                onMoreOptionsClick = onMoreOptionsClick,
+                customShape = RoundedCornerShape(10.dp),
+                showAlbumArt = false,
                 onClick = {
-                    playerViewModel.playSongs(
-                        songsToPlay = playbackQueue,
-                        startSong = song,
-                        queueName = "Daily Mix"
+                    playerViewModel.showAndPlaySong(
+                        song = song,
+                        contextSongs = playbackQueue,
+                        queueName = "Daily Mix",
+                        isVoluntaryPlay = false
                     )
                 },
                 modifier = Modifier.fillMaxWidth()
@@ -277,5 +397,32 @@ private fun ViewAllDailyMixButton(
                 modifier = Modifier.size(20.dp)
             )
         }
+    }
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+private fun rememberDailyMixTitleStyle(): TextStyle {
+    return remember {
+        TextStyle(
+            fontFamily = FontFamily(
+                Font(
+                    resId = R.font.gflex_variable,
+                    variationSettings = FontVariation.Settings(
+                        FontVariation.weight(630),
+                        FontVariation.width(136f),
+                        FontVariation.grade(40),
+                        FontVariation.Setting("ROND", 100f),
+                        FontVariation.Setting("XTRA", 520f),
+                        FontVariation.Setting("YOPQ", 90f),
+                        FontVariation.Setting("YTLC", 505f)
+                    )
+                )
+            ),
+            fontWeight = FontWeight(630),
+            fontSize = 20.sp,
+            lineHeight = 22.sp,
+            letterSpacing = (-0.35).sp
+        )
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
@@ -77,9 +78,11 @@ fun EnhancedSongListItem(
     isLoading: Boolean = false,
     showAlbumArt: Boolean = true,
     customShape: androidx.compose.ui.graphics.Shape? = null,
+    containerColorOverride: Color? = null,
     isSelected: Boolean = false,
     selectionIndex: Int? = null,
     isSelectionMode: Boolean = false,
+    showMoreOptionsButton: Boolean = true,
     onLongPress: () -> Unit = {},
     onMoreOptionsClick: (Song) -> Unit,
     onClick: () -> Unit
@@ -119,31 +122,11 @@ fun EnhancedSongListItem(
             customShape
         } else {
             RoundedCornerShape(animatedCornerRadius)
-//            AbsoluteSmoothCornerShape(
-//                cornerRadiusTL = animatedCornerRadius,
-//                smoothnessAsPercentTR = 60,
-//                cornerRadiusTR = animatedCornerRadius,
-//                smoothnessAsPercentBR = 60,
-//                cornerRadiusBL = animatedCornerRadius,
-//                smoothnessAsPercentBL = 60,
-//                cornerRadiusBR = animatedCornerRadius,
-//                smoothnessAsPercentTL = 60
-//            )
         }
     }
 
     val albumShape = remember(animatedAlbumCornerRadius) {
         RoundedCornerShape(animatedAlbumCornerRadius)
-//        AbsoluteSmoothCornerShape(
-//            cornerRadiusTL = animatedAlbumCornerRadius,
-//            smoothnessAsPercentTR = 60,
-//            cornerRadiusTR = animatedAlbumCornerRadius,
-//            smoothnessAsPercentBR = 60,
-//            cornerRadiusBL = animatedAlbumCornerRadius,
-//            smoothnessAsPercentBL = 60,
-//            cornerRadiusBR = animatedAlbumCornerRadius,
-//            smoothnessAsPercentTL = 60
-//        )
     }
 
     val colors = MaterialTheme.colorScheme
@@ -153,7 +136,7 @@ fun EnhancedSongListItem(
         targetValue = when {
             isSelected -> colors.secondaryContainer
             isCurrentSong && !isLoading -> colors.primaryContainer
-            else -> colors.surfaceContainerLow
+            else -> containerColorOverride ?: colors.surfaceContainerLow
         },
         animationSpec = tween(durationMillis = 300),
         label = "containerColorAnimation"
@@ -186,7 +169,7 @@ fun EnhancedSongListItem(
                 .fillMaxWidth()
                 .clip(surfaceShape),
             shape = surfaceShape,
-            color = colors.surfaceContainerLow,
+            color = containerColorOverride ?: colors.surfaceContainerLow,
         ) {
             Row(
                 modifier = Modifier
@@ -371,7 +354,10 @@ fun EnhancedSongListItem(
                     )
                 }
                 
-                if (isCurrentSong && !isSelectionMode) {
+                val showPlayingIndicator = isCurrentSong && !isSelectionMode
+                val showTrailingAction = showMoreOptionsButton && !isSelectionMode
+
+                if (showPlayingIndicator) {
                      PlayingEqIcon(
                          modifier = Modifier
                              .padding(start = 8.dp)
@@ -380,11 +366,12 @@ fun EnhancedSongListItem(
                          isPlaying = isPlaying
                      )
                 }
-                
-                Spacer(modifier = Modifier.width(12.dp))
-                
-                // Hide more options button in selection mode
-                if (!isSelectionMode) {
+
+                if (showPlayingIndicator || showTrailingAction) {
+                    Spacer(modifier = Modifier.width(12.dp))
+                }
+
+                if (showTrailingAction) {
                     FilledIconButton(
                         onClick = { onMoreOptionsClick(song) },
                         colors = IconButtonDefaults.filledIconButtonColors(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -275,6 +275,12 @@ fun HomeScreen(
                             onClickOpen = {
                                 navController.navigateSafely(Screen.DailyMixScreen.route)
                             },
+                            onNavigateToAlbum = { song ->
+                                navController.navigateSafely(Screen.AlbumDetail.createRoute(song.albumId))
+                            },
+                            onNavigateToArtist = { song ->
+                                navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
+                            },
                             playerViewModel = playerViewModel
                         )
                     }

--- a/app/src/main/java/com/theveloper/pixelplay/utils/shapes/RoundedStarShape.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/shapes/RoundedStarShape.kt
@@ -41,29 +41,28 @@ class RoundedStarShape(
         layoutDirection: LayoutDirection,
         density: Density
     ): Outline = Outline.Generic(Path().apply {
-
-
         val r = min(size.height, size.width) * 0.4 * mapRange(1.0, 0.0, 0.5, 1.0, curve)
 
         val xCenter = size.width * .5f
         val yCenter = size.height * .5f
 
-        moveTo(xCenter, yCenter)
-
-        var t = 0.0
-
-        while (t <= TWO_PI) {
+        fun pointAt(t: Double): Pair<Float, Float> {
             val x = r * (cos(t - rotationDegree) * (1 + curve * cos(sides * t)))
             val y = r * (sin(t - rotationDegree) * (1 + curve * cos(sides * t)))
-            lineTo((x + xCenter).toFloat(), (y + yCenter).toFloat())
+            return (x + xCenter).toFloat() to (y + yCenter).toFloat()
+        }
 
+        val (startX, startY) = pointAt(0.0)
+        moveTo(startX, startY)
+
+        var t = steps
+        while (t < TWO_PI) {
+            val (x, y) = pointAt(t)
+            lineTo(x, y)
             t += steps
         }
 
-        val x = r * (cos(t - rotationDegree) * (1 + curve * cos(sides * t)))
-        val y = r * (sin(t - rotationDegree) * (1 + curve * cos(sides * t)))
-        lineTo((x + xCenter).toFloat(), (y + yCenter).toFloat())
-
+        close()
     })
 
 


### PR DESCRIPTION
- **Daily Mix**:
    - Add support for a song info bottom sheet, allowing users to toggle favorites, add to queue/playlists, edit metadata, and navigate to album/artist details directly from the Daily Mix card.
    - Implement `PlaylistBottomSheet` integration within the Daily Mix flow.
    - Update `DailyMixCard` to use `surfaceContainer` color and refine layout padding.
    - Redesign the "DAILY MIX" title using a custom variable font style (`gflex_variable`) with specific weight and variation settings.
    - Refactor the song list to use `EnhancedSongListItem` for a more consistent look, featuring custom shapes and container colors.
- **UI Components**:
    - **EnhancedSongListItem**: Add `containerColorOverride` and `showMoreOptionsButton` props to allow more granular visual customization across different screens.
    - **RoundedStarShape**: Refactor path generation logic for better efficiency and fix a minor redundancy in point calculation.
- **Navigation**:
    - Update `HomeScreen` to provide navigation callbacks for albums and artists from the Daily Mix section.