### PR TITLE
feat: refine playback position restoration and improve UI layout RTL …

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -567,7 +567,7 @@ fun UnifiedPlayerSheet(
                                         )
                                     )
                                     layout(constraints.maxWidth, targetHeightPx) {
-                                        placeable.place(startPaddingPx, 0)
+                                        placeable.placeRelative(startPaddingPx, 0)
                                     }
                                 }
                                 .miniPlayerDismissHorizontalGesture(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -550,7 +550,7 @@ fun UnifiedPlayerSheetV2(
                                     )
                                 )
                                 layout(constraints.maxWidth, targetHeightPx) {
-                                    placeable.place(startPaddingPx, 0)
+                                    placeable.placeRelative(startPaddingPx, 0)
                                 }
                             }
                             .miniPlayerDismissHorizontalGesture(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -60,9 +60,14 @@ class PlaybackStateHolder @Inject constructor(
     // Internal State
     private var isSeeking = false
     private var remoteSeekUnlockJob: Job? = null
+    private var activePositionOccurrenceMediaId: String? = null
+    private var activePositionOccurrenceToken: Long = 0L
+    private var nextPositionOccurrenceToken: Long = 1L
     private var pausedPositionOverrideMediaId: String? = null
+    private var pausedPositionOverrideToken: Long? = null
     private var pausedPositionOverrideMs: Long? = null
     private var coldStartSnapshotMediaId: String? = null
+    private var coldStartSnapshotToken: Long? = null
     private var coldStartSnapshotPositionMs: Long? = null
 
     fun initialize(coroutineScope: CoroutineScope) {
@@ -109,10 +114,20 @@ class PlaybackStateHolder @Inject constructor(
         _currentPosition.value = resolveUiPosition(mediaId, reportedPositionMs)
     }
 
+    fun ensureCurrentPlaybackOccurrence(mediaId: String?) {
+        activatePlaybackOccurrence(mediaId, forceNewOccurrence = false)
+    }
+
+    fun onPlaybackOccurrenceTransition(mediaId: String?) {
+        activatePlaybackOccurrence(mediaId, forceNewOccurrence = true)
+    }
+
     fun rememberPausedPositionOverride(mediaId: String?, positionMs: Long) {
         val safeMediaId = mediaId?.takeIf { it.isNotBlank() } ?: return
+        val activeToken = activatePlaybackOccurrence(safeMediaId, forceNewOccurrence = false) ?: return
         val safePosition = positionMs.coerceAtLeast(0L)
         pausedPositionOverrideMediaId = safeMediaId
+        pausedPositionOverrideToken = activeToken
         pausedPositionOverrideMs = safePosition
         _currentPosition.value = safePosition
     }
@@ -120,10 +135,12 @@ class PlaybackStateHolder @Inject constructor(
     fun clearCurrentPositionHints(mediaId: String? = null) {
         if (mediaId == null || pausedPositionOverrideMediaId == mediaId) {
             pausedPositionOverrideMediaId = null
+            pausedPositionOverrideToken = null
             pausedPositionOverrideMs = null
         }
         if (mediaId == null || coldStartSnapshotMediaId == mediaId) {
             coldStartSnapshotMediaId = null
+            coldStartSnapshotToken = null
             coldStartSnapshotPositionMs = null
         }
     }
@@ -135,10 +152,19 @@ class PlaybackStateHolder @Inject constructor(
             return safeReportedPosition
         }
 
+        val activeToken = activatePlaybackOccurrence(safeMediaId, forceNewOccurrence = false)
+            ?: return safeReportedPosition
+
         val pausedOverride = pausedPositionOverrideMs
-            ?.takeIf { pausedPositionOverrideMediaId == safeMediaId }
+            ?.takeIf {
+                pausedPositionOverrideMediaId == safeMediaId &&
+                    pausedPositionOverrideToken == activeToken
+            }
         val coldStartSeed = coldStartSnapshotPositionMs
-            ?.takeIf { coldStartSnapshotMediaId == safeMediaId }
+            ?.takeIf {
+                coldStartSnapshotMediaId == safeMediaId &&
+                    coldStartSnapshotToken == activeToken
+            }
         val preferredPosition = pausedOverride ?: coldStartSeed
 
         if (preferredPosition == null) {
@@ -151,18 +177,66 @@ class PlaybackStateHolder @Inject constructor(
 
         val drift = abs(safeReportedPosition - preferredPosition)
         if (drift <= DURATION_MISMATCH_TOLERANCE_MS || safeReportedPosition >= preferredPosition) {
-            if (pausedPositionOverrideMediaId == safeMediaId) {
+            if (pausedPositionOverrideMediaId == safeMediaId && pausedPositionOverrideToken == activeToken) {
                 pausedPositionOverrideMediaId = null
+                pausedPositionOverrideToken = null
                 pausedPositionOverrideMs = null
             }
-            if (coldStartSnapshotMediaId == safeMediaId) {
+            if (coldStartSnapshotMediaId == safeMediaId && coldStartSnapshotToken == activeToken) {
                 coldStartSnapshotMediaId = null
+                coldStartSnapshotToken = null
                 coldStartSnapshotPositionMs = null
             }
             return safeReportedPosition
         }
 
         return preferredPosition
+    }
+
+    private fun activatePlaybackOccurrence(
+        mediaId: String?,
+        forceNewOccurrence: Boolean
+    ): Long? {
+        val safeMediaId = mediaId?.takeIf { it.isNotBlank() } ?: run {
+            activePositionOccurrenceMediaId = null
+            activePositionOccurrenceToken = 0L
+            if (forceNewOccurrence) {
+                pausedPositionOverrideMediaId = null
+                pausedPositionOverrideToken = null
+                pausedPositionOverrideMs = null
+            }
+            return null
+        }
+
+        val shouldAdvance =
+            forceNewOccurrence ||
+                activePositionOccurrenceToken == 0L ||
+                activePositionOccurrenceMediaId != safeMediaId
+
+        if (!shouldAdvance) {
+            return activePositionOccurrenceToken
+        }
+
+        activePositionOccurrenceMediaId = safeMediaId
+        activePositionOccurrenceToken = nextPositionOccurrenceToken++
+
+        pausedPositionOverrideMediaId = null
+        pausedPositionOverrideToken = null
+        pausedPositionOverrideMs = null
+
+        if (coldStartSnapshotToken != null) {
+            coldStartSnapshotMediaId = null
+            coldStartSnapshotToken = null
+            coldStartSnapshotPositionMs = null
+        } else if (coldStartSnapshotMediaId == safeMediaId && coldStartSnapshotPositionMs != null) {
+            coldStartSnapshotToken = activePositionOccurrenceToken
+        } else if (coldStartSnapshotMediaId != null) {
+            coldStartSnapshotMediaId = null
+            coldStartSnapshotToken = null
+            coldStartSnapshotPositionMs = null
+        }
+
+        return activePositionOccurrenceToken
     }
     
     /* -------------------------------------------------------------------------- */

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2019,6 +2019,7 @@ class PlayerViewModel @Inject constructor(
         updateCurrentPlaybackQueueFromPlayer(playerCtrl)
 
         playerCtrl.currentMediaItem?.let { mediaItem ->
+            playbackStateHolder.ensureCurrentPlaybackOccurrence(mediaItem.mediaId)
             val song = resolveSongFromMediaItem(mediaItem)
 
             if (song != null) {
@@ -2100,6 +2101,7 @@ class PlayerViewModel @Inject constructor(
 
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 if (isRemoteSessionControllingPlayback()) return
+                playbackStateHolder.onPlaybackOccurrenceTransition(mediaItem?.mediaId)
                 preparePlaybackAudioMetadataForMedia(mediaItem?.mediaId)
                 transitionSchedulerJob?.cancel()
                 lyricsStateHolder.cancelLoading()

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
@@ -1,0 +1,77 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.model.PlaybackQueueItemSnapshot
+import com.theveloper.pixelplay.data.model.PlaybackQueueSnapshot
+import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
+import com.theveloper.pixelplay.data.service.player.DualPlayerEngine
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MainCoroutineExtension::class)
+class PlaybackStateHolderTest {
+
+    private val dualPlayerEngine: DualPlayerEngine = mockk(relaxed = true)
+    private val userPreferencesRepository: UserPreferencesRepository = mockk(relaxed = true)
+    private val castStateHolder: CastStateHolder = mockk(relaxed = true)
+    private val queueStateHolder: QueueStateHolder = mockk(relaxed = true)
+    private val listeningStatsTracker: ListeningStatsTracker = mockk(relaxed = true)
+
+    private fun createHolder() = PlaybackStateHolder(
+        dualPlayerEngine = dualPlayerEngine,
+        userPreferencesRepository = userPreferencesRepository,
+        castStateHolder = castStateHolder,
+        queueStateHolder = queueStateHolder,
+        listeningStatsTracker = listeningStatsTracker
+    )
+
+    @Test
+    fun `paused override does not bleed into later occurrence with same media id`() {
+        val holder = createHolder()
+
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
+        holder.rememberPausedPositionOverride("duplicate-song", 91_000L)
+
+        holder.onPlaybackOccurrenceTransition("another-song")
+        holder.onPlaybackOccurrenceTransition("duplicate-song")
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+
+        assertEquals(0L, holder.currentPosition.value)
+    }
+
+    @Test
+    fun `cold start snapshot only applies to the first matching occurrence`() = runTest {
+        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns PlaybackQueueSnapshot(
+            items = listOf(
+                PlaybackQueueItemSnapshot(
+                    mediaId = "duplicate-song",
+                    uri = "file:///music/duplicate-song.mp3"
+                )
+            ),
+            currentMediaId = "duplicate-song",
+            currentIndex = 0,
+            currentPositionMs = 48_000L
+        )
+
+        val holder = createHolder()
+        holder.initialize(this)
+        advanceUntilIdle()
+
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+        assertEquals(48_000L, holder.currentPosition.value)
+
+        holder.onPlaybackOccurrenceTransition("another-song")
+        holder.onPlaybackOccurrenceTransition("duplicate-song")
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+
+        assertEquals(0L, holder.currentPosition.value)
+    }
+}


### PR DESCRIPTION
…support

- **Playback Logic**:
    - Introduce "occurrence tokens" in `PlaybackStateHolder` to distinguish between different plays of the same media ID.
    - Ensure paused position overrides and cold start snapshots only apply to the specific occurrence they were intended for, preventing state bleeding across duplicate songs in a queue.
    - Add `ensureCurrentPlaybackOccurrence` and `onPlaybackOccurrenceTransition` to manage media transition lifecycle.
    - Fix an issue where a cold start snapshot could incorrectly apply to subsequent plays of the same song.
- **UI Components**:
    - Update `UnifiedPlayerSheet` and `UnifiedPlayerSheetV2` to use `placeRelative` in mini-player layout for better support of right-to-left (RTL) locales.
- **Testing**:
    - Add `PlaybackStateHolderTest` to verify position override isolation and snapshot application logic.