### PR TITLE
fix: library shuffle button behavior

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -155,11 +155,11 @@ class MusicRepositoryImpl @Inject constructor(
 
     override suspend fun getRandomSongs(limit: Int): List<Song> = withContext(Dispatchers.IO) {
         // Use DAO's optimized random query with filter support
-        val allowed = userPreferencesRepository.allowedDirectoriesFlow.first()
-        val blocked = userPreferencesRepository.blockedDirectoriesFlow.first()
-        val applyFilter = blocked.isNotEmpty()
-        
-        musicDao.getRandomSongs(limit, allowed.toList(), applyFilter).map { it.toSong() }
+        val allowedDirs = userPreferencesRepository.allowedDirectoriesFlow.first()
+        val blockedDirs = userPreferencesRepository.blockedDirectoriesFlow.first()
+        val (allowedParentDirs, applyFilter) = computeAllowedDirs(allowedDirs, blockedDirs)
+
+        musicDao.getRandomSongs(limit, allowedParentDirs, applyFilter).map { it.toSong() }
     }
 
     override suspend fun saveTelegramSongs(songs: List<Song>) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LibraryActionRow.kt
@@ -144,16 +144,8 @@ fun LibraryActionRow(
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     // Determine button colors based on shuffle state (not for playlist tab)
-                    val buttonContainerColor = if (!isPlaylistTab && isShuffleEnabled) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.tertiaryContainer
-                    }
-                    val buttonContentColor = if (!isPlaylistTab && isShuffleEnabled) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onTertiaryContainer
-                    }
+                    val buttonContainerColor = MaterialTheme.colorScheme.tertiaryContainer
+                    val buttonContentColor = MaterialTheme.colorScheme.onTertiaryContainer
                     
                     FilledTonalButton(
                         onClick = onMainActionClick,
@@ -170,7 +162,7 @@ fun LibraryActionRow(
                         modifier = Modifier.height(genHeight)
                     ) {
                         val icon = if (isPlaylistTab) Icons.AutoMirrored.Rounded.PlaylistAdd else Icons.Rounded.Shuffle
-                        val text = if (isPlaylistTab) "New" else if (isShuffleEnabled) "Shuffle On" else "Shuffle"
+                        val text = if (isPlaylistTab) "New" else "Shuffle"
                         val contentDesc = if (isPlaylistTab) "Create New Playlist" else "Shuffle Play"
 
                         Row(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -837,18 +837,7 @@ class PlayerViewModel @Inject constructor(
 
     fun shuffleAllSongs() {
         Log.d("ShuffleDebug", "shuffleAllSongs called.")
-        // Don't use ExoPlayer's shuffle mode - we manually shuffle instead
-        val currentSong = playbackStateHolder.stablePlayerState.value.currentSong
-        val isPlaying = playbackStateHolder.stablePlayerState.value.isPlaying
-
-        // If something is playing, just toggle shuffle on current queue
-        if (currentSong != null && isPlaying) {
-            if (!playbackStateHolder.stablePlayerState.value.isShuffleEnabled) {
-                toggleShuffle()
-            }
-            return
-        }
-
+        
         // Load random songs from DB instead of materializing the entire library
         viewModelScope.launch {
             val randomSongs = musicRepository.getRandomSongs(limit = 500)
@@ -918,17 +907,6 @@ class PlayerViewModel @Inject constructor(
 
     fun shuffleFavoriteSongs() {
         Log.d("ShuffleDebug", "shuffleFavoriteSongs called.")
-        // Don't use ExoPlayer's shuffle mode - we manually shuffle instead
-        val currentSong = playbackStateHolder.stablePlayerState.value.currentSong
-        val isPlaying = playbackStateHolder.stablePlayerState.value.isPlaying
-
-        // If something is playing, just toggle shuffle on current queue
-        if (currentSong != null && isPlaying) {
-            if (!playbackStateHolder.stablePlayerState.value.isShuffleEnabled) {
-                toggleShuffle()
-            }
-            return
-        }
 
         // Load favorite songs from DB on-demand instead of holding them in memory
         viewModelScope.launch {


### PR DESCRIPTION
### Description
This PR fixes some bugs and confusion around the Library's Shuffle button behavior:

1. **Fix Empty Shuffle**: `getRandomSongs` in `MusicRepositoryImpl.kt` previously returned an empty list there is blocked folders in the settings. This is now fixed by using computeAllowedDirs.
2. **Make Shuffle Button Static**: The Shuffle button no longer changes color or text (to "Shuffle On") like a toggle button. It will now definitively stay as an action button.
3. **Always Trigger a New Shuffle**: Removed the check in `PlayerViewModel.kt` that blocks re-shuffling if there's already a song playing with shuffle enabled, making shuffle button in songs tab and liked tab always create a new shuffle.
