### PR TITLE
Fix: correct artist online/offline identification

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -1073,12 +1073,18 @@ interface MusicDao {
                 :filterMode = 1
                 AND songs.content_uri_string NOT LIKE 'telegram://%'
                 AND songs.content_uri_string NOT LIKE 'netease://%'
+                AND songs.content_uri_string NOT LIKE 'gdrive://%'
+                AND songs.content_uri_string NOT LIKE 'qqmusic://%'
+                AND songs.content_uri_string NOT LIKE 'navidrome://%'
             )
             OR (
                 :filterMode = 2
                 AND (
                     songs.content_uri_string LIKE 'telegram://%'
                     OR songs.content_uri_string LIKE 'netease://%'
+                    OR songs.content_uri_string LIKE 'gdrive://%'
+                    OR songs.content_uri_string LIKE 'qqmusic://%'
+                    OR songs.content_uri_string LIKE 'navidrome://%'
                 )
             )
         )


### PR DESCRIPTION
## Description
The artist online/offline filter was inconsistent with songs and albums. Specifically, Google Drive, QQ Music, and Navidrome protocols were missing from the artist filtering logic in MusicDao.kt.

## Changes
- Updated getArtistsWithSongCountsFiltered query in MusicDao.kt to include gdrive://, qqmusic://, and navidrome:// protocols for proper online/offline categorization.

This ensures that artists from these sources are correctly hidden in offline mode and visible in online mode.