### PR TITLE
feat: implement pagination and deep track synchronization for Netease…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
@@ -51,6 +51,9 @@ class NeteaseRepository @Inject constructor(
         private const val NETEASE_PARENT_DIRECTORY = "/Cloud/Netease"
         private const val NETEASE_GENRE = "Netease Cloud"
         private const val NETEASE_PLAYLIST_PREFIX = "netease_playlist:"
+        private const val NETEASE_PLAYLIST_PAGE_SIZE = 50
+        private const val NETEASE_SONG_DETAIL_BATCH_SIZE = 500
+        private const val NETEASE_MAX_PLAYLIST_PAGES = 200
     }
 
     private val prefs: SharedPreferences =
@@ -202,30 +205,59 @@ class NeteaseRepository @Inject constructor(
             try {
                 val uid = if (userId != -1L) userId else api.getCurrentUserId()
                 Timber.d("syncUserPlaylists: fetching playlists for uid=$uid")
-                val raw = api.getUserPlaylists(uid)
-                Timber.d("syncUserPlaylists: response length=${raw.length}")
-                val root = JSONObject(raw)
+                val entitiesById = LinkedHashMap<Long, NeteasePlaylistEntity>()
+                var offset = 0
+                var page = 0
+                var hasMore = true
 
-                if (root.optInt("code", -1) != 200) {
-                    Timber.e("syncUserPlaylists: API error code=${root.optInt("code")}")
-                    return@withContext Result.failure(Exception("API error: code ${root.optInt("code")}"))
-                }
+                while (hasMore) {
+                    val raw = api.getUserPlaylists(
+                        userId = uid,
+                        offset = offset,
+                        limit = NETEASE_PLAYLIST_PAGE_SIZE
+                    )
+                    Timber.d("syncUserPlaylists: page=$page offset=$offset response length=${raw.length}")
+                    val root = JSONObject(raw)
 
-                val playlistArray = root.optJSONArray("playlist") ?: return@withContext Result.success(emptyList())
-                val entities = mutableListOf<NeteasePlaylistEntity>()
+                    if (root.optInt("code", -1) != 200) {
+                        Timber.e("syncUserPlaylists: API error code=${root.optInt("code")}")
+                        return@withContext Result.failure(Exception("API error: code ${root.optInt("code")}"))
+                    }
 
-                for (i in 0 until playlistArray.length()) {
-                    val pl = playlistArray.optJSONObject(i) ?: continue
-                    entities.add(
-                        NeteasePlaylistEntity(
-                            id = pl.optLong("id"),
+                    val playlistArray = root.optJSONArray("playlist") ?: break
+                    val fetchedCount = playlistArray.length()
+                    if (fetchedCount == 0) break
+
+                    for (i in 0 until fetchedCount) {
+                        val pl = playlistArray.optJSONObject(i) ?: continue
+                        val id = pl.optLong("id")
+                        if (id <= 0L) continue
+                        entitiesById[id] = NeteasePlaylistEntity(
+                            id = id,
                             name = pl.optString("name", ""),
                             coverUrl = pl.optString("coverImgUrl", ""),
                             songCount = pl.optInt("trackCount", 0),
                             lastSyncTime = System.currentTimeMillis()
                         )
-                    )
+                    }
+
+                    offset += fetchedCount
+                    val totalCount = root.optInt("count", -1)
+                    val moreFlag = root.optBoolean("more", false)
+                    hasMore = when {
+                        moreFlag -> true
+                        totalCount > 0 -> offset < totalCount
+                        else -> fetchedCount >= NETEASE_PLAYLIST_PAGE_SIZE
+                    }
+
+                    page += 1
+                    if (page >= NETEASE_MAX_PLAYLIST_PAGES) {
+                        Timber.w("syncUserPlaylists: reached max page guard ($NETEASE_MAX_PLAYLIST_PAGES), stopping pagination")
+                        hasMore = false
+                    }
                 }
+
+                val entities = entitiesById.values.toList()
 
                 val localPlaylists = dao.getAllPlaylistsList()
                 val remoteIds = entities.map { it.id }.toSet()
@@ -269,20 +301,79 @@ class NeteaseRepository @Inject constructor(
 
                 val playlist = root.optJSONObject("playlist")
                     ?: return@withContext Result.failure(Exception("No playlist data"))
-                val tracks = playlist.optJSONArray("tracks")
-                    ?: return@withContext Result.success(0)
+                val embeddedTracks = playlist.optJSONArray("tracks")
+                val trackIds = playlist.optJSONArray("trackIds")
+                val playlistName = playlist.optString("name", "")
 
-                val entities = mutableListOf<NeteaseSongEntity>()
-                for (i in 0 until tracks.length()) {
-                    val track = tracks.optJSONObject(i) ?: continue
-                    entities.add(parseTrackToEntity(track, playlistId))
+                val entitiesBySongId = LinkedHashMap<Long, NeteaseSongEntity>()
+                val orderedTrackIds = mutableListOf<Long>()
+
+                for (i in 0 until (embeddedTracks?.length() ?: 0)) {
+                    val track = embeddedTracks?.optJSONObject(i) ?: continue
+                    val entity = parseTrackToEntity(track, playlistId)
+                    entitiesBySongId[entity.neteaseId] = entity
+                }
+
+                for (i in 0 until (trackIds?.length() ?: 0)) {
+                    val id = trackIds?.optJSONObject(i)?.optLong("id") ?: 0L
+                    if (id > 0L) {
+                        orderedTrackIds.add(id)
+                    }
+                }
+
+                val existingTrackIds = entitiesBySongId.keys.toSet()
+                val missingTrackIds = if (orderedTrackIds.isNotEmpty()) {
+                    orderedTrackIds.filterNot(existingTrackIds::contains)
+                } else {
+                    emptyList()
+                }
+
+                if (missingTrackIds.isNotEmpty()) {
+                    Timber.d(
+                        "syncPlaylistSongs: playlistId=$playlistId needs ${missingTrackIds.size} additional tracks beyond embedded detail"
+                    )
+                    missingTrackIds.chunked(NETEASE_SONG_DETAIL_BATCH_SIZE).forEach { chunk ->
+                        val detailRaw = api.getSongDetails(chunk)
+                        val detailRoot = JSONObject(detailRaw)
+                        if (detailRoot.optInt("code", -1) != 200) {
+                            Timber.w(
+                                "syncPlaylistSongs: getSongDetails failed for chunk size=${chunk.size}, code=${detailRoot.optInt("code", -1)}"
+                            )
+                            return@forEach
+                        }
+                        val detailSongs = detailRoot.optJSONArray("songs") ?: return@forEach
+                        for (i in 0 until detailSongs.length()) {
+                            val track = detailSongs.optJSONObject(i) ?: continue
+                            val entity = parseTrackToEntity(track, playlistId)
+                            entitiesBySongId[entity.neteaseId] = entity
+                        }
+                    }
+                }
+
+                val entities = if (orderedTrackIds.isNotEmpty()) {
+                    val ordered = orderedTrackIds.mapNotNull { entitiesBySongId[it] }
+                    if (ordered.size < entitiesBySongId.size) {
+                        val orderedSet = orderedTrackIds.toSet()
+                        ordered + entitiesBySongId.values.filterNot { it.neteaseId in orderedSet }
+                    } else {
+                        ordered
+                    }
+                } else {
+                    entitiesBySongId.values.toList()
+                }
+
+                val expectedTrackCount = playlist.optInt("trackCount", orderedTrackIds.size)
+                if (expectedTrackCount > 0 && entities.size < expectedTrackCount) {
+                    Timber.w(
+                        "syncPlaylistSongs: playlistId=$playlistId expected=$expectedTrackCount synced=${entities.size} (API may still be limiting some tracks)"
+                    )
                 }
 
                 dao.deleteSongsByPlaylist(playlistId)
                 dao.insertSongs(entities)
                 
                 // Create or update the corresponding app playlist
-                updateAppPlaylistForNeteasePlaylist(playlistId, playlist.optString("name", ""), entities)
+                updateAppPlaylistForNeteasePlaylist(playlistId, playlistName, entities)
                 
                 if (syncUnifiedLibrary) {
                     syncUnifiedLibrarySongsFromNetease()

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseApiService.kt
@@ -9,6 +9,7 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
 import java.io.IOException
@@ -257,6 +258,29 @@ class NeteaseApiService @Inject constructor() {
             "s" to "8"
         )
         return request("https://music.163.com/api/v6/playlist/detail", params, CryptoMode.API, "POST", usePersistedCookies = true)
+    }
+
+    /**
+     * Fetch full track metadata for a list of song IDs.
+     * This is used to complete playlist sync when playlist/detail embeds only a subset of tracks.
+     */
+    fun getSongDetails(songIds: List<Long>): String {
+        if (songIds.isEmpty()) {
+            return """{"code":200,"songs":[]}"""
+        }
+
+        val ids = JSONArray()
+        val c = JSONArray()
+        songIds.forEach { id ->
+            ids.put(id)
+            c.put(JSONObject().put("id", id))
+        }
+
+        val params = mutableMapOf<String, Any>(
+            "ids" to ids.toString(),
+            "c" to c.toString()
+        )
+        return request("https://music.163.com/api/v3/song/detail", params, CryptoMode.API, "POST", usePersistedCookies = true)
     }
 
     // ─── Song Data ─────────────────────────────────────────────────────

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/qqmusic/QqMusicApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/qqmusic/QqMusicApiService.kt
@@ -83,14 +83,15 @@ class QqMusicApiService @Inject constructor(
     /**
      * Get user's playlists (created and collected).
      */
-    suspend fun getUserPlaylists(): String = withContext(Dispatchers.IO) {
+    suspend fun getUserPlaylists(start: Int = 0, count: Int = 100): String = withContext(Dispatchers.IO) {
         val uin = extractUin()
         val gtk = getGTK()
+        val ein = (start + count - 1).coerceAtLeast(start)
         Timber.d("getUserPlaylists: uin=$uin, gtk=$gtk")
         val url = "https://c.y.qq.com/fav/fcgi-bin/fcg_get_profile_order_asset.fcg?" +
                 "format=json&inCharset=utf-8&outCharset=utf-8&notice=0" +
                 "&platform=yqq&needNewCode=1" +
-                "&uin=$uin&g_tk=$gtk&cid=205360956&userid=$uin&reqtype=3&sin=0&ein=100"
+                "&uin=$uin&g_tk=$gtk&cid=205360956&userid=$uin&reqtype=3&sin=$start&ein=$ein"
 
         makeGetRequest(url)
     }
@@ -98,11 +99,16 @@ class QqMusicApiService @Inject constructor(
     /**
      * Get playlist detail including all songs.
      */
-    suspend fun getPlaylistDetail(playlistId: Long): String = withContext(Dispatchers.IO) {
+    suspend fun getPlaylistDetail(
+        playlistId: Long,
+        songBegin: Int = 0,
+        songNum: Int = 1000
+    ): String = withContext(Dispatchers.IO) {
         val gtk = getGTK()
         val url = "https://c.y.qq.com/qzone/fcg-bin/fcg_ucc_getcdinfo_byids_cp.fcg?" +
                 "type=1&json=1&utf8=1&onlysong=0" +
-                "&disstid=$playlistId&g_tk=$gtk&format=json&inCharset=utf-8&outCharset=utf-8"
+                "&disstid=$playlistId&song_begin=$songBegin&song_num=$songNum" +
+                "&g_tk=$gtk&format=json&inCharset=utf-8&outCharset=utf-8"
 
         makeGetRequest(url)
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
@@ -51,6 +51,9 @@ class QqMusicRepository @Inject constructor(
         private const val QQ_MUSIC_PARENT_DIRECTORY = "/Cloud/QQMusic"
         private const val QQ_MUSIC_GENRE = "QQ Music"
         private const val QQ_MUSIC_PLAYLIST_PREFIX = "qqmusic_playlist:"
+        private const val QQ_USER_PLAYLIST_PAGE_SIZE = 100
+        private const val QQ_PLAYLIST_SONG_PAGE_SIZE = 1000
+        private const val QQ_MAX_PLAYLIST_PAGES = 200
     }
 
     data class BulkSyncResult(
@@ -232,36 +235,75 @@ class QqMusicRepository @Inject constructor(
         }
         return withContext(Dispatchers.IO) {
             runCatching {
-                val raw = api.getUserPlaylists()
-                Timber.d("syncUserPlaylists: response length=${raw.length}")
-                val root = JSONObject(raw)
-                val code = root.optInt("code", -1)
-                if (code != 0) {
-                    throw Exception("QQ Music API Error: code=$code. Check your login.")
-                }
+                val entitiesById = LinkedHashMap<Long, QqMusicPlaylistEntity>()
+                var start = 0
+                var page = 0
 
-                val data = root.optJSONObject("data") ?: return@runCatching emptyList()
-                val cdlist = data.optJSONArray("cdlist") ?: return@runCatching emptyList()
+                while (true) {
+                    val raw = api.getUserPlaylists(start = start, count = QQ_USER_PLAYLIST_PAGE_SIZE)
+                    Timber.d("syncUserPlaylists: page=$page start=$start response length=${raw.length}")
+                    val root = JSONObject(raw)
+                    val code = root.optInt("code", -1)
+                    if (code != 0) {
+                        throw Exception("QQ Music API Error: code=$code. Check your login.")
+                    }
 
-                val entities = mutableListOf<QqMusicPlaylistEntity>()
-                for (i in 0 until cdlist.length()) {
-                    val pl = cdlist.optJSONObject(i) ?: continue
-                    val songCount = pl.optInt("songnum", 0)
-                    // Skip empty playlists (deleted or not yet populated)
-                    if (songCount == 0) continue
-                    val name = decodeBase64IfNeeded(pl.optString("dissname", ""))
-                    // Skip playlists with blank names
-                    if (name.isBlank()) continue
-                    entities.add(
-                        QqMusicPlaylistEntity(
-                            id = pl.optLong("dissid", 0L),
-                            name = name,
-                            coverUrl = pl.optString("logo", ""),
-                            songCount = songCount,
-                            lastSyncTime = System.currentTimeMillis()
+                    val data = root.optJSONObject("data") ?: break
+                    val cdlist = data.optJSONArray("cdlist") ?: break
+                    val fetchedCount = cdlist.length()
+                    if (fetchedCount == 0) break
+
+                    var newInPage = 0
+                    for (i in 0 until fetchedCount) {
+                        val pl = cdlist.optJSONObject(i) ?: continue
+                        val songCount = pl.optInt("songnum", 0)
+                        // Skip empty playlists (deleted or not yet populated)
+                        if (songCount == 0) continue
+                        val id = pl.optLong("dissid", 0L)
+                        if (id <= 0L) continue
+                        val name = decodeBase64IfNeeded(pl.optString("dissname", ""))
+                        // Skip playlists with blank names
+                        if (name.isBlank()) continue
+                        val previous = entitiesById.put(
+                            id,
+                            QqMusicPlaylistEntity(
+                                id = id,
+                                name = name,
+                                coverUrl = pl.optString("logo", ""),
+                                songCount = songCount,
+                                lastSyncTime = System.currentTimeMillis()
+                            )
                         )
+                        if (previous == null) newInPage += 1
+                    }
+
+                    start += fetchedCount
+
+                    val totalCandidates = listOf(
+                        data.optInt("total", -1),
+                        data.optInt("dissnum", -1),
+                        data.optInt("totaldissnum", -1),
+                        data.optInt("cdnum", -1),
+                        data.optInt("dirnum", -1)
                     )
+                    val total = totalCandidates.firstOrNull { it > 0 } ?: -1
+                    val reachedTotal = total > 0 && start >= total
+                    val hasLikelyMore = fetchedCount >= QQ_USER_PLAYLIST_PAGE_SIZE
+
+                    if (reachedTotal || !hasLikelyMore) break
+                    if (newInPage == 0 && page > 0) {
+                        Timber.w("syncUserPlaylists: pagination returned no new playlists at page=$page, stopping")
+                        break
+                    }
+
+                    page += 1
+                    if (page >= QQ_MAX_PLAYLIST_PAGES) {
+                        Timber.w("syncUserPlaylists: reached max page guard ($QQ_MAX_PLAYLIST_PAGES), stopping pagination")
+                        break
+                    }
                 }
+
+                val entities = entitiesById.values.toList()
 
                 val localPlaylists = dao.getAllPlaylistsList()
                 val remoteIds = entities.map { it.id }.toSet()
@@ -287,22 +329,65 @@ class QqMusicRepository @Inject constructor(
     suspend fun syncPlaylistSongs(playlistId: Long): Result<Int> {
         return withContext(Dispatchers.IO) {
             runCatching {
-                val raw = api.getPlaylistDetail(playlistId)
-                val root = JSONObject(raw)
+                val entitiesById = LinkedHashMap<String, QqMusicSongEntity>()
+                var songBegin = 0
+                var page = 0
+                var expectedSongCount = -1
 
-                val code = root.optInt("code", -1)
-                if (code != 0) {
-                    throw Exception("API error code=$code")
+                while (true) {
+                    val raw = api.getPlaylistDetail(
+                        playlistId = playlistId,
+                        songBegin = songBegin,
+                        songNum = QQ_PLAYLIST_SONG_PAGE_SIZE
+                    )
+                    val root = JSONObject(raw)
+
+                    val code = root.optInt("code", -1)
+                    if (code != 0) {
+                        throw Exception("API error code=$code")
+                    }
+
+                    val cdlist = root.optJSONArray("cdlist") ?: throw Exception("No cdlist")
+                    val firstCd = cdlist.optJSONObject(0) ?: throw Exception("Empty cdlist")
+                    val songlist = firstCd.optJSONArray("songlist") ?: break
+                    val fetchedCount = songlist.length()
+                    if (fetchedCount == 0) break
+
+                    if (expectedSongCount < 0) {
+                        expectedSongCount = firstCd.optInt("songnum", firstCd.optInt("total_song_num", -1))
+                    }
+
+                    var newInPage = 0
+                    for (i in 0 until fetchedCount) {
+                        val track = songlist.optJSONObject(i) ?: continue
+                        val entity = parseTrackToEntity(track, playlistId)
+                        if (entity.songMid.isBlank()) continue
+                        val previous = entitiesById.put(entity.id, entity)
+                        if (previous == null) newInPage += 1
+                    }
+
+                    songBegin += fetchedCount
+                    val reachedExpected = expectedSongCount > 0 && songBegin >= expectedSongCount
+                    val hasLikelyMore = fetchedCount >= QQ_PLAYLIST_SONG_PAGE_SIZE
+
+                    if (reachedExpected || !hasLikelyMore) break
+                    if (newInPage == 0) {
+                        Timber.w("syncPlaylistSongs: pagination returned no new songs for playlistId=$playlistId at page=$page, stopping")
+                        break
+                    }
+
+                    page += 1
+                    if (page >= QQ_MAX_PLAYLIST_PAGES) {
+                        Timber.w("syncPlaylistSongs: reached max page guard ($QQ_MAX_PLAYLIST_PAGES) for playlistId=$playlistId")
+                        break
+                    }
                 }
 
-                val cdlist = root.optJSONArray("cdlist") ?: throw Exception("No cdlist")
-                val firstCd = cdlist.optJSONObject(0) ?: throw Exception("Empty cdlist")
-                val songlist = firstCd.optJSONArray("songlist") ?: return@runCatching 0
-
-                val entities = mutableListOf<QqMusicSongEntity>()
-                for (i in 0 until songlist.length()) {
-                    val track = songlist.optJSONObject(i) ?: continue
-                    entities.add(parseTrackToEntity(track, playlistId))
+                val entities = entitiesById.values.toList()
+                if (expectedSongCount > 0 && entities.size < expectedSongCount) {
+                    Timber.w(
+                        "syncPlaylistSongs: playlistId=$playlistId expected=$expectedSongCount synced=${entities.size} (API may still be limiting)"
+                    )
                 }
 
                 dao.deleteSongsByPlaylist(playlistId)


### PR DESCRIPTION
… and QQ Music

- **Netease Cloud Music**:
    - Add `getSongDetails` API to fetch full track metadata for large playlists where the detail API only returns a subset of tracks.
    - Implement paginated fetching for user playlists using `offset` and `limit` to ensure all playlists are discovered.
    - Enhance `syncPlaylistSongs` to identify missing tracks using `trackIds` and fetch them in batches (500 songs/request).
    - Maintain playlist track ordering based on the remote `trackIds` list.

- **QQ Music**:
    - Update `getUserPlaylists` and `getPlaylistDetail` API calls to support pagination parameters (`sin`/`ein` and `song_begin`/`song_num`).
    - Implement a loop-based pagination strategy in `syncUserPlaylists` to retrieve all user-created and collected playlists.
    - Implement paginated song retrieval in `syncPlaylistSongs` (1000 songs per page) to handle large playlists that were previously truncated.

- **General**:
    - Add safety guards (`MAX_PLAYLIST_PAGES`) to prevent infinite loops during synchronization.
    - Improve logging for synchronization progress and error states.
    - Use `LinkedHashMap` to maintain insertion order while preventing duplicate entities during paginated fetches.