### PR TITLE
fix: reset refreshing state in StatsViewModel

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/StatsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/StatsViewModel.kt
@@ -105,6 +105,7 @@ class StatsViewModel @Inject constructor(
             _uiState.update { current ->
                 current.copy(
                     isLoading = false,
+                    isRefreshing = false,
                     summary = summary.getOrNull(),
                     selectedRange = range
                 )


### PR DESCRIPTION
- Update `StatsViewModel` to set `isRefreshing` to `false` when loading completes to correctly reflect the UI state.