### PR TITLE
feat: enhance backup validation and restore robustness for engagement…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/BackupManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/BackupManager.kt
@@ -102,8 +102,12 @@ class BackupManager @Inject constructor(
         runCatching {
             // Validate file first
             val fileValidation = validationPipeline.validateFile(uri)
+            val warnings = mutableListOf<String>()
             if (fileValidation is BackupValidationResult.Invalid && fileValidation.fatalErrors.isNotEmpty()) {
                 throw IllegalArgumentException(fileValidation.fatalErrors.first().message)
+            }
+            if (fileValidation is BackupValidationResult.Invalid) {
+                warnings.addAll(fileValidation.warnings.map { it.message })
             }
 
             // Build restore plan
@@ -111,12 +115,38 @@ class BackupManager @Inject constructor(
 
             // Validate manifest
             val manifestValidation = validationPipeline.validateManifest(plan.manifest)
-            val warnings = plan.warnings.toMutableList()
+            warnings.addAll(plan.warnings)
             if (manifestValidation is BackupValidationResult.Invalid) {
                 if (manifestValidation.fatalErrors.isNotEmpty()) {
                     throw IllegalArgumentException(manifestValidation.fatalErrors.first().message)
                 }
                 warnings.addAll(manifestValidation.warnings.map { it.message })
+            }
+
+            val modulePayloads = backupReader.readAllModulePayloads(uri).getOrThrow()
+            plan.availableModules.toList().sortedBy { it.key }.forEach { section ->
+                val payload = modulePayloads[section.key]
+                    ?: throw IllegalArgumentException(
+                        "Backup is missing the payload for ${section.label}."
+                    )
+
+                val moduleValidation = validationPipeline.validateModulePayload(
+                    section = section,
+                    payload = payload,
+                    manifest = plan.manifest
+                )
+                if (moduleValidation is BackupValidationResult.Invalid) {
+                    if (moduleValidation.fatalErrors.isNotEmpty()) {
+                        throw IllegalArgumentException(
+                            "${section.label}: ${moduleValidation.fatalErrors.first().message}"
+                        )
+                    }
+                    warnings.addAll(
+                        moduleValidation.warnings.map { warning ->
+                            "${section.label}: ${warning.message}"
+                        }
+                    )
+                }
             }
 
             plan.copy(warnings = warnings)

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandler.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandler.kt
@@ -1,7 +1,9 @@
 package com.theveloper.pixelplay.data.backup.module
 
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.theveloper.pixelplay.data.backup.model.BackupSection
 import com.theveloper.pixelplay.data.database.EngagementDao
 import com.theveloper.pixelplay.data.database.SongEngagementEntity
@@ -30,10 +32,105 @@ class EngagementStatsModuleHandler @Inject constructor(
     override suspend fun snapshot(): String = export()
 
     override suspend fun restore(payload: String) = withContext(Dispatchers.IO) {
-        val type = TypeToken.getParameterized(List::class.java, SongEngagementEntity::class.java).type
-        val stats: List<SongEngagementEntity> = gson.fromJson(payload, type)
+        val parsed = JsonParser.parseString(payload)
+        require(parsed.isJsonArray) { "Engagement stats payload must be a JSON array." }
+
+        val sourceEntries = parsed.asJsonArray.size()
+        val stats = parseEntries(parsed.asJsonArray)
+        if (sourceEntries > 0 && stats.isEmpty()) {
+            throw IllegalArgumentException("Engagement stats backup does not contain any valid entries.")
+        }
+
         engagementDao.replaceAll(stats)
     }
 
     override suspend fun rollback(snapshot: String) = restore(snapshot)
+
+    private fun parseEntries(array: com.google.gson.JsonArray): List<SongEngagementEntity> {
+        val merged = linkedMapOf<String, SongEngagementEntity>()
+        array.forEach { element ->
+            val entry = parseEntry(element) ?: return@forEach
+            merged.merge(entry.songId, entry, ::mergeEntries)
+        }
+        return merged.values.toList()
+    }
+
+    private fun parseEntry(element: JsonElement): SongEngagementEntity? {
+        if (!element.isJsonObject) return null
+
+        val obj = element.asJsonObject
+        val songId = readString(obj, "songId", "song_id")
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: return null
+
+        return SongEngagementEntity(
+            songId = songId,
+            playCount = (readInt(obj, "playCount", "play_count", "score", "plays") ?: 0).coerceAtLeast(0),
+            totalPlayDurationMs = (
+                readLong(
+                    obj,
+                    "totalPlayDurationMs",
+                    "total_play_duration_ms",
+                    "totalDuration",
+                    "total_duration",
+                    "durationMs",
+                    "duration_ms"
+                ) ?: 0L
+            ).coerceAtLeast(0L),
+            lastPlayedTimestamp = (
+                readLong(
+                    obj,
+                    "lastPlayedTimestamp",
+                    "last_played_timestamp",
+                    "lastPlayedAt",
+                    "last_played_at",
+                    "timestamp"
+                ) ?: 0L
+            ).coerceAtLeast(0L)
+        )
+    }
+
+    private fun mergeEntries(
+        existing: SongEngagementEntity,
+        incoming: SongEngagementEntity
+    ): SongEngagementEntity {
+        return SongEngagementEntity(
+            songId = existing.songId,
+            playCount = maxOf(existing.playCount, incoming.playCount),
+            totalPlayDurationMs = maxOf(existing.totalPlayDurationMs, incoming.totalPlayDurationMs),
+            lastPlayedTimestamp = maxOf(existing.lastPlayedTimestamp, incoming.lastPlayedTimestamp)
+        )
+    }
+
+    private fun readString(obj: JsonObject, vararg keys: String): String? {
+        return keys.asSequence()
+            .mapNotNull { key ->
+                obj.get(key)
+                    ?.takeIf { it.isJsonPrimitive }
+                    ?.asString
+            }
+            .firstOrNull()
+    }
+
+    private fun readInt(obj: JsonObject, vararg keys: String): Int? {
+        return keys.asSequence()
+            .mapNotNull { key -> readLongValue(obj.get(key))?.toInt() }
+            .firstOrNull()
+    }
+
+    private fun readLong(obj: JsonObject, vararg keys: String): Long? {
+        return keys.asSequence()
+            .mapNotNull { key -> readLongValue(obj.get(key)) }
+            .firstOrNull()
+    }
+
+    private fun readLongValue(element: JsonElement?): Long? {
+        val primitive = element?.takeIf { it.isJsonPrimitive }?.asJsonPrimitive ?: return null
+        return when {
+            primitive.isNumber -> primitive.asNumber.toLong()
+            primitive.isString -> primitive.asString.toLongOrNull()
+            else -> null
+        }
+    }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutor.kt
@@ -62,8 +62,9 @@ class RestoreExecutor @Inject constructor(
             selectedModules.forEach { section ->
                 val payload = allPayloads[section.key]
                 if (payload == null) {
-                    Log.w(TAG, "Module ${section.key} not found in backup, skipping")
-                    return@forEach
+                    throw IllegalStateException(
+                        "Backup is missing the payload for ${section.label}."
+                    )
                 }
 
                 // Validate each module payload
@@ -90,7 +91,7 @@ class RestoreExecutor @Inject constructor(
         }
 
         // ---- PHASE 3: RESTORE ----
-        val restoredModules = mutableSetOf<BackupSection>()
+        val restoredModules = mutableListOf<BackupSection>()
         var currentSection: BackupSection? = null
         try {
             modulePayloads.forEach { (section, payload) ->
@@ -109,9 +110,10 @@ class RestoreExecutor @Inject constructor(
             }
         } catch (e: Exception) {
             Log.e(TAG, "Restore failed at module, rolling back", e)
-            // ROLLBACK all already-restored modules
+            // Roll back in reverse restore order, including the module that failed mid-restore.
             var rollbackSuccess = true
-            restoredModules.forEach { section ->
+            val rollbackOrder = (restoredModules + listOfNotNull(currentSection)).distinct().asReversed()
+            rollbackOrder.forEach { section ->
                 try {
                     val snapshot = snapshots[section]
                     if (snapshot != null) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidator.kt
@@ -12,6 +12,11 @@ import javax.inject.Singleton
 class ModuleSchemaValidator @Inject constructor(
     private val contentSanitizer: ContentSanitizer
 ) {
+    private data class NumericFieldResult(
+        val present: Boolean,
+        val value: Long?
+    )
+
     companion object {
         const val MAX_STRING_LENGTH = 50_000
         const val MAX_ENTRIES_PER_MODULE = 100_000
@@ -200,12 +205,117 @@ class ModuleSchemaValidator @Inject constructor(
     }
 
     private fun validateEngagementStats(array: com.google.gson.JsonArray, errors: MutableList<ValidationError>) {
+        val seenSongIds = mutableSetOf<String>()
         array.forEachIndexed { i, element ->
-            if (!element.isJsonObject) return@forEachIndexed
+            if (!element.isJsonObject) {
+                errors.add(
+                    ValidationError(
+                        "INVALID_ENGAGEMENT_ENTRY",
+                        "EngagementStats[$i]: entry is not a JSON object",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+                return@forEachIndexed
+            }
             val obj = element.asJsonObject
-            val playCount = obj.get("play_count")?.asInt ?: obj.get("playCount")?.asInt ?: 0
-            if (playCount < 0) {
-                errors.add(ValidationError("NEGATIVE_PLAY_COUNT", "EngagementStats[$i]: negative play count", module = "engagement_stats", severity = Severity.WARNING))
+            val songId = readStringField(obj, "songId", "song_id")?.trim()
+            if (songId.isNullOrEmpty()) {
+                errors.add(
+                    ValidationError(
+                        "MISSING_SONG_ID",
+                        "EngagementStats[$i]: missing songId",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            } else if (!seenSongIds.add(songId)) {
+                errors.add(
+                    ValidationError(
+                        "DUPLICATE_SONG_ID",
+                        "EngagementStats[$i]: duplicate songId '$songId'",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            }
+
+            val playCount = readNumericField(obj, "play_count", "playCount", "score", "plays")
+            if (playCount.present && playCount.value == null) {
+                errors.add(
+                    ValidationError(
+                        "INVALID_PLAY_COUNT",
+                        "EngagementStats[$i]: play count is not numeric",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            } else if ((playCount.value ?: 0L) < 0L) {
+                errors.add(
+                    ValidationError(
+                        "NEGATIVE_PLAY_COUNT",
+                        "EngagementStats[$i]: negative play count",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            }
+
+            val totalDuration = readNumericField(
+                obj,
+                "total_play_duration_ms",
+                "totalPlayDurationMs",
+                "totalDuration",
+                "total_duration",
+                "durationMs",
+                "duration_ms"
+            )
+            if (totalDuration.present && totalDuration.value == null) {
+                errors.add(
+                    ValidationError(
+                        "INVALID_TOTAL_DURATION",
+                        "EngagementStats[$i]: total duration is not numeric",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            } else if ((totalDuration.value ?: 0L) < 0L) {
+                errors.add(
+                    ValidationError(
+                        "NEGATIVE_TOTAL_DURATION",
+                        "EngagementStats[$i]: negative total duration",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            }
+
+            val lastPlayed = readNumericField(
+                obj,
+                "last_played_timestamp",
+                "lastPlayedTimestamp",
+                "lastPlayedAt",
+                "last_played_at",
+                "timestamp"
+            )
+            if (lastPlayed.present && lastPlayed.value == null) {
+                errors.add(
+                    ValidationError(
+                        "INVALID_LAST_PLAYED_TIMESTAMP",
+                        "EngagementStats[$i]: last played timestamp is not numeric",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
+            } else if ((lastPlayed.value ?: 0L) < 0L) {
+                errors.add(
+                    ValidationError(
+                        "NEGATIVE_LAST_PLAYED_TIMESTAMP",
+                        "EngagementStats[$i]: negative last played timestamp",
+                        module = "engagement_stats",
+                        severity = Severity.WARNING
+                    )
+                )
             }
         }
     }
@@ -265,4 +375,28 @@ class ModuleSchemaValidator @Inject constructor(
         }
     }
 
+    private fun readStringField(obj: com.google.gson.JsonObject, vararg keys: String): String? {
+        return keys.asSequence()
+            .mapNotNull { key ->
+                obj.get(key)
+                    ?.takeIf { it.isJsonPrimitive }
+                    ?.asString
+            }
+            .firstOrNull()
+    }
+
+    private fun readNumericField(obj: com.google.gson.JsonObject, vararg keys: String): NumericFieldResult {
+        keys.forEach { key ->
+            val primitive = obj.get(key)
+                ?.takeIf { it.isJsonPrimitive }
+                ?.asJsonPrimitive
+                ?: return@forEach
+            return when {
+                primitive.isNumber -> NumericFieldResult(present = true, value = primitive.asNumber.toLong())
+                primitive.isString -> NumericFieldResult(present = true, value = primitive.asString.toLongOrNull())
+                else -> NumericFieldResult(present = true, value = null)
+            }
+        }
+        return NumericFieldResult(present = false, value = null)
+    }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/BackupManagerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/BackupManagerTest.kt
@@ -1,0 +1,146 @@
+package com.theveloper.pixelplay.data.backup
+
+import android.content.Context
+import android.net.Uri
+import com.theveloper.pixelplay.data.backup.format.BackupReader
+import com.theveloper.pixelplay.data.backup.format.BackupWriter
+import com.theveloper.pixelplay.data.backup.history.BackupHistoryRepository
+import com.theveloper.pixelplay.data.backup.model.BackupManifest
+import com.theveloper.pixelplay.data.backup.model.BackupModuleInfo
+import com.theveloper.pixelplay.data.backup.model.BackupSection
+import com.theveloper.pixelplay.data.backup.model.BackupValidationResult
+import com.theveloper.pixelplay.data.backup.model.DeviceInfo
+import com.theveloper.pixelplay.data.backup.model.ModuleRestoreDetail
+import com.theveloper.pixelplay.data.backup.model.RestorePlan
+import com.theveloper.pixelplay.data.backup.model.ValidationError
+import com.theveloper.pixelplay.data.backup.module.BackupModuleHandler
+import com.theveloper.pixelplay.data.backup.restore.RestoreExecutor
+import com.theveloper.pixelplay.data.backup.restore.RestorePlanner
+import com.theveloper.pixelplay.data.backup.validation.ValidationPipeline
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupManagerTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val backupWriter: BackupWriter = mockk()
+    private val backupReader: BackupReader = mockk()
+    private val restorePlanner: RestorePlanner = mockk()
+    private val restoreExecutor: RestoreExecutor = mockk()
+    private val validationPipeline: ValidationPipeline = mockk()
+    private val backupHistoryRepository: BackupHistoryRepository = mockk(relaxed = true)
+
+    private val manager = BackupManager(
+        context = context,
+        backupWriter = backupWriter,
+        backupReader = backupReader,
+        restorePlanner = restorePlanner,
+        restoreExecutor = restoreExecutor,
+        validationPipeline = validationPipeline,
+        backupHistoryRepository = backupHistoryRepository,
+        handlers = emptyMap<BackupSection, BackupModuleHandler>()
+    )
+
+    private val backupUri: Uri = mockk(relaxed = true)
+
+    @Test
+    fun `inspectBackup surfaces file and module warnings in the restore plan`() = runTest {
+        val plan = restorePlan(selectedModules = setOf(BackupSection.ENGAGEMENT_STATS))
+
+        every { validationPipeline.validateFile(backupUri) } returns BackupValidationResult.Invalid(
+            listOf(
+                ValidationError(
+                    code = "FILE_EXTENSION",
+                    message = "File extension is not .pxpl.",
+                    severity = com.theveloper.pixelplay.data.backup.model.Severity.WARNING
+                )
+            )
+        )
+        coEvery { restorePlanner.buildRestorePlan(backupUri) } returns Result.success(plan)
+        every { validationPipeline.validateManifest(plan.manifest) } returns BackupValidationResult.Valid
+        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(
+            mapOf(BackupSection.ENGAGEMENT_STATS.key to """[{"playCount": 1}]""")
+        )
+        every {
+            validationPipeline.validateModulePayload(
+                BackupSection.ENGAGEMENT_STATS,
+                """[{"playCount": 1}]""",
+                plan.manifest
+            )
+        } returns BackupValidationResult.Invalid(
+            listOf(
+                ValidationError(
+                    code = "MISSING_SONG_ID",
+                    message = "EngagementStats[0]: missing songId",
+                    module = BackupSection.ENGAGEMENT_STATS.key,
+                    severity = com.theveloper.pixelplay.data.backup.model.Severity.WARNING
+                )
+            )
+        )
+
+        val result = manager.inspectBackup(backupUri).getOrThrow()
+
+        assertEquals(
+            listOf(
+                "File extension is not .pxpl.",
+                "Engagement Stats: EngagementStats[0]: missing songId"
+            ),
+            result.warnings
+        )
+    }
+
+    @Test
+    fun `inspectBackup fails when the manifest lists a module without payload`() = runTest {
+        val plan = restorePlan(selectedModules = setOf(BackupSection.FAVORITES))
+
+        every { validationPipeline.validateFile(backupUri) } returns BackupValidationResult.Valid
+        coEvery { restorePlanner.buildRestorePlan(backupUri) } returns Result.success(plan)
+        every { validationPipeline.validateManifest(plan.manifest) } returns BackupValidationResult.Valid
+        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(emptyMap())
+
+        val result = manager.inspectBackup(backupUri)
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "Backup is missing the payload for Favorites.",
+            result.exceptionOrNull()?.message
+        )
+    }
+
+    private fun restorePlan(selectedModules: Set<BackupSection>): RestorePlan {
+        val modules = selectedModules.associate { section ->
+            section.key to BackupModuleInfo(
+                checksum = "sha256:test",
+                entryCount = 1,
+                sizeBytes = 32
+            )
+        }
+        return RestorePlan(
+            manifest = BackupManifest(
+                schemaVersion = BackupManifest.CURRENT_SCHEMA_VERSION,
+                appVersion = "test",
+                appVersionCode = 1,
+                createdAt = 1_700_000_000_000,
+                deviceInfo = DeviceInfo(),
+                modules = modules
+            ),
+            backupUri = "content://pixelplay/test-backup",
+            availableModules = selectedModules,
+            selectedModules = selectedModules,
+            moduleDetails = selectedModules.associateWith {
+                ModuleRestoreDetail(
+                    entryCount = 1,
+                    sizeBytes = 32,
+                    willOverwrite = true
+                )
+            }
+        )
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandlerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandlerTest.kt
@@ -1,0 +1,76 @@
+package com.theveloper.pixelplay.data.backup.module
+
+import com.google.gson.GsonBuilder
+import com.theveloper.pixelplay.data.database.EngagementDao
+import com.theveloper.pixelplay.data.database.SongEngagementEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EngagementStatsModuleHandlerTest {
+
+    private val engagementDao: EngagementDao = mockk(relaxed = true)
+    private val handler = EngagementStatsModuleHandler(
+        engagementDao = engagementDao,
+        gson = GsonBuilder().serializeNulls().create()
+    )
+
+    @Test
+    fun `restore sanitizes legacy fields skips malformed rows and merges duplicates`() = runTest {
+        val payload = """
+            [
+              {"songId":"song-1","playCount":3,"totalDuration":1200,"lastPlayedAt":100},
+              {"song_id":"song-2","play_count":"-4","duration_ms":"500","last_played_timestamp":"250"},
+              {"songId":"song-1","playCount":2,"totalPlayDurationMs":4000,"lastPlayedTimestamp":300},
+              {"songId":"   ","playCount":8},
+              "bad-row"
+            ]
+        """.trimIndent()
+
+        coEvery { engagementDao.replaceAll(any()) } returns Unit
+
+        handler.restore(payload)
+
+        coVerify(exactly = 1) {
+            engagementDao.replaceAll(
+                listOf(
+                    SongEngagementEntity(
+                        songId = "song-1",
+                        playCount = 3,
+                        totalPlayDurationMs = 4000,
+                        lastPlayedTimestamp = 300
+                    ),
+                    SongEngagementEntity(
+                        songId = "song-2",
+                        playCount = 0,
+                        totalPlayDurationMs = 500,
+                        lastPlayedTimestamp = 250
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `restore rejects payloads that contain no usable entries`() {
+        val payload = """[{"playCount": 3}, null, "bad-row"]"""
+
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            runTest {
+                handler.restore(payload)
+            }
+        }
+
+        assertEquals(
+            "Engagement stats backup does not contain any valid entries.",
+            error.message
+        )
+        coVerify(exactly = 0) { engagementDao.replaceAll(any()) }
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutorTest.kt
@@ -1,0 +1,121 @@
+package com.theveloper.pixelplay.data.backup.restore
+
+import android.net.Uri
+import com.theveloper.pixelplay.data.backup.format.BackupReader
+import com.theveloper.pixelplay.data.backup.model.BackupManifest
+import com.theveloper.pixelplay.data.backup.model.BackupModuleInfo
+import com.theveloper.pixelplay.data.backup.model.BackupSection
+import com.theveloper.pixelplay.data.backup.model.BackupValidationResult
+import com.theveloper.pixelplay.data.backup.model.DeviceInfo
+import com.theveloper.pixelplay.data.backup.model.ModuleRestoreDetail
+import com.theveloper.pixelplay.data.backup.model.RestorePlan
+import com.theveloper.pixelplay.data.backup.model.RestoreResult
+import com.theveloper.pixelplay.data.backup.module.BackupModuleHandler
+import com.theveloper.pixelplay.data.backup.validation.ValidationPipeline
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RestoreExecutorTest {
+
+    private val backupReader: BackupReader = mockk()
+    private val validationPipeline: ValidationPipeline = mockk()
+    private val favoritesHandler: BackupModuleHandler = mockk(relaxed = true)
+    private val playbackHistoryHandler: BackupModuleHandler = mockk(relaxed = true)
+
+    private val executor = RestoreExecutor(
+        backupReader = backupReader,
+        validationPipeline = validationPipeline,
+        handlers = mapOf(
+            BackupSection.FAVORITES to favoritesHandler,
+            BackupSection.PLAYBACK_HISTORY to playbackHistoryHandler
+        )
+    )
+
+    private val backupUri: Uri = mockk(relaxed = true)
+
+    @Test
+    fun `execute rolls back the module that fails during restore`() = runTest {
+        val plan = restorePlan(
+            selectedModules = setOf(BackupSection.FAVORITES, BackupSection.PLAYBACK_HISTORY)
+        )
+
+        coEvery { favoritesHandler.snapshot() } returns "favorites-snapshot"
+        coEvery { playbackHistoryHandler.snapshot() } returns "history-snapshot"
+        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(
+            mapOf(
+                BackupSection.FAVORITES.key to "favorites-payload",
+                BackupSection.PLAYBACK_HISTORY.key to "history-payload"
+            )
+        )
+        every {
+            validationPipeline.validateModulePayload(any(), any(), any())
+        } returns BackupValidationResult.Valid
+        coEvery { favoritesHandler.restore("favorites-payload") } returns Unit
+        coEvery { playbackHistoryHandler.restore("history-payload") } throws IllegalStateException("boom")
+        coEvery { favoritesHandler.rollback("favorites-snapshot") } returns Unit
+        coEvery { playbackHistoryHandler.rollback("history-snapshot") } returns Unit
+
+        val result = executor.execute(backupUri, plan) { }
+
+        val failure = assertInstanceOf(RestoreResult.TotalFailure::class.java, result)
+        assertTrue(failure.error.contains("Playback History"))
+        coVerify(exactly = 1) { favoritesHandler.rollback("favorites-snapshot") }
+        coVerify(exactly = 1) { playbackHistoryHandler.rollback("history-snapshot") }
+    }
+
+    @Test
+    fun `execute fails when a selected module payload is missing`() = runTest {
+        val plan = restorePlan(selectedModules = setOf(BackupSection.FAVORITES))
+
+        coEvery { favoritesHandler.snapshot() } returns "favorites-snapshot"
+        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(emptyMap())
+
+        val result = executor.execute(backupUri, plan) { }
+
+        val failure = assertInstanceOf(RestoreResult.TotalFailure::class.java, result)
+        assertEquals(
+            "Validation failed: Backup is missing the payload for Favorites.",
+            failure.error
+        )
+        coVerify(exactly = 0) { favoritesHandler.restore(any()) }
+    }
+
+    private fun restorePlan(selectedModules: Set<BackupSection>): RestorePlan {
+        val modules = selectedModules.associate { section ->
+            section.key to BackupModuleInfo(
+                checksum = "sha256:test",
+                entryCount = 1,
+                sizeBytes = 32
+            )
+        }
+        return RestorePlan(
+            manifest = BackupManifest(
+                schemaVersion = BackupManifest.CURRENT_SCHEMA_VERSION,
+                appVersion = "test",
+                appVersionCode = 1,
+                createdAt = 1_700_000_000_000,
+                deviceInfo = DeviceInfo(),
+                modules = modules
+            ),
+            backupUri = backupUri.toString(),
+            availableModules = selectedModules,
+            selectedModules = selectedModules,
+            moduleDetails = selectedModules.associateWith {
+                ModuleRestoreDetail(
+                    entryCount = 1,
+                    sizeBytes = 32,
+                    willOverwrite = true
+                )
+            }
+        )
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidatorTest.kt
@@ -108,6 +108,30 @@ class ModuleSchemaValidatorTest {
     }
 
     @Test
+    fun `engagement stats with missing song id and invalid numbers emit warnings`() {
+        val payload = """[{"playCount": "oops", "totalDuration": -5, "lastPlayedTimestamp": "bad"}]"""
+        val result = validator.validate(BackupSection.ENGAGEMENT_STATS, payload)
+        assertTrue(result is BackupValidationResult.Invalid)
+        val warnings = (result as BackupValidationResult.Invalid).warnings
+        assertTrue(warnings.any { it.code == "MISSING_SONG_ID" })
+        assertTrue(warnings.any { it.code == "INVALID_PLAY_COUNT" })
+        assertTrue(warnings.any { it.code == "NEGATIVE_TOTAL_DURATION" })
+        assertTrue(warnings.any { it.code == "INVALID_LAST_PLAYED_TIMESTAMP" })
+    }
+
+    @Test
+    fun `engagement stats with duplicate song ids emit warning`() {
+        val payload = """[
+            {"songId": "123", "playCount": 1},
+            {"songId": "123", "playCount": 2}
+        ]"""
+        val result = validator.validate(BackupSection.ENGAGEMENT_STATS, payload)
+        assertTrue(result is BackupValidationResult.Invalid)
+        val warnings = (result as BackupValidationResult.Invalid).warnings
+        assertTrue(warnings.any { it.code == "DUPLICATE_SONG_ID" })
+    }
+
+    @Test
     fun `empty array passes validation`() {
         val payload = "[]"
         val result = validator.validate(BackupSection.FAVORITES, payload)


### PR DESCRIPTION
… stats

- **Backup & Restore**:
    - Update `BackupManager` and `RestoreExecutor` to perform mandatory module payload validation during both inspection and restoration phases.
    - Improve error handling to throw an `IllegalStateException` when expected module payloads are missing, instead of silently skipping them.
    - Refine `RestoreExecutor` rollback logic to ensure all restored modules (including the failed one) are rolled back in reverse order.
- **Engagement Stats**:
    - Refactor `EngagementStatsModuleHandler` to manually parse and sanitize JSON payloads, adding support for legacy field names (e.g., `play_count`, `total_duration`) and numeric strings.
    - Implement merging logic for duplicate song entries in the same backup, favoring the highest values for play counts and timestamps.
    - Add strict validation in `ModuleSchemaValidator` for engagement stats to detect missing song IDs, duplicate IDs, and malformed or negative numeric fields.
- **Testing**:
    - Add `BackupManagerTest` to verify that file and module warnings are correctly surfaced during backup inspection.
    - Add `EngagementStatsModuleHandlerTest` to ensure sanitization, merging of duplicates, and rejection of invalid payloads work as intended.
    - Add `RestoreExecutorTest` to validate rollback behavior during partial restore failures.
    - Expand `ModuleSchemaValidatorTest` with specific cases for engagement stats schema violations.