### PR TITLE
Add intent filters for music widgets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,7 +63,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.APP_MUSIC" />
             </intent-filter>
-            
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />


### PR DESCRIPTION
Add standard intent filters for music widgets

This resolves an issue where third-party Material You widgets and other external controllers (in my specific case M3 Expressive Widgets) could not detect or launch PixelPlayer. The app was missing the standard APP_MUSIC category and MUSIC_PLAYER action intents in its manifest, preventing the Android system from offering it as a default player option.

Hopefully Fixes #831 