### PR TITLE
feat: allow customizable album art size in `EnhancedSongListItem`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.size.Size
 import com.theveloper.pixelplay.data.model.Song
@@ -61,6 +63,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
  * @param isCurrentSong Whether this is the current song in the queue (may be paused)
  * @param isLoading Whether to show loading shimmer state
  * @param showAlbumArt Whether to show the album art
+ * @param albumArtSize Size of the album art thumbnail when shown
  * @param customShape Optional custom shape for the surface
  * @param isSelected Whether this item is selected in multi-selection mode
  * @param isSelectionMode Whether multi-selection mode is active
@@ -77,6 +80,7 @@ fun EnhancedSongListItem(
     isCurrentSong: Boolean = false,
     isLoading: Boolean = false,
     showAlbumArt: Boolean = true,
+    albumArtSize: Dp = 46.dp,
     customShape: androidx.compose.ui.graphics.Shape? = null,
     containerColorOverride: Color? = null,
     isSelected: Boolean = false,
@@ -87,6 +91,8 @@ fun EnhancedSongListItem(
     onMoreOptionsClick: (Song) -> Unit,
     onClick: () -> Unit
 ) {
+    val albumArtTargetSizePx = with(LocalDensity.current) { albumArtSize.roundToPx() * 3 }
+
     // Animate corner radius based on current song state
     val animatedCornerRadius by animateDpAsState(
         targetValue = if (isCurrentSong && !isLoading) 50.dp else 22.dp,
@@ -95,7 +101,7 @@ fun EnhancedSongListItem(
     )
 
     val animatedAlbumCornerRadius by animateDpAsState(
-        targetValue = if (isCurrentSong && !isLoading) 50.dp else 12.dp,
+        targetValue = if (isCurrentSong && !isLoading) 50.dp else 10.dp,
         animationSpec = tween(durationMillis = 400),
         label = "albumCornerRadiusAnimation"
     )
@@ -180,7 +186,7 @@ fun EnhancedSongListItem(
                 if(showAlbumArt) {
                     ShimmerBox(
                         modifier = Modifier
-                            .size(56.dp)
+                            .size(albumArtSize)
                             .clip(CircleShape)
                     )
                     Spacer(modifier = Modifier.width(12.dp))
@@ -277,14 +283,14 @@ fun EnhancedSongListItem(
                 if (showAlbumArt) {
                     Box(
                         modifier = Modifier
-                            .size(56.dp)
+                            .size(albumArtSize)
                             .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
                     ) {
                         SmartImage(
                             model = song.albumArtUriString,
                             contentDescription = song.title,
                             shape = albumShape,
-                            targetSize = Size(168, 168),
+                            targetSize = Size(albumArtTargetSizePx, albumArtTargetSizePx),
                             modifier = Modifier.fillMaxSize()
                         )
                         

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.data.model.Song
@@ -24,6 +26,7 @@ internal data class LibrarySongPlaybackUiState(
 internal fun LibraryPlaybackAwareSongItem(
     song: Song,
     playerViewModel: PlayerViewModel,
+    albumArtSize: Dp = 56.dp,
     isSelected: Boolean = false,
     selectionIndex: Int? = null,
     isSelectionMode: Boolean = false,
@@ -48,6 +51,7 @@ internal fun LibraryPlaybackAwareSongItem(
         isPlaying = playbackUiState.isPlaying,
         isCurrentSong = playbackUiState.isCurrentSong,
         isLoading = false,
+        albumArtSize = albumArtSize,
         isSelected = isSelected,
         selectionIndex = selectionIndex,
         isSelectionMode = isSelectionMode,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -331,6 +331,7 @@ fun LibrarySongsTab(
                                         song = song,
                                         playerViewModel = playerViewModel,
                                         isSelected = isSelected,
+                                        albumArtSize = 46.dp,
                                         isSelectionMode = isSelectionMode,
                                         selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,
                                         onLongPress = rememberedOnLongPress,


### PR DESCRIPTION
- **UI Components**:
    - Add `albumArtSize` parameter to `EnhancedSongListItem`, defaulting to `46.dp`.
    - Refactor `EnhancedSongListItem` to use the dynamic `albumArtSize` for its layout and calculate a proportional `targetSize` for `SmartImage` based on screen density.
    - Update `LibraryPlaybackAwareSongItem` to support the new `albumArtSize` parameter, defaulting it to `56.dp`.
    - Adjust `LibrarySongsTab` to pass a specific `albumArtSize` of `46.dp` to the song list items.
    - Slightly reduce the default non-active album corner radius from `12.dp` to `10.dp` for a sharper aesthetic.