### PR TITLE
feat: optimize library song list rendering and state management

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
@@ -1,0 +1,58 @@
+package com.theveloper.pixelplay.presentation.screens
+
+import androidx.annotation.OptIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.media3.common.util.UnstableApi
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
+import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@Immutable
+internal data class LibrarySongPlaybackUiState(
+    val isCurrentSong: Boolean = false,
+    val isPlaying: Boolean = false
+)
+
+@OptIn(UnstableApi::class)
+@Composable
+internal fun LibraryPlaybackAwareSongItem(
+    song: Song,
+    playerViewModel: PlayerViewModel,
+    isSelected: Boolean = false,
+    selectionIndex: Int? = null,
+    isSelectionMode: Boolean = false,
+    onLongPress: () -> Unit = {},
+    onMoreOptionsClick: (Song) -> Unit,
+    onClick: () -> Unit
+) {
+    val playbackUiState by remember(song.id, playerViewModel) {
+        playerViewModel.stablePlayerState
+            .map { state ->
+                val isCurrentSong = state.currentSong?.id == song.id
+                LibrarySongPlaybackUiState(
+                    isCurrentSong = isCurrentSong,
+                    isPlaying = isCurrentSong && state.isPlaying
+                )
+            }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = LibrarySongPlaybackUiState())
+
+    EnhancedSongListItem(
+        song = song,
+        isPlaying = playbackUiState.isPlaying,
+        isCurrentSong = playbackUiState.isCurrentSong,
+        isLoading = false,
+        isSelected = isSelected,
+        selectionIndex = selectionIndex,
+        isSelectionMode = isSelectionMode,
+        onLongPress = onLongPress,
+        onMoreOptionsClick = onMoreOptionsClick,
+        onClick = onClick
+    )
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -1005,8 +1005,19 @@ fun LibraryScreen(
                                 playlistUiState.playlists.filterNot { it.source == "TELEGRAM" }
                             }
                         }
-                        val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
+                        val allSongsLazyPagingItems = libraryViewModel.songsPagingFlow.collectAsLazyPagingItems()
                         val favoritePagingItems = libraryViewModel.favoritesPagingFlow.collectAsLazyPagingItems()
+                        val isLibraryLoading by libraryViewModel.isLoadingLibrary.collectAsStateWithLifecycle()
+                        val hasCurrentSong by remember(playerViewModel) {
+                            playerViewModel.stablePlayerState
+                                .map { state -> state.currentSong != null && state.currentSong != Song.emptySong() }
+                                .distinctUntilChanged()
+                        }.collectAsStateWithLifecycle(initialValue = false)
+                        val isShuffleEnabled by remember(playerViewModel) {
+                            playerViewModel.stablePlayerState
+                                .map { it.isShuffleEnabled }
+                                .distinctUntilChanged()
+                        }.collectAsStateWithLifecycle(initialValue = false)
 
                         LaunchedEffect(
                             playlistUiState.showTelegramCloudPlaylists,
@@ -1156,7 +1167,7 @@ fun LibraryScreen(
                                     folderRootLabel = playerUiState.folderSource.displayName,
                                     onFolderClick = { playerViewModel.navigateToFolder(it) },
                                     onNavigateBack = { playerViewModel.navigateBackFolder() },
-                                    isShuffleEnabled = stablePlayerState.isShuffleEnabled,
+                                    isShuffleEnabled = isShuffleEnabled,
                                     showStorageFilterButton = currentTabId == LibraryTabId.SONGS ||
                                         currentTabId == LibraryTabId.ALBUMS ||
                                         currentTabId == LibraryTabId.ARTISTS ||
@@ -1320,15 +1331,9 @@ fun LibraryScreen(
                                 )
                                 when (tabTitles.getOrNull(tabIndex)?.toLibraryTabIdOrNull()) {
                                     LibraryTabId.SONGS -> {
-                                        // Use Paging 3 flow from LibraryStateHolder
-                                        val allSongsLazyPagingItems = libraryViewModel.songsPagingFlow.collectAsLazyPagingItems()
-                                        // We can use libraryViewModel.isLoadingLibrary or similar if needed for global loading state
-                                        val isLibraryLoading by libraryViewModel.isLoadingLibrary.collectAsStateWithLifecycle()
-
                                         LibrarySongsTab(
                                             songs = allSongsLazyPagingItems,
                                             isLoading = isLibraryLoading,
-                                            stablePlayerState = stablePlayerState,
                                             playerViewModel = playerViewModel,
                                             bottomBarHeight = bottomBarHeightDp,
                                             onMoreOptionsClick = stableOnMoreOptionsClick,
@@ -1345,7 +1350,8 @@ fun LibraryScreen(
                                             onLocateCurrentSongVisibilityChanged = { songsShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { songsLocateAction = it },
                                             sortOption = playerUiState.currentSongSortOption,
-                                            storageFilter = playerUiState.currentStorageFilter
+                                            storageFilter = playerUiState.currentStorageFilter,
+                                            hasCurrentSong = hasCurrentSong
                                         )
                                     }
                                     LibraryTabId.ALBUMS -> {
@@ -1433,7 +1439,8 @@ fun LibraryScreen(
                                             sortOption = playerUiState.currentFavoriteSortOption,
                                             onLocateCurrentSongVisibilityChanged = { likedShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { likedLocateAction = it },
-                                            storageFilter = playerUiState.currentStorageFilter
+                                            storageFilter = playerUiState.currentStorageFilter,
+                                            hasCurrentSong = hasCurrentSong
                                         )
                                     }
 
@@ -1450,6 +1457,7 @@ fun LibraryScreen(
                                             val folders = playerUiState.musicFolders
                                             val currentFolder = playerUiState.currentFolder
                                             val isLoading = playerUiState.isLoadingLibraryCategories
+                                            val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
 
                                             LibraryFoldersTab(
                                                 folders = folders,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
@@ -62,6 +62,7 @@ import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongLis
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
 import com.theveloper.pixelplay.presentation.viewmodel.StablePlayerState
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -81,9 +82,9 @@ fun LibraryFavoritesTab(
     sortOption: SortOption,
     onLocateCurrentSongVisibilityChanged: (Boolean) -> Unit = {},
     onRegisterLocateCurrentSongAction: ((() -> Unit)?) -> Unit = {},
-    storageFilter: StorageFilter = StorageFilter.ALL
+    storageFilter: StorageFilter = StorageFilter.ALL,
+    hasCurrentSong: Boolean = false
 ) {
-    val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
     val visibilityCallback by rememberUpdatedState(onLocateCurrentSongVisibilityChanged)
@@ -91,7 +92,11 @@ fun LibraryFavoritesTab(
     var lastHandledFavoriteSortKey by remember { mutableStateOf(sortOption.storageKey) }
     var pendingFavoriteSortScrollReset by remember { mutableStateOf(false) }
     var favoriteSortSawRefreshLoading by remember { mutableStateOf(false) }
-    val currentSongId = stablePlayerState.currentSong?.id
+    val currentSongId by remember(playerViewModel) {
+        playerViewModel.stablePlayerState
+            .map { it.currentSong?.id }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = null)
 
     val currentSongListIndex = remember(favoriteSongs.itemCount, currentSongId) {
         if (currentSongId == null) -1
@@ -212,12 +217,9 @@ fun LibraryFavoritesTab(
                         ) { index ->
                             val song = favoriteSongs[index]
                             if (song != null) {
-                                val isPlayingThisSong =
-                                    song.id == stablePlayerState.currentSong?.id && stablePlayerState.isPlaying
-                                EnhancedSongListItem(
+                                LibraryPlaybackAwareSongItem(
                                     song = song,
-                                    isCurrentSong = stablePlayerState.currentSong?.id == song.id,
-                                    isPlaying = isPlayingThisSong,
+                                    playerViewModel = playerViewModel,
                                     onMoreOptionsClick = { onMoreOptionsClick(song) },
                                     isSelected = selectedSongIds.contains(song.id),
                                     selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,
@@ -248,7 +250,7 @@ fun LibraryFavoritesTab(
                         }
                     }
 
-                    val bottomPadding = if (stablePlayerState.currentSong != null && stablePlayerState.currentSong != Song.emptySong())
+                    val bottomPadding = if (hasCurrentSong)
                         bottomBarHeight + MiniPlayerHeight + 16.dp
                     else
                         bottomBarHeight + 16.dp

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -1,13 +1,11 @@
 package com.theveloper.pixelplay.presentation.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -36,10 +34,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.data.model.LibraryTabId
 import com.theveloper.pixelplay.data.model.Song
@@ -47,9 +44,9 @@ import com.theveloper.pixelplay.data.model.StorageFilter
 import com.theveloper.pixelplay.data.model.SortOption
 import com.theveloper.pixelplay.presentation.components.MiniPlayerHeight
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
-import com.theveloper.pixelplay.presentation.viewmodel.StablePlayerState
 import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.LoadState
@@ -61,7 +58,6 @@ import androidx.paging.LoadState
 fun LibrarySongsTab(
     songs: LazyPagingItems<Song>, // Changed from ImmutableList<Song>
     isLoading: Boolean, // Kept for initial load or other states, though Paging has its own
-    stablePlayerState: StablePlayerState,
     playerViewModel: PlayerViewModel,
     bottomBarHeight: Dp,
     onMoreOptionsClick: (Song) -> Unit,
@@ -76,7 +72,8 @@ fun LibrarySongsTab(
     getSelectionIndex: (String) -> Int? = { null },
     onLocateCurrentSongVisibilityChanged: (Boolean) -> Unit = {},
     onRegisterLocateCurrentSongAction: ((() -> Unit)?) -> Unit = {},
-    storageFilter: StorageFilter = StorageFilter.ALL
+    storageFilter: StorageFilter = StorageFilter.ALL,
+    hasCurrentSong: Boolean = false
 ) {
     val listState = rememberLazyListState()
     val pullToRefreshState = rememberPullToRefreshState()
@@ -86,8 +83,11 @@ fun LibrarySongsTab(
     var lastHandledSongSortKey by remember { mutableStateOf(sortOption.storageKey) }
     var pendingSongSortScrollReset by remember { mutableStateOf(false) }
     var songSortSawRefreshLoading by remember { mutableStateOf(false) }
-    
-    val currentSongId = stablePlayerState.currentSong?.id
+    val currentSongId by remember(playerViewModel) {
+        playerViewModel.stablePlayerState
+            .map { it.currentSong?.id }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = null)
 
     // Check if list is effectively empty (based on Paging state)
     // val isListEmpty = songs.itemCount == 0 && songs.loadState.refresh is LoadState.NotLoading
@@ -118,8 +118,8 @@ fun LibrarySongsTab(
     }
 
     // New action just triggers the ViewModel request
-    val locateCurrentSongAction: (() -> Unit)? = remember(stablePlayerState.currentSong) {
-        if (stablePlayerState.currentSong == null) {
+    val locateCurrentSongAction: (() -> Unit)? = remember(currentSongId) {
+        if (currentSongId == null) {
             null
         } else {
             {
@@ -307,7 +307,6 @@ fun LibrarySongsTab(
                                 val song = songs[index]
                                 
                                 if (song != null) {
-                                    val isPlayingThisSong = song.id == stablePlayerState.currentSong?.id && stablePlayerState.isPlaying
                                     val isSelected = selectedSongIds.contains(song.id)
                                     
                                     val rememberedOnMoreOptionsClick: (Song) -> Unit = remember(onMoreOptionsClick) {
@@ -328,11 +327,9 @@ fun LibrarySongsTab(
                                         { onSongLongPress(song) }
                                     }
 
-                                    EnhancedSongListItem(
+                                    LibraryPlaybackAwareSongItem(
                                         song = song,
-                                        isPlaying = isPlayingThisSong,
-                                        isCurrentSong = stablePlayerState.currentSong?.id == song.id,
-                                        isLoading = false,
+                                        playerViewModel = playerViewModel,
                                         isSelected = isSelected,
                                         isSelectionMode = isSelectionMode,
                                         selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,
@@ -355,7 +352,7 @@ fun LibrarySongsTab(
                         }
                         
                         // ScrollBar Overlay
-                        val bottomPadding = if (stablePlayerState.currentSong != null && stablePlayerState.currentSong != Song.emptySong()) 
+                        val bottomPadding = if (hasCurrentSong)
                             bottomBarHeight + MiniPlayerHeight + 16.dp 
                         else 
                             bottomBarHeight + 16.dp

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryViewModel.kt
@@ -1,5 +1,7 @@
 package com.theveloper.pixelplay.presentation.viewmodel
 
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -9,9 +11,9 @@ class LibraryViewModel @Inject constructor(
     private val libraryStateHolder: LibraryStateHolder
 ) : ViewModel() {
 
-    val songsPagingFlow = libraryStateHolder.songsPagingFlow
+    val songsPagingFlow = libraryStateHolder.songsPagingFlow.cachedIn(viewModelScope)
 
-    val favoritesPagingFlow = libraryStateHolder.favoritesPagingFlow
+    val favoritesPagingFlow = libraryStateHolder.favoritesPagingFlow.cachedIn(viewModelScope)
 
     val favoriteSongCountFlow = libraryStateHolder.favoriteSongCountFlow
 


### PR DESCRIPTION
- **New Components**:
    - Introduce `LibraryPlaybackAwareSongItem`, a state-aware wrapper for `EnhancedSongListItem` that internally manages its own playback and selection state via `playerViewModel.stablePlayerState`.
- **Library Screens & Tabs**:
    - Refactor `LibrarySongsTab` and `LibrarySongsAndFavoritesTabs` to use the new `LibraryPlaybackAwareSongItem`, reducing unnecessary recompositions of the entire list when playback state changes.
    - Lift playback state collection (e.g., `hasCurrentSong`, `isShuffleEnabled`) out of individual tab items and into `LibraryScreen` or specific tab headers to improve performance.
    - Replace passing the full `StablePlayerState` object into tabs with specific primitive flags and memoized `Flow` transformations.
    - Improve "Locate Current Song" logic by using a derived `currentSongId` flow with `distinctUntilChanged`.
- **ViewModels**:
    - Use `cachedIn(viewModelScope)` for `songsPagingFlow` and `favoritesPagingFlow` in `LibraryViewModel` to ensure paging state is preserved across configuration changes and shared efficiently.
- **UI Consistency**:
    - Refine bottom padding logic across library tabs to consistently account for the mini-player height only when a valid song is loaded.