### PR TITLE
feat: refactor grayscale color scheme generation for neutral artwork

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
@@ -387,6 +387,6 @@ class ColorSchemeProcessor @Inject constructor(
     companion object {
         private const val TAG = "ColorSchemeProcessor"
         private const val CACHE_KEY_SEPARATOR = "|"
-        private const val CACHE_ALGORITHM_VERSION = "algo_v2"
+        private const val CACHE_ALGORITHM_VERSION = "algo_v5"
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
@@ -5,6 +5,7 @@ import android.util.LruCache
 import androidx.compose.material3.ColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
 import com.theveloper.pixelplay.presentation.viewmodel.ColorSchemePair
 import com.google.android.material.color.utilities.DynamicScheme
 import com.google.android.material.color.utilities.Hct
@@ -13,11 +14,11 @@ import com.google.android.material.color.utilities.QuantizerCelebi
 import com.google.android.material.color.utilities.SchemeExpressive
 import com.google.android.material.color.utilities.SchemeFruitSalad
 import com.google.android.material.color.utilities.SchemeMonochrome
-import com.google.android.material.color.utilities.SchemeNeutral
 import com.google.android.material.color.utilities.SchemeTonalSpot
 import com.google.android.material.color.utilities.SchemeVibrant
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
 import androidx.core.graphics.scale
+import kotlin.math.abs
 import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.roundToInt
@@ -46,12 +47,13 @@ private data class ScoredHct(
 )
 
 private val extractedColorCache = LruCache<Int, Color>(32)
-private const val GRAYSCALE_CHROMA_THRESHOLD = 10.0
+private const val GRAYSCALE_CHROMA_THRESHOLD = 12.0
 private const val NEUTRAL_PIXEL_CHROMA_THRESHOLD = 8.0
 private const val HIGH_CHROMA_THRESHOLD = 18.0
 private const val REQUIRED_NEUTRAL_POPULATION = 0.92
 private const val MAX_HIGH_CHROMA_POPULATION = 0.03
 private const val MAX_WEIGHTED_CHROMA_FOR_NEUTRAL = 9.0
+private const val MAX_GRAYSCALE_CHANNEL_DELTA = 14
 
 fun clearExtractedColorCache() {
     extractedColorCache.evictAll()
@@ -82,10 +84,8 @@ fun extractSeedColor(
         val quantized = QuantizerCelebi.quantize(pixels, config.quantizerMaxColors)
         val mostlyNeutralArtwork = isMostlyNeutralArtwork(quantized)
 
-        if (mostlyNeutralArtwork) {
-            val avgHct = Hct.fromInt(fallbackArgb)
-            val neutralSeed = Hct.from(avgHct.hue, 0.0, avgHct.tone).toInt()
-            return@runCatching Color(neutralSeed)
+        if (mostlyNeutralArtwork && isArgbNearGrayscale(fallbackArgb)) {
+            return@runCatching Color(fallbackArgb)
         }
 
         val rankedSeeds = scoreQuantizedColors(
@@ -109,22 +109,29 @@ fun generateColorSchemeFromSeed(
     paletteStyle: AlbumArtPaletteStyle = AlbumArtPaletteStyle.default
 ): ColorSchemePair {
     return runCatching {
-        val sourceHct = Hct.fromInt(seedColor.toArgb())
-        val shouldForceNeutral = sourceHct.chroma < GRAYSCALE_CHROMA_THRESHOLD
+        val seedArgb = seedColor.toArgb()
+        val sourceHct = Hct.fromInt(seedArgb)
+        val shouldForceNeutral = paletteStyle != AlbumArtPaletteStyle.MONOCHROME &&
+            shouldUseNeutralArtworkScheme(seedArgb, sourceHct)
 
         val lightScheme = createDynamicScheme(
             sourceHct = sourceHct,
             paletteStyle = paletteStyle,
-            isDark = false,
-            forceNeutral = shouldForceNeutral
+            isDark = false
         ).toComposeColorScheme()
         val darkScheme = createDynamicScheme(
             sourceHct = sourceHct,
             paletteStyle = paletteStyle,
-            isDark = true,
-            forceNeutral = shouldForceNeutral
+            isDark = true
         ).toComposeColorScheme()
-        ColorSchemePair(lightScheme, darkScheme)
+        if (shouldForceNeutral) {
+            ColorSchemePair(
+                light = lightScheme.toGrayscaleColorScheme(),
+                dark = darkScheme.toGrayscaleColorScheme()
+            )
+        } else {
+            ColorSchemePair(lightScheme, darkScheme)
+        }
     }.getOrElse {
         ColorSchemePair(LightColorScheme, DarkColorScheme)
     }
@@ -215,13 +222,8 @@ private fun scoreQuantizedColors(
 private fun createDynamicScheme(
     sourceHct: Hct,
     paletteStyle: AlbumArtPaletteStyle,
-    isDark: Boolean,
-    forceNeutral: Boolean
+    isDark: Boolean
 ): DynamicScheme {
-    if (forceNeutral && paletteStyle != AlbumArtPaletteStyle.MONOCHROME) {
-        return SchemeNeutral(sourceHct, isDark, 0.0)
-    }
-
     return when (paletteStyle) {
         AlbumArtPaletteStyle.TONAL_SPOT -> SchemeTonalSpot(sourceHct, isDark, 0.0)
         AlbumArtPaletteStyle.VIBRANT -> SchemeVibrant(sourceHct, isDark, 0.0)
@@ -284,6 +286,83 @@ private fun isMostlyNeutralArtwork(colorsToPopulation: Map<Int, Int>): Boolean {
     return neutralRatio >= REQUIRED_NEUTRAL_POPULATION &&
         highChromaRatio <= MAX_HIGH_CHROMA_POPULATION &&
         meanChroma <= MAX_WEIGHTED_CHROMA_FOR_NEUTRAL
+}
+
+private fun shouldUseNeutralArtworkScheme(argb: Int, sourceHct: Hct): Boolean {
+    return sourceHct.chroma <= GRAYSCALE_CHROMA_THRESHOLD &&
+        isArgbNearGrayscale(argb)
+}
+
+private fun isArgbNearGrayscale(argb: Int): Boolean {
+    val red = (argb ushr 16) and 0xFF
+    val green = (argb ushr 8) and 0xFF
+    val blue = argb and 0xFF
+    return maxOf(
+        abs(red - green),
+        abs(green - blue),
+        abs(red - blue)
+    ) <= MAX_GRAYSCALE_CHANNEL_DELTA
+}
+
+private fun ColorScheme.toGrayscaleColorScheme(): ColorScheme {
+    fun convert(color: Color): Color {
+        val hsl = FloatArray(3)
+        ColorUtils.colorToHSL(color.toArgb(), hsl)
+        hsl[0] = 0f
+        hsl[1] = 0f
+        return Color(ColorUtils.HSLToColor(hsl))
+    }
+
+    return copy(
+        primary = convert(primary),
+        onPrimary = convert(onPrimary),
+        primaryContainer = convert(primaryContainer),
+        onPrimaryContainer = convert(onPrimaryContainer),
+        inversePrimary = convert(inversePrimary),
+        secondary = convert(secondary),
+        onSecondary = convert(onSecondary),
+        secondaryContainer = convert(secondaryContainer),
+        onSecondaryContainer = convert(onSecondaryContainer),
+        tertiary = convert(tertiary),
+        onTertiary = convert(onTertiary),
+        tertiaryContainer = convert(tertiaryContainer),
+        onTertiaryContainer = convert(onTertiaryContainer),
+        background = convert(background),
+        onBackground = convert(onBackground),
+        surface = convert(surface),
+        onSurface = convert(onSurface),
+        surfaceVariant = convert(surfaceVariant),
+        onSurfaceVariant = convert(onSurfaceVariant),
+        surfaceTint = convert(surfaceTint),
+        inverseSurface = convert(inverseSurface),
+        inverseOnSurface = convert(inverseOnSurface),
+        error = convert(error),
+        onError = convert(onError),
+        errorContainer = convert(errorContainer),
+        onErrorContainer = convert(onErrorContainer),
+        outline = convert(outline),
+        outlineVariant = convert(outlineVariant),
+        scrim = convert(scrim),
+        surfaceBright = convert(surfaceBright),
+        surfaceDim = convert(surfaceDim),
+        surfaceContainer = convert(surfaceContainer),
+        surfaceContainerHigh = convert(surfaceContainerHigh),
+        surfaceContainerHighest = convert(surfaceContainerHighest),
+        surfaceContainerLow = convert(surfaceContainerLow),
+        surfaceContainerLowest = convert(surfaceContainerLowest),
+        primaryFixed = convert(primaryFixed),
+        primaryFixedDim = convert(primaryFixedDim),
+        onPrimaryFixed = convert(onPrimaryFixed),
+        onPrimaryFixedVariant = convert(onPrimaryFixedVariant),
+        secondaryFixed = convert(secondaryFixed),
+        secondaryFixedDim = convert(secondaryFixedDim),
+        onSecondaryFixed = convert(onSecondaryFixed),
+        onSecondaryFixedVariant = convert(onSecondaryFixedVariant),
+        tertiaryFixed = convert(tertiaryFixed),
+        tertiaryFixedDim = convert(tertiaryFixedDim),
+        onTertiaryFixed = convert(onTertiaryFixed),
+        onTertiaryFixedVariant = convert(onTertiaryFixedVariant)
+    )
 }
 
 private fun DynamicScheme.toComposeColorScheme(): ColorScheme {

--- a/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
@@ -1,0 +1,201 @@
+package com.theveloper.pixelplay.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.core.graphics.ColorUtils
+import com.google.android.material.color.utilities.DynamicScheme
+import com.google.android.material.color.utilities.Hct
+import com.google.android.material.color.utilities.SchemeExpressive
+import com.google.android.material.color.utilities.SchemeFruitSalad
+import com.google.android.material.color.utilities.SchemeMonochrome
+import com.google.android.material.color.utilities.SchemeTonalSpot
+import com.google.android.material.color.utilities.SchemeVibrant
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
+import org.junit.Test
+
+class ColorRolesTest {
+    private val nonMonochromeStyles = AlbumArtPaletteStyle.entries.filterNot {
+        it == AlbumArtPaletteStyle.MONOCHROME
+    }
+
+    @Test
+    fun generateColorSchemeFromSeed_autoNeutralOutputIsPureGrayscale() {
+        val seed = Color(0xFF7F7F7F)
+
+        nonMonochromeStyles.forEach { style ->
+            val actual = generateColorSchemeFromSeed(seed, style)
+            val nonGrayscaleLight = actual.light.toArgbList().filterNot(::isGrayscaleArgb)
+            val nonGrayscaleDark = actual.dark.toArgbList().filterNot(::isGrayscaleArgb)
+
+            assertThat(nonGrayscaleLight).isEmpty()
+            assertThat(nonGrayscaleDark).isEmpty()
+        }
+    }
+
+    @Test
+    fun generateColorSchemeFromSeed_keepsStyleSpecificSchemeForMutedGreenSeeds() {
+        val seed = Color(0xFF556B2F)
+        val sourceHct = Hct.fromInt(seed.toArgb())
+
+        nonMonochromeStyles.forEach { style ->
+            val actual = generateColorSchemeFromSeed(seed, style)
+
+            assertThat(actual.light.toArgbList())
+                .containsExactlyElementsIn(
+                    expectedScheme(style, sourceHct, isDark = false).toArgbList()
+                )
+                .inOrder()
+            assertThat(actual.dark.toArgbList())
+                .containsExactlyElementsIn(
+                    expectedScheme(style, sourceHct, isDark = true).toArgbList()
+                )
+                .inOrder()
+        }
+    }
+
+    @Test
+    fun generateColorSchemeFromSeed_keepsMonochromeStyleExplicit() {
+        val seed = Color(0xFF7F7F7F)
+        val sourceHct = Hct.fromInt(seed.toArgb())
+        val actual = generateColorSchemeFromSeed(seed, AlbumArtPaletteStyle.MONOCHROME)
+
+        assertThat(actual.light.toArgbList())
+            .containsExactlyElementsIn(
+                SchemeMonochrome(sourceHct, false, 0.0).toArgbList()
+            )
+            .inOrder()
+        assertThat(actual.dark.toArgbList())
+            .containsExactlyElementsIn(
+                SchemeMonochrome(sourceHct, true, 0.0).toArgbList()
+            )
+            .inOrder()
+    }
+
+    private fun expectedScheme(
+        style: AlbumArtPaletteStyle,
+        sourceHct: Hct,
+        isDark: Boolean
+    ): DynamicScheme {
+        return when (style) {
+            AlbumArtPaletteStyle.TONAL_SPOT -> SchemeTonalSpot(sourceHct, isDark, 0.0)
+            AlbumArtPaletteStyle.VIBRANT -> SchemeVibrant(sourceHct, isDark, 0.0)
+            AlbumArtPaletteStyle.EXPRESSIVE -> SchemeExpressive(sourceHct, isDark, 0.0)
+            AlbumArtPaletteStyle.FRUIT_SALAD -> SchemeFruitSalad(sourceHct, isDark, 0.0)
+            AlbumArtPaletteStyle.MONOCHROME -> SchemeMonochrome(sourceHct, isDark, 0.0)
+        }
+    }
+
+    private fun ColorScheme.toArgbList(): List<Int> {
+        return listOf(
+            primary,
+            onPrimary,
+            primaryContainer,
+            onPrimaryContainer,
+            inversePrimary,
+            secondary,
+            onSecondary,
+            secondaryContainer,
+            onSecondaryContainer,
+            tertiary,
+            onTertiary,
+            tertiaryContainer,
+            onTertiaryContainer,
+            background,
+            onBackground,
+            surface,
+            onSurface,
+            surfaceVariant,
+            onSurfaceVariant,
+            surfaceTint,
+            inverseSurface,
+            inverseOnSurface,
+            error,
+            onError,
+            errorContainer,
+            onErrorContainer,
+            outline,
+            outlineVariant,
+            scrim,
+            surfaceBright,
+            surfaceDim,
+            surfaceContainer,
+            surfaceContainerHigh,
+            surfaceContainerHighest,
+            surfaceContainerLow,
+            surfaceContainerLowest,
+            primaryFixed,
+            primaryFixedDim,
+            onPrimaryFixed,
+            onPrimaryFixedVariant,
+            secondaryFixed,
+            secondaryFixedDim,
+            onSecondaryFixed,
+            onSecondaryFixedVariant,
+            tertiaryFixed,
+            tertiaryFixedDim,
+            onTertiaryFixed,
+            onTertiaryFixedVariant
+        ).map(Color::toArgb)
+    }
+
+    private fun DynamicScheme.toArgbList(): List<Int> {
+        return listOf(
+            getPrimary(),
+            getOnPrimary(),
+            getPrimaryContainer(),
+            getOnPrimaryContainer(),
+            getInversePrimary(),
+            getSecondary(),
+            getOnSecondary(),
+            getSecondaryContainer(),
+            getOnSecondaryContainer(),
+            getTertiary(),
+            getOnTertiary(),
+            getTertiaryContainer(),
+            getOnTertiaryContainer(),
+            getBackground(),
+            getOnBackground(),
+            getSurface(),
+            getOnSurface(),
+            getSurfaceVariant(),
+            getOnSurfaceVariant(),
+            getSurfaceTint(),
+            getInverseSurface(),
+            getInverseOnSurface(),
+            getError(),
+            getOnError(),
+            getErrorContainer(),
+            getOnErrorContainer(),
+            getOutline(),
+            getOutlineVariant(),
+            getScrim(),
+            getSurfaceBright(),
+            getSurfaceDim(),
+            getSurfaceContainer(),
+            getSurfaceContainerHigh(),
+            getSurfaceContainerHighest(),
+            getSurfaceContainerLow(),
+            getSurfaceContainerLowest(),
+            getPrimaryFixed(),
+            getPrimaryFixedDim(),
+            getOnPrimaryFixed(),
+            getOnPrimaryFixedVariant(),
+            getSecondaryFixed(),
+            getSecondaryFixedDim(),
+            getOnSecondaryFixed(),
+            getOnSecondaryFixedVariant(),
+            getTertiaryFixed(),
+            getTertiaryFixedDim(),
+            getOnTertiaryFixed(),
+            getOnTertiaryFixedVariant()
+        )
+    }
+
+    private fun isGrayscaleArgb(argb: Int): Boolean {
+        val hsl = FloatArray(3)
+        ColorUtils.colorToHSL(argb, hsl)
+        return hsl[1] == 0f
+    }
+}


### PR DESCRIPTION
- **Color Extraction**:
    - Refine neutral artwork detection by introducing `isArgbNearGrayscale` and increasing the `GRAYSCALE_CHROMA_THRESHOLD` to 12.0.
    - Update seed color selection to preserve the fallback ARGB value when artwork is identified as mostly neutral.
- **Color Roles & Theming**:
    - Implement `toGrayscaleColorScheme` to explicitly convert all `ColorScheme` roles to pure grayscale via HSL manipulation when a neutral scheme is required.
    - Replace `SchemeNeutral` with a manual grayscale transformation of the selected palette style to ensure consistency across different `AlbumArtPaletteStyle` configurations.
    - Add `shouldUseNeutralArtworkScheme` logic to prevent forced neutral schemes when using `AlbumArtPaletteStyle.MONOCHROME`.
- **Infrastructure**:
    - Increment `CACHE_ALGORITHM_VERSION` to `algo_v5` to invalidate previous color extraction results.
    - Add `ColorRolesTest` to verify grayscale output for neutral seeds and ensure style-specific schemes are preserved for colorful seeds.