### PR TITLE
Fix Navidrome multi-playlist sync overwrite for non-numeric playlist IDs

### DIFF
--- a/app/schemas/com.theveloper.pixelplay.data.database.PixelPlayDatabase/29.json
+++ b/app/schemas/com.theveloper.pixelplay.data.database.PixelPlayDatabase/29.json
@@ -2067,7 +2067,7 @@
       },
       {
         "tableName": "navidrome_songs",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `navidrome_id` TEXT NOT NULL, `playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `cover_art_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `suffix` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `navidrome_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `cover_art_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `suffix` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -2084,7 +2084,7 @@
           {
             "fieldPath": "playlistId",
             "columnName": "playlist_id",
-            "affinity": "INTEGER",
+            "affinity": "TEXT",
             "notNull": true
           },
           {

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeDao.kt
@@ -21,7 +21,7 @@ interface NavidromeDao {
     suspend fun getAllNavidromeSongsList(): List<NavidromeSongEntity>
 
     @Query("SELECT * FROM navidrome_songs WHERE playlist_id = :playlistId ORDER BY date_added DESC")
-    fun getSongsByPlaylist(playlistId: Long): Flow<List<NavidromeSongEntity>>
+    fun getSongsByPlaylist(playlistId: String): Flow<List<NavidromeSongEntity>>
 
     @Query("SELECT * FROM navidrome_songs WHERE title LIKE '%' || :query || '%' OR artist LIKE '%' || :query || '%'")
     fun searchSongs(query: String): Flow<List<NavidromeSongEntity>>
@@ -42,7 +42,7 @@ interface NavidromeDao {
     suspend fun deleteSong(songId: String)
 
     @Query("DELETE FROM navidrome_songs WHERE playlist_id = :playlistId")
-    suspend fun deleteSongsByPlaylist(playlistId: Long)
+    suspend fun deleteSongsByPlaylist(playlistId: String)
 
     // ─── Playlists ─────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeSongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeSongEntity.kt
@@ -12,7 +12,7 @@ import com.theveloper.pixelplay.data.navidrome.model.NavidromeSong
  *
  * @property id The composite ID (playlistId_songId)
  * @property navidromeId The unique song ID from the Subsonic server
- * @property playlistId The ID of the playlist this song belongs to (0 if not in a playlist)
+ * @property playlistId The ID of the playlist this song belongs to
  * @property title The song title
  * @property artist The artist name
  * @property artistId The artist ID on the server (optional)
@@ -41,7 +41,7 @@ import com.theveloper.pixelplay.data.navidrome.model.NavidromeSong
 data class NavidromeSongEntity(
     @PrimaryKey val id: String,
     @ColumnInfo(name = "navidrome_id") val navidromeId: String,
-    @ColumnInfo(name = "playlist_id") val playlistId: Long,
+    @ColumnInfo(name = "playlist_id") val playlistId: String,
     val title: String,
     val artist: String,
     @ColumnInfo(name = "artist_id") val artistId: String?,
@@ -89,7 +89,7 @@ fun NavidromeSongEntity.toSong(): Song {
 /**
  * Convert a [NavidromeSong] to a [NavidromeSongEntity] for database storage.
  */
-fun NavidromeSong.toEntity(playlistId: Long): NavidromeSongEntity {
+fun NavidromeSong.toEntity(playlistId: String): NavidromeSongEntity {
     return NavidromeSongEntity(
         id = "${playlistId}_$id",
         navidromeId = id,

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -777,7 +777,7 @@ abstract class PixelPlayDatabase : RoomDatabase() {
                     CREATE TABLE IF NOT EXISTS navidrome_songs (
                         id TEXT NOT NULL PRIMARY KEY,
                         navidrome_id TEXT NOT NULL,
-                        playlist_id INTEGER NOT NULL,
+                        playlist_id TEXT NOT NULL,
                         title TEXT NOT NULL,
                         artist TEXT NOT NULL,
                         artist_id TEXT,

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -165,7 +165,7 @@ class NavidromeRepository @Inject constructor(
         // Delete all Navidrome playlists from database
         val playlistsToDelete = dao.getAllPlaylistsList()
         playlistsToDelete.forEach { playlist ->
-            dao.deleteSongsByPlaylist(playlist.id.toLongOrNull() ?: 0L)
+            dao.deleteSongsByPlaylist(playlist.id)
             deleteAppPlaylistForNavidromePlaylist(playlist.id)
         }
 
@@ -245,7 +245,7 @@ class NavidromeRepository @Inject constructor(
                 if (stalePlaylists.isNotEmpty()) {
                     Timber.d("$TAG: Removing ${stalePlaylists.size} stale playlists")
                     stalePlaylists.forEach { stale ->
-                        dao.deleteSongsByPlaylist(stale.id.toLongOrNull() ?: 0L)
+                        dao.deleteSongsByPlaylist(stale.id)
                         dao.deletePlaylist(stale.id)
                         deleteAppPlaylistForNavidromePlaylist(stale.id)
                     }
@@ -294,11 +294,12 @@ class NavidromeRepository @Inject constructor(
                 }
 
                 val entities = songs.map { song: NavidromeSong ->
-                    song.toEntity(playlistId.toLongOrNull() ?: 0L)
+                    song.toEntity(playlistId)
                 }
 
                 if (entities.isNotEmpty()) {
-                    dao.deleteSongsByPlaylist(playlistId.toLongOrNull() ?: 0L)
+                    Timber.d("$TAG: Playlist $playlistId - Deleting old songs, inserting ${entities.size} new songs")
+                    dao.deleteSongsByPlaylist(playlistId)
                     dao.insertSongs(entities)
                     
                     // Update app playlist only if we have data
@@ -308,14 +309,17 @@ class NavidromeRepository @Inject constructor(
                     // This is a TRULY empty playlist on the server.
                     // We should ONLY clear it if we actually got a successful empty list response,
                     // not a parse error.
-                    dao.deleteSongsByPlaylist(playlistId.toLongOrNull() ?: 0L)
+                    Timber.d("$TAG: Playlist $playlistId is empty on server, clearing local cache")
+                    dao.deleteSongsByPlaylist(playlistId)
                     val playlistName = dao.getPlaylistById(playlistId)?.name ?: "Playlist"
                     updateAppPlaylistForNavidromePlaylist(playlistId, playlistName, emptyList())
                 } else {
                     Timber.w("$TAG: songJsons was not empty (${songJsons.size}) but entities was empty. Parsing issue?")
                 }
 
-                syncUnifiedLibrarySongsFromNavidrome()
+                // NOTE: Unified library sync is now handled by the caller (e.g., syncAllPlaylistsAndSongs)
+                // to avoid multiple redundant syncs. If you need immediate sync for single playlist,
+                // call syncUnifiedLibrarySongsFromNavidrome() after this method.
 
                 Timber.d("$TAG: Synced ${entities.size} songs for playlist $playlistId")
                 Result.success(entities.size)
@@ -360,6 +364,7 @@ class NavidromeRepository @Inject constructor(
                 )
             }
 
+            // Sync to unified library once after all playlists are synced
             syncUnifiedLibrarySongsFromNavidrome()
 
             Result.success(
@@ -381,7 +386,7 @@ class NavidromeRepository @Inject constructor(
      * Get songs in a playlist as Flow of Song.
      */
     fun getPlaylistSongs(playlistId: String): Flow<List<Song>> {
-        return dao.getSongsByPlaylist(playlistId.toLongOrNull() ?: 0L).map { entities ->
+        return dao.getSongsByPlaylist(playlistId).map { entities ->
             entities.map { it.toSong() }
         }
     }
@@ -683,7 +688,7 @@ class NavidromeRepository @Inject constructor(
     // ─── Delete ────────────────────────────────────────────────────────────
 
     suspend fun deletePlaylist(playlistId: String) {
-        dao.deleteSongsByPlaylist(playlistId.toLongOrNull() ?: 0L)
+        dao.deleteSongsByPlaylist(playlistId)
         dao.deletePlaylist(playlistId)
         deleteAppPlaylistForNavidromePlaylist(playlistId)
         syncUnifiedLibrarySongsFromNavidrome()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -79,7 +79,11 @@ class NavidromeDashboardViewModel @Inject constructor(
             _syncMessage.value = "Syncing songs..."
             val result = repository.syncPlaylistSongs(playlistId)
             result.fold(
-                onSuccess = { _syncMessage.value = "Synced $it songs" },
+                onSuccess = { count ->
+                    // Sync to unified library after successfully syncing individual playlist
+                    repository.syncUnifiedLibrarySongsFromNavidrome()
+                    _syncMessage.value = "Synced $count songs"
+                },
                 onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
             )
             _isSyncing.value = false


### PR DESCRIPTION
## Summary
- switch Navidrome  handling from numeric conversion to string across entity, DAO, and repository
- update schema/migration definition for  to 
- keep unified-library sync batched in bulk sync and trigger it explicitly after single-playlist sync

## Root Cause
Navidrome/OpenSubsonic playlist IDs are protocol-level string IDs. Converting IDs with  caused non-numeric IDs to collapse into , so songs from multiple playlists were written under the same playlist bucket.

## Validation
- To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.13/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon JVM discovery is an incubating feature.
Daemon will be stopped at the end of the build 
Reusing configuration cache.
> Task :shared:preBuild UP-TO-DATE
> Task :app:preBuild UP-TO-DATE
> Task :shared:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :app:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :app:preDebugBuild UP-TO-DATE
> Task :shared:preDebugBuild UP-TO-DATE
> Task :app:generateDebugResValues UP-TO-DATE
> Task :app:createDebugCompatibleScreenManifests UP-TO-DATE
> Task :shared:writeDebugAarMetadata UP-TO-DATE
> Task :shared:processDebugNavigationResources UP-TO-DATE
> Task :shared:generateDebugResValues UP-TO-DATE
> Task :shared:javaPreCompileDebug UP-TO-DATE
> Task :shared:processDebugManifest UP-TO-DATE
> Task :app:generateDebugBuildConfig UP-TO-DATE
> Task :shared:extractDeepLinksDebug UP-TO-DATE
> Task :app:extractDeepLinksDebug UP-TO-DATE
> Task :shared:generateDebugResources UP-TO-DATE
> Task :shared:packageDebugResources UP-TO-DATE
> Task :shared:compileDebugLibraryResources UP-TO-DATE
> Task :app:generateDebugResources UP-TO-DATE
> Task :shared:parseDebugLocalResources UP-TO-DATE
> Task :app:packageDebugResources UP-TO-DATE
> Task :shared:generateDebugRFile UP-TO-DATE
> Task :app:mapDebugSourceSetPaths UP-TO-DATE
> Task :app:mergeDebugResources UP-TO-DATE
> Task :app:checkDebugAarMetadata UP-TO-DATE
> Task :app:processDebugNavigationResources UP-TO-DATE
> Task :shared:compileDebugKotlin UP-TO-DATE
> Task :app:compileDebugNavigationResources UP-TO-DATE
> Task :app:parseDebugLocalResources UP-TO-DATE
> Task :shared:compileDebugJavaWithJavac NO-SOURCE
> Task :shared:bundleLibCompileToJarDebug UP-TO-DATE
> Task :app:processDebugMainManifest UP-TO-DATE
> Task :app:processDebugManifest UP-TO-DATE
> Task :app:processDebugManifestForPackage UP-TO-DATE
> Task :app:processDebugResources UP-TO-DATE
> Task :app:kspDebugKotlin UP-TO-DATE
> Task :app:compileDebugKotlin UP-TO-DATE

BUILD SUCCESSFUL in 3s
31 actionable tasks: 31 up-to-date
Configuration cache entry reused. passed

## Notes
This PR is prepared for development-stage testing and focuses on correctness of Navidrome playlist mapping and sync behavior.