### PR TITLE
UI: optimize LibraryNavigationPill width and text overflow

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -2077,17 +2077,18 @@ fun LibraryNavigationPill(
                 softWrap = false,
             ).size.width.toDp()
         }
-        val idealTitleWidth = idealTextWidth +
-            titleHorizontalPadding * 2 +
-            titleIconSize +
-            titleIconSpacing
+        val targetArrowWidth = arrowContentWidth + (targetArrowHorizontalPadding * 2)
         val availableWidth = if (availableWidthPx > 0) {
             with(density) { availableWidthPx.toDp() }
         } else {
-            idealTitleWidth + arrowContentWidth + (targetArrowHorizontalPadding * 2) + pillGap
+            // High fallback value for initial composition
+            1000.dp
         }
-        val targetArrowWidth = arrowContentWidth + (targetArrowHorizontalPadding * 2)
-        val maxTitleWidth = (availableWidth - targetArrowWidth - pillGap).coerceAtLeast(0.dp)
+        val maxTitleWidth = (availableWidth - targetArrowWidth - pillGap - 40.dp).coerceAtLeast(0.dp)
+        val idealTitleWidth = idealTextWidth +
+            titleHorizontalPadding * 2 +
+            (if (showIcon) (titleIconSize + titleIconSpacing) else 0.dp) +
+            4.dp // Tiny safety buffer
         val naturalTitleWidth = minOf(idealTitleWidth, maxTitleWidth)
         val minCompressedTitleWidth = (
             titleHorizontalPadding * 2 +
@@ -2195,13 +2196,15 @@ fun LibraryNavigationPill(
                                     Spacer(modifier = Modifier.width(titleIconSpacing))
                                 }
                             }
-                            Text(
-                                modifier = Modifier.weight(1f, fill = false),
+            Text(
+                                modifier = Modifier
+                                    .weight(1f, fill = false)
+                                    .padding(end = 4.dp), // Add slight end padding for safety
                                 text = targetState.title,
                                 style = titleStyle,
                                 maxLines = 1,
                                 softWrap = false,
-                                overflow = TextOverflow.Ellipsis,
+                                overflow = TextOverflow.Visible, // Change to Visible to prevent early ellipsis
                                 color = MaterialTheme.colorScheme.onPrimaryContainer
                             )
                         }


### PR DESCRIPTION
## Description
This PR optimizes the `LibraryNavigationPill` in the Library screen to prevent premature text ellipsis when there is still available horizontal space.

### Changes:
- **Improved Width Calculation**: Adjusted `maxTitleWidth` logic to more accurately respect physical screen space while reserving space for the arrow button.
- **Dynamic Text Policy**: Changed `Text` overflow from `Ellipsis` to `Visible` and added a safety padding to ensure long tab titles are fully visible.
- **Icon-Aware Ideal Width**: The ideal width calculation now correctly deduces or includes icon space based on the `showIcon` state.

### Why?
- Users reported that tab titles were being truncated (showing '...') even when there was plenty of empty space to the right of the navigation pill.