### PR TITLE
feat: refactor player sheet theme resolution and enhance SmartImage p…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -1716,6 +1716,7 @@ private fun QueueMiniPlayer(
                 model = song.albumArtUriString,
                 shape = albumShape,
                 contentDescription = "Carátula",
+                placeHolderBackgroundColor = colors.surfaceContainerLow,
                 modifier = Modifier
                     .size(56.dp)
                     .clip(albumShape),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
@@ -55,6 +55,7 @@ fun SmartImage(
     colorFilter: ColorFilter? = null,
     alpha: Float = 1f,
     placeholderModel: Any? = null,
+    placeHolderBackgroundColor: Color = MaterialTheme.colorScheme.surfaceContainerHigh,
     onState: ((AsyncImagePainter.State) -> Unit)? = null
 ) {
     val context = LocalContext.current
@@ -157,7 +158,7 @@ fun SmartImage(
                                 modifier = Modifier.fillMaxSize(),
                                 drawableResId = placeholderResId,
                                 contentDescription = contentDescription,
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                containerColor = placeHolderBackgroundColor,
                                 iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                 alpha = alpha
                             )
@@ -168,7 +169,7 @@ fun SmartImage(
                         modifier = Modifier.fillMaxSize(),
                         drawableResId = placeholderResId,
                         contentDescription = contentDescription,
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        containerColor = placeHolderBackgroundColor,
                         iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         alpha = alpha
                     )
@@ -191,7 +192,7 @@ fun SmartImage(
                         modifier = Modifier.fillMaxSize(),
                         drawableResId = errorResId,
                         contentDescription = contentDescription,
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        containerColor = placeHolderBackgroundColor,
                         iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         alpha = alpha
                     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetThemeState.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetThemeState.kt
@@ -37,6 +37,21 @@ internal data class SheetThemeState(
     val playerAreaBackground: Color
 )
 
+internal fun resolvePlayerSheetTargetScheme(
+    isAlbumArtTheme: Boolean,
+    hasAlbumArt: Boolean,
+    currentSongActiveScheme: ColorScheme?,
+    lastAlbumScheme: ColorScheme?,
+    systemColorScheme: ColorScheme
+): ColorScheme {
+    return when {
+        !isAlbumArtTheme || !hasAlbumArt -> systemColorScheme
+        currentSongActiveScheme != null -> currentSongActiveScheme
+        lastAlbumScheme != null -> lastAlbumScheme
+        else -> systemColorScheme
+    }
+}
+
 @Composable
 internal fun rememberSheetThemeState(
     activePlayerSchemePair: ColorSchemePair?,
@@ -48,8 +63,7 @@ internal fun rememberSheetThemeState(
     systemColorScheme: ColorScheme
 ): SheetThemeState {
     val isAlbumArtTheme = playerThemePreference == ThemePreference.ALBUM_ART
-    val hasAlbumArt = currentSong?.albumArtUriString != null
-    val needsAlbumScheme = isAlbumArtTheme && hasAlbumArt
+    val hasAlbumArt = !currentSong?.albumArtUriString.isNullOrBlank()
 
     val activePlayerScheme = remember(activePlayerSchemePair, isDarkTheme) {
         activePlayerSchemePair?.let { if (isDarkTheme) it.dark else it.light }
@@ -95,19 +109,23 @@ internal fun rememberSheetThemeState(
     // Capture nullable var for smart-cast
     val lastAlbumSchemeSnapshot = lastAlbumScheme
 
-    // Use lastAlbumScheme (previous song's color) as fallback while new color loads
-    val rawAlbumColorScheme = if (isAlbumArtTheme) {
-        currentSongActiveScheme ?: lastAlbumSchemeSnapshot ?: systemColorScheme
-    } else {
-        systemColorScheme
-    }
+    // Cross-song fallback is only valid while a new track with usable album art is still loading.
+    // Tracks without art must resolve directly to the system scheme, otherwise previous colors stick.
+    val rawAlbumColorScheme = resolvePlayerSheetTargetScheme(
+        isAlbumArtTheme = isAlbumArtTheme,
+        hasAlbumArt = hasAlbumArt,
+        currentSongActiveScheme = currentSongActiveScheme,
+        lastAlbumScheme = lastAlbumSchemeSnapshot,
+        systemColorScheme = systemColorScheme
+    )
 
-    val rawMiniPlayerScheme = when {
-        !needsAlbumScheme -> systemColorScheme
-        currentSongActiveScheme != null -> currentSongActiveScheme
-        lastAlbumSchemeSnapshot != null -> lastAlbumSchemeSnapshot
-        else -> systemColorScheme
-    }
+    val rawMiniPlayerScheme = resolvePlayerSheetTargetScheme(
+        isAlbumArtTheme = isAlbumArtTheme,
+        hasAlbumArt = hasAlbumArt,
+        currentSongActiveScheme = currentSongActiveScheme,
+        lastAlbumScheme = lastAlbumSchemeSnapshot,
+        systemColorScheme = systemColorScheme
+    )
 
     // --- Batch Color Animation ---
     // Instead of 34×2 = 68 independent animateColorAsState (one Spring coroutine each),

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/components/scoped/SheetThemeStateTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/components/scoped/SheetThemeStateTest.kt
@@ -1,0 +1,52 @@
+package com.theveloper.pixelplay.presentation.components.scoped
+
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SheetThemeStateTest {
+
+    private val systemScheme = lightColorScheme(primary = Color(0xFF336699))
+    private val activeAlbumScheme = lightColorScheme(primary = Color(0xFFAA2244))
+    private val previousAlbumScheme = lightColorScheme(primary = Color(0xFF228855))
+
+    @Test
+    fun resolvePlayerSheetTargetScheme_withoutAlbumArt_usesSystemScheme() {
+        val resolved = resolvePlayerSheetTargetScheme(
+            isAlbumArtTheme = true,
+            hasAlbumArt = false,
+            currentSongActiveScheme = null,
+            lastAlbumScheme = previousAlbumScheme,
+            systemColorScheme = systemScheme
+        )
+
+        assertThat(resolved).isSameInstanceAs(systemScheme)
+    }
+
+    @Test
+    fun resolvePlayerSheetTargetScheme_withPendingAlbumPalette_reusesPreviousAlbumScheme() {
+        val resolved = resolvePlayerSheetTargetScheme(
+            isAlbumArtTheme = true,
+            hasAlbumArt = true,
+            currentSongActiveScheme = null,
+            lastAlbumScheme = previousAlbumScheme,
+            systemColorScheme = systemScheme
+        )
+
+        assertThat(resolved).isSameInstanceAs(previousAlbumScheme)
+    }
+
+    @Test
+    fun resolvePlayerSheetTargetScheme_withReadyAlbumPalette_usesCurrentAlbumScheme() {
+        val resolved = resolvePlayerSheetTargetScheme(
+            isAlbumArtTheme = true,
+            hasAlbumArt = true,
+            currentSongActiveScheme = activeAlbumScheme,
+            lastAlbumScheme = previousAlbumScheme,
+            systemColorScheme = systemScheme
+        )
+
+        assertThat(resolved).isSameInstanceAs(activeAlbumScheme)
+    }
+}


### PR DESCRIPTION
…laceholders

- **Theming**:
    - Extract `resolvePlayerSheetTargetScheme` logic to a standalone internal function to ensure consistent color scheme resolution between the mini-player and full-screen player.
    - Fix an issue where colors from a previous album would persist on tracks without album art; tracks without art now correctly fallback to the system scheme immediately.
    - Improve track art detection by checking for null or blank URI strings.
    - Add Unit Tests for `SheetThemeState` resolution logic to cover system fallback, palette pending, and palette ready states.
- **UI Components**:
    - Update `SmartImage` to accept a custom `placeHolderBackgroundColor`, defaulting to `surfaceContainerHigh`.
    - Refine `QueueBottomSheet` list items to use `surfaceContainerLow` for image placeholders to improve visual contrast.