### PR TITLE
fix: improve cold start playback snapshot restoration in `PlaybackSta…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -70,6 +70,41 @@ class PlaybackStateHolder @Inject constructor(
     private var coldStartSnapshotToken: Long? = null
     private var coldStartSnapshotPositionMs: Long? = null
 
+    private fun clearColdStartSnapshot() {
+        coldStartSnapshotMediaId = null
+        coldStartSnapshotToken = null
+        coldStartSnapshotPositionMs = null
+    }
+
+    /**
+     * Binds a restored snapshot to the active playback occurrence when possible.
+     *
+     * If the first occurrence was already activated before the snapshot finished loading, we
+     * attach the snapshot to that token so resume still works. If playback has already advanced
+     * past the first occurrence, the snapshot is stale and must be discarded.
+     */
+    private fun rememberColdStartSnapshot(mediaId: String, positionMs: Long): Boolean {
+        coldStartSnapshotMediaId = mediaId
+        coldStartSnapshotToken = null
+        coldStartSnapshotPositionMs = positionMs
+
+        if (nextPositionOccurrenceToken == 1L) {
+            return true
+        }
+
+        if (
+            activePositionOccurrenceToken == 1L &&
+            nextPositionOccurrenceToken == 2L &&
+            activePositionOccurrenceMediaId == mediaId
+        ) {
+            coldStartSnapshotToken = activePositionOccurrenceToken
+            return true
+        }
+
+        clearColdStartSnapshot()
+        return false
+    }
+
     fun initialize(coroutineScope: CoroutineScope) {
         this.scope = coroutineScope
         scope?.launch {
@@ -82,9 +117,9 @@ class PlaybackStateHolder @Inject constructor(
                 ?: return@launch
             val snapshotPositionMs = snapshot.currentPositionMs.coerceAtLeast(0L)
             if (snapshotPositionMs <= 0L) return@launch
-
-            coldStartSnapshotMediaId = snapshotMediaId
-            coldStartSnapshotPositionMs = snapshotPositionMs
+            if (!rememberColdStartSnapshot(snapshotMediaId, snapshotPositionMs)) {
+                return@launch
+            }
 
             val controller = mediaController
             if (
@@ -139,9 +174,7 @@ class PlaybackStateHolder @Inject constructor(
             pausedPositionOverrideMs = null
         }
         if (mediaId == null || coldStartSnapshotMediaId == mediaId) {
-            coldStartSnapshotMediaId = null
-            coldStartSnapshotToken = null
-            coldStartSnapshotPositionMs = null
+            clearColdStartSnapshot()
         }
     }
 
@@ -183,9 +216,7 @@ class PlaybackStateHolder @Inject constructor(
                 pausedPositionOverrideMs = null
             }
             if (coldStartSnapshotMediaId == safeMediaId && coldStartSnapshotToken == activeToken) {
-                coldStartSnapshotMediaId = null
-                coldStartSnapshotToken = null
-                coldStartSnapshotPositionMs = null
+                clearColdStartSnapshot()
             }
             return safeReportedPosition
         }
@@ -225,15 +256,11 @@ class PlaybackStateHolder @Inject constructor(
         pausedPositionOverrideMs = null
 
         if (coldStartSnapshotToken != null) {
-            coldStartSnapshotMediaId = null
-            coldStartSnapshotToken = null
-            coldStartSnapshotPositionMs = null
+            clearColdStartSnapshot()
         } else if (coldStartSnapshotMediaId == safeMediaId && coldStartSnapshotPositionMs != null) {
             coldStartSnapshotToken = activePositionOccurrenceToken
         } else if (coldStartSnapshotMediaId != null) {
-            coldStartSnapshotMediaId = null
-            coldStartSnapshotToken = null
-            coldStartSnapshotPositionMs = null
+            clearColdStartSnapshot()
         }
 
         return activePositionOccurrenceToken

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
@@ -32,6 +32,21 @@ class PlaybackStateHolderTest {
         listeningStatsTracker = listeningStatsTracker
     )
 
+    private fun snapshot(
+        mediaId: String = "duplicate-song",
+        positionMs: Long = 48_000L
+    ) = PlaybackQueueSnapshot(
+        items = listOf(
+            PlaybackQueueItemSnapshot(
+                mediaId = mediaId,
+                uri = "file:///music/$mediaId.mp3"
+            )
+        ),
+        currentMediaId = mediaId,
+        currentIndex = 0,
+        currentPositionMs = positionMs
+    )
+
     @Test
     fun `paused override does not bleed into later occurrence with same media id`() {
         val holder = createHolder()
@@ -48,17 +63,7 @@ class PlaybackStateHolderTest {
 
     @Test
     fun `cold start snapshot only applies to the first matching occurrence`() = runTest {
-        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns PlaybackQueueSnapshot(
-            items = listOf(
-                PlaybackQueueItemSnapshot(
-                    mediaId = "duplicate-song",
-                    uri = "file:///music/duplicate-song.mp3"
-                )
-            ),
-            currentMediaId = "duplicate-song",
-            currentIndex = 0,
-            currentPositionMs = 48_000L
-        )
+        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns snapshot()
 
         val holder = createHolder()
         holder.initialize(this)
@@ -70,6 +75,57 @@ class PlaybackStateHolderTest {
 
         holder.onPlaybackOccurrenceTransition("another-song")
         holder.onPlaybackOccurrenceTransition("duplicate-song")
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+
+        assertEquals(0L, holder.currentPosition.value)
+    }
+
+    @Test
+    fun `late cold start snapshot binds to the already active first occurrence`() = runTest {
+        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns snapshot()
+
+        val holder = createHolder()
+        holder.initialize(this)
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+        assertEquals(0L, holder.currentPosition.value)
+
+        advanceUntilIdle()
+
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+
+        assertEquals(48_000L, holder.currentPosition.value)
+    }
+
+    @Test
+    fun `late cold start snapshot is discarded after playback occurrence advances`() = runTest {
+        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns snapshot()
+
+        val holder = createHolder()
+        holder.initialize(this)
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
+        holder.onPlaybackOccurrenceTransition("another-song")
+        holder.onPlaybackOccurrenceTransition("duplicate-song")
+
+        advanceUntilIdle()
+
+        holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
+
+        assertEquals(0L, holder.currentPosition.value)
+    }
+
+    @Test
+    fun `late cold start snapshot is discarded after first occurrence already ended`() = runTest {
+        coEvery { userPreferencesRepository.getPlaybackQueueSnapshotOnce() } returns snapshot()
+
+        val holder = createHolder()
+        holder.initialize(this)
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
+        holder.onPlaybackOccurrenceTransition(null)
+
+        advanceUntilIdle()
+
+        holder.ensureCurrentPlaybackOccurrence("duplicate-song")
         holder.syncCurrentPositionFromPlayer("duplicate-song", 0L)
 
         assertEquals(0L, holder.currentPosition.value)


### PR DESCRIPTION
…teHolder`

- **Snapshot Logic**:
    - Implement `rememberColdStartSnapshot` to bind restored positions to the active media occurrence, even if the snapshot loads after playback has already initialized.
    - Ensure snapshots are discarded if playback has already advanced past the intended first occurrence to prevent stale position overrides.
    - Add `clearColdStartSnapshot` helper to consistently reset snapshot-related state.
- **Playback Tracking**:
    - Refactor `onPlaybackOccurrenceTransition` and `syncCurrentPositionFromPlayer` to use the new snapshot binding and clearing logic.
    - Improve synchronization between the player's reported position and the cold start restoration token.
- **Testing**:
    - Add comprehensive unit tests in `PlaybackStateHolderTest` covering late cold start scenarios, including successful binding to active occurrences and proper discarding of stale snapshots.
    - Introduce a `snapshot()` helper function to simplify test data creation.