### PR TITLE
feat: refine playback position synchronization and restoration logic

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -1300,11 +1300,13 @@ class MusicService : MediaLibraryService() {
                     resolvedIndex,
                     snapshot.currentPositionMs.coerceAtLeast(0L)
                 )
+                // Even paused restores must prepare the timeline so duration/seek state is
+                // available immediately when the UI opens after a cold start.
+                player.prepare()
                 player.repeatMode = safeRepeatMode
                 player.shuffleModeEnabled = false
                 isManualShuffleEnabled = snapshot.shuffleEnabled
                 if (snapshot.playWhenReady) {
-                    player.prepare()
                     player.playWhenReady = true
                 }
             } finally {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -60,9 +60,37 @@ class PlaybackStateHolder @Inject constructor(
     // Internal State
     private var isSeeking = false
     private var remoteSeekUnlockJob: Job? = null
+    private var pausedPositionOverrideMediaId: String? = null
+    private var pausedPositionOverrideMs: Long? = null
+    private var coldStartSnapshotMediaId: String? = null
+    private var coldStartSnapshotPositionMs: Long? = null
 
     fun initialize(coroutineScope: CoroutineScope) {
         this.scope = coroutineScope
+        scope?.launch {
+            val snapshot = runCatching {
+                userPreferencesRepository.getPlaybackQueueSnapshotOnce()
+            }.getOrNull() ?: return@launch
+
+            val snapshotMediaId = snapshot.currentMediaId
+                ?: snapshot.items.getOrNull(snapshot.currentIndex)?.mediaId
+                ?: return@launch
+            val snapshotPositionMs = snapshot.currentPositionMs.coerceAtLeast(0L)
+            if (snapshotPositionMs <= 0L) return@launch
+
+            coldStartSnapshotMediaId = snapshotMediaId
+            coldStartSnapshotPositionMs = snapshotPositionMs
+
+            val controller = mediaController
+            if (
+                controller != null &&
+                !controller.isPlaying &&
+                controller.currentMediaItem?.mediaId == snapshotMediaId &&
+                _currentPosition.value == 0L
+            ) {
+                _currentPosition.value = snapshotPositionMs
+            }
+        }
     }
 
     fun setMediaController(controller: MediaController?) {
@@ -75,6 +103,66 @@ class PlaybackStateHolder @Inject constructor(
 
     fun setCurrentPosition(positionMs: Long) {
         _currentPosition.value = positionMs.coerceAtLeast(0L)
+    }
+
+    fun syncCurrentPositionFromPlayer(mediaId: String?, reportedPositionMs: Long) {
+        _currentPosition.value = resolveUiPosition(mediaId, reportedPositionMs)
+    }
+
+    fun rememberPausedPositionOverride(mediaId: String?, positionMs: Long) {
+        val safeMediaId = mediaId?.takeIf { it.isNotBlank() } ?: return
+        val safePosition = positionMs.coerceAtLeast(0L)
+        pausedPositionOverrideMediaId = safeMediaId
+        pausedPositionOverrideMs = safePosition
+        _currentPosition.value = safePosition
+    }
+
+    fun clearCurrentPositionHints(mediaId: String? = null) {
+        if (mediaId == null || pausedPositionOverrideMediaId == mediaId) {
+            pausedPositionOverrideMediaId = null
+            pausedPositionOverrideMs = null
+        }
+        if (mediaId == null || coldStartSnapshotMediaId == mediaId) {
+            coldStartSnapshotMediaId = null
+            coldStartSnapshotPositionMs = null
+        }
+    }
+
+    private fun resolveUiPosition(mediaId: String?, reportedPositionMs: Long): Long {
+        val safeReportedPosition = reportedPositionMs.coerceAtLeast(0L)
+        val safeMediaId = mediaId?.takeIf { it.isNotBlank() }
+        if (safeMediaId == null) {
+            return safeReportedPosition
+        }
+
+        val pausedOverride = pausedPositionOverrideMs
+            ?.takeIf { pausedPositionOverrideMediaId == safeMediaId }
+        val coldStartSeed = coldStartSnapshotPositionMs
+            ?.takeIf { coldStartSnapshotMediaId == safeMediaId }
+        val preferredPosition = pausedOverride ?: coldStartSeed
+
+        if (preferredPosition == null) {
+            return safeReportedPosition
+        }
+
+        if (safeReportedPosition <= 0L) {
+            return preferredPosition
+        }
+
+        val drift = abs(safeReportedPosition - preferredPosition)
+        if (drift <= DURATION_MISMATCH_TOLERANCE_MS || safeReportedPosition >= preferredPosition) {
+            if (pausedPositionOverrideMediaId == safeMediaId) {
+                pausedPositionOverrideMediaId = null
+                pausedPositionOverrideMs = null
+            }
+            if (coldStartSnapshotMediaId == safeMediaId) {
+                coldStartSnapshotMediaId = null
+                coldStartSnapshotPositionMs = null
+            }
+            return safeReportedPosition
+        }
+
+        return preferredPosition
     }
     
     /* -------------------------------------------------------------------------- */
@@ -136,8 +224,10 @@ class PlaybackStateHolder @Inject constructor(
         } else {
             remoteSeekUnlockJob?.cancel()
             castStateHolder.setRemotelySeeking(false)
-            mediaController?.seekTo(position)
-            setCurrentPosition(position)
+            val targetPosition = position.coerceAtLeast(0L)
+            val currentMediaId = mediaController?.currentMediaItem?.mediaId
+            rememberPausedPositionOverride(currentMediaId, targetPosition)
+            mediaController?.seekTo(targetPosition)
         }
     }
 
@@ -353,8 +443,9 @@ class PlaybackStateHolder @Inject constructor(
                          )
                          
                          listeningStatsTracker.onProgress(currentPosition, true)
-                         if (_currentPosition.value != currentPosition) {
-                             _currentPosition.value = currentPosition
+                         val resolvedPosition = resolveUiPosition(currentMediaId, currentPosition)
+                         if (_currentPosition.value != resolvedPosition) {
+                             _currentPosition.value = resolvedPosition
                          }
                          
                          _stablePlayerState.update { state ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1989,6 +1989,18 @@ class PlayerViewModel @Inject constructor(
                 (castStateHolder.isRemotePlaybackActive.value || castStateHolder.isCastConnecting.value)
     }
 
+    private fun syncPlaybackPositionFromPlayer(
+        mediaId: String?,
+        reportedPositionMs: Long
+    ): Long {
+        playbackStateHolder.syncCurrentPositionFromPlayer(mediaId, reportedPositionMs)
+        val resolvedPosition = playbackStateHolder.currentPosition.value
+        if (resolvedPosition != _playerUiState.value.currentPosition) {
+            _playerUiState.update { it.copy(currentPosition = resolvedPosition) }
+        }
+        return resolvedPosition
+    }
+
     private fun setupMediaControllerListeners() {
         Trace.beginSection("PlayerViewModel.setupMediaControllerListeners")
         val playerCtrl = mediaController ?: return Trace.endSection()
@@ -2022,8 +2034,7 @@ class PlayerViewModel @Inject constructor(
                         totalDuration = resolvedDuration
                     )
                 }
-                playbackStateHolder.setCurrentPosition(initialPosition)
-                _playerUiState.update { it.copy(currentPosition = initialPosition) }
+                syncPlaybackPositionFromPlayer(mediaItem.mediaId, initialPosition)
                 viewModelScope.launch {
                     val uri = song.albumArtUriString?.toUri()
                     val currentUri = playbackStateHolder.stablePlayerState.value.currentSong?.albumArtUriString
@@ -2047,6 +2058,7 @@ class PlayerViewModel @Inject constructor(
                         playWhenReady = false
                     )
                 }
+                playbackStateHolder.clearCurrentPositionHints()
                 playbackStateHolder.setCurrentPosition(0L)
                 _playerUiState.update { it.copy(currentPosition = 0L) }
                 resetPlaybackAudioMetadata()
@@ -2077,10 +2089,7 @@ class PlayerViewModel @Inject constructor(
                 } else {
                     stopProgressUpdates()
                     val pausedPosition = playerCtrl.currentPosition.coerceAtLeast(0L)
-                    playbackStateHolder.setCurrentPosition(pausedPosition)
-                    if (pausedPosition != _playerUiState.value.currentPosition) {
-                        _playerUiState.update { it.copy(currentPosition = pausedPosition) }
-                    }
+                    syncPlaybackPositionFromPlayer(playerCtrl.currentMediaItem?.mediaId, pausedPosition)
                 }
             }
 
@@ -2151,13 +2160,15 @@ class PlayerViewModel @Inject constructor(
                                 playWhenReady = playerCtrl.playWhenReady
                             )
                         }
-                        playbackStateHolder.setCurrentPosition(0L)
-                        _playerUiState.update { it.copy(currentPosition = 0L) }
+                        val transitionPosition = syncPlaybackPositionFromPlayer(
+                            transitionedItem.mediaId,
+                            playerCtrl.currentPosition.coerceAtLeast(0L)
+                        )
 
                         song?.let { currentSongValue ->
                             listeningStatsTracker.onSongChanged(
                                 song = currentSongValue,
-                                positionMs = 0L,
+                                positionMs = transitionPosition,
                                 durationMs = resolvedDuration,
                                 isPlaying = playerCtrl.isPlaying
                             )
@@ -2181,6 +2192,7 @@ class PlayerViewModel @Inject constructor(
                                     totalDuration = 0L
                                 )
                             }
+                            playbackStateHolder.clearCurrentPositionHints()
                             resetPlaybackAudioMetadata()
                         }
                     }
@@ -2192,12 +2204,14 @@ class PlayerViewModel @Inject constructor(
                 refreshPlaybackAudioMetadata(playerCtrl)
                 if (playbackState == Player.STATE_READY) {
                     clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
+                    val readyPosition = playerCtrl.currentPosition.coerceAtLeast(0L)
                     val songDurationHint = playbackStateHolder.stablePlayerState.value.currentSong?.duration ?: 0L
                     val resolvedDuration = playbackStateHolder.resolveDurationForPlaybackState(
                         reportedDurationMs = playerCtrl.duration,
                         songDurationHintMs = songDurationHint,
-                        currentPositionMs = playerCtrl.currentPosition.coerceAtLeast(0L)
+                        currentPositionMs = readyPosition
                     )
+                    syncPlaybackPositionFromPlayer(playerCtrl.currentMediaItem?.mediaId, readyPosition)
                     playbackStateHolder.updateStablePlayerState { it.copy(totalDuration = resolvedDuration) }
                     listeningStatsTracker.updateDuration(resolvedDuration)
                     startProgressUpdates()
@@ -2220,6 +2234,7 @@ class PlayerViewModel @Inject constructor(
                                 totalDuration = 0L
                             )
                         }
+                        playbackStateHolder.clearCurrentPositionHints()
                         playbackStateHolder.setCurrentPosition(0L)
                         _playerUiState.update { it.copy(currentPosition = 0L) }
                         resetPlaybackAudioMetadata()
@@ -3127,6 +3142,10 @@ class PlayerViewModel @Inject constructor(
 
     fun seekTo(position: Long) {
         playbackStateHolder.seekTo(position)
+        val resolvedPosition = playbackStateHolder.currentPosition.value
+        if (resolvedPosition != _playerUiState.value.currentPosition) {
+            _playerUiState.update { it.copy(currentPosition = resolvedPosition) }
+        }
     }
 
     fun nextSong() {


### PR DESCRIPTION
- **Music Service**:
    - Ensure `player.prepare()` is always called during snapshot restoration, even when paused, to make duration and seek state available immediately after a cold start.
- **Playback Management**:
    - Implement `syncCurrentPositionFromPlayer` in `PlayerViewModel` to centralize UI position updates and handle state consistency.
    - Introduce "position hints" (paused overrides and cold start seeds) in `PlaybackStateHolder` to prevent the UI from flickering to 0ms when reloading a saved session or seeking while paused.
    - Implement a position resolution strategy that accounts for small drifts and ensures reported player positions eventually supersede cached hints once playback progresses.
    - Add `clearCurrentPositionHints` to reset manual position overrides during media transitions or player resets.
- **UI State**:
    - Improve synchronization between `PlaybackStateHolder` and `PlayerViewModel` UI state during seeks and state changes.
    - Initialize `PlaybackStateHolder` with a background check for the last saved playback snapshot to populate the initial UI position before the `MediaController` connects.