### PR TITLE
Improve backup compatibility and field naming stability for database …

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -66,6 +66,12 @@
 -keep class com.theveloper.pixelplay.data.preferences.PreferenceBackupEntry { *; }
 -keep class com.theveloper.pixelplay.data.backup.model.** { *; }
 -keep class com.theveloper.pixelplay.data.backup.module.** { *; }
+# Backup payload entities are part of the persisted .pxpl contract.
+-keep class com.theveloper.pixelplay.data.database.FavoritesEntity { *; }
+-keep class com.theveloper.pixelplay.data.database.SongEngagementEntity { *; }
+-keep class com.theveloper.pixelplay.data.database.LyricsEntity { *; }
+-keep class com.theveloper.pixelplay.data.database.SearchHistoryEntity { *; }
+-keep class com.theveloper.pixelplay.data.database.TransitionRuleEntity { *; }
 
 # Netty channel classes are instantiated reflectively and require public no-arg constructors.
 # Without these, release builds can fail with:

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidator.kt
@@ -175,9 +175,16 @@ class ModuleSchemaValidator @Inject constructor(
         array.forEachIndexed { i, element ->
             if (!element.isJsonObject) return@forEachIndexed
             val obj = element.asJsonObject
-            val songId = obj.get("songId")?.asLong ?: 0
-            if (songId <= 0) {
-                errors.add(ValidationError("INVALID_SONG_ID", "Favorites[$i]: invalid songId", module = "favorites", severity = Severity.WARNING))
+            val songId = readNumericField(obj, "songId", "song_id")
+            if (!songId.present || songId.value == null || songId.value <= 0L) {
+                errors.add(
+                    ValidationError(
+                        "INVALID_SONG_ID",
+                        "Favorites[$i]: invalid songId",
+                        module = "favorites",
+                        severity = Severity.WARNING
+                    )
+                )
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/FavoritesEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/FavoritesEntity.kt
@@ -3,6 +3,7 @@ package com.theveloper.pixelplay.data.database
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
 
 @Entity(
     tableName = "favorites",
@@ -11,7 +12,11 @@ import androidx.room.PrimaryKey
     ]
 )
 data class FavoritesEntity(
-    @PrimaryKey val songId: Long,
+    @PrimaryKey
+    @SerializedName(value = "songId", alternate = ["song_id"])
+    val songId: Long,
+    @SerializedName(value = "isFavorite", alternate = ["is_favorite"])
     val isFavorite: Boolean = true,
+    @SerializedName(value = "timestamp", alternate = ["addedAt", "added_at"])
     val timestamp: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/LyricsEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/LyricsEntity.kt
@@ -2,11 +2,17 @@ package com.theveloper.pixelplay.data.database
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
 
 @Entity(tableName = "lyrics")
 data class LyricsEntity(
-    @PrimaryKey val songId: Long,
+    @PrimaryKey
+    @SerializedName(value = "songId", alternate = ["song_id"])
+    val songId: Long,
+    @SerializedName("content")
     val content: String,
+    @SerializedName(value = "isSynced", alternate = ["is_synced"])
     val isSynced: Boolean = false,
+    @SerializedName("source")
     val source: String? = null // "local", "remote", "embedded" - optional
 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/SearchHistoryEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/SearchHistoryEntity.kt
@@ -3,13 +3,20 @@ package com.theveloper.pixelplay.data.database
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
 import com.theveloper.pixelplay.data.model.SearchHistoryItem
 
 @Entity(tableName = "search_history")
 data class SearchHistoryEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    @ColumnInfo(name = "query") val query: String,
-    @ColumnInfo(name = "timestamp") val timestamp: Long
+    @PrimaryKey(autoGenerate = true)
+    @SerializedName("id")
+    val id: Long = 0,
+    @ColumnInfo(name = "query")
+    @SerializedName("query")
+    val query: String,
+    @ColumnInfo(name = "timestamp")
+    @SerializedName("timestamp")
+    val timestamp: Long
 )
 
 fun SearchHistoryEntity.toSearchHistoryItem(): SearchHistoryItem {

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/SongEngagementEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/SongEngagementEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
 
 /**
  * Room entity for storing song engagement statistics.
@@ -19,14 +20,24 @@ import androidx.room.PrimaryKey
 data class SongEngagementEntity(
     @PrimaryKey
     @ColumnInfo(name = "song_id")
+    @SerializedName(value = "songId", alternate = ["song_id"])
     val songId: String,
     
     @ColumnInfo(name = "play_count")
+    @SerializedName(value = "playCount", alternate = ["play_count", "score", "plays"])
     val playCount: Int = 0,
     
     @ColumnInfo(name = "total_play_duration_ms")
+    @SerializedName(
+        value = "totalPlayDurationMs",
+        alternate = ["total_play_duration_ms", "totalDuration", "total_duration", "durationMs", "duration_ms"]
+    )
     val totalPlayDurationMs: Long = 0L,
     
     @ColumnInfo(name = "last_played_timestamp")
+    @SerializedName(
+        value = "lastPlayedTimestamp",
+        alternate = ["last_played_timestamp", "lastPlayedAt", "last_played_at", "timestamp"]
+    )
     val lastPlayedTimestamp: Long = 0L
 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/TransitionRuleEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/TransitionRuleEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.google.gson.annotations.SerializedName
 import com.theveloper.pixelplay.data.model.TransitionSettings
 
 @Entity(
@@ -11,9 +12,16 @@ import com.theveloper.pixelplay.data.model.TransitionSettings
     indices = [Index(value = ["playlistId", "fromTrackId", "toTrackId"], unique = true)]
 )
 data class TransitionRuleEntity(
-    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @PrimaryKey(autoGenerate = true)
+    @SerializedName("id")
+    val id: Long = 0,
+    @SerializedName("playlistId")
     val playlistId: String,
+    @SerializedName(value = "fromTrackId", alternate = ["fromSongId", "from_song_id"])
     val fromTrackId: String?,
+    @SerializedName(value = "toTrackId", alternate = ["toSongId", "to_song_id"])
     val toTrackId: String?,
-    @Embedded val settings: TransitionSettings
+    @Embedded
+    @SerializedName("settings")
+    val settings: TransitionSettings
 )

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandlerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/module/EngagementStatsModuleHandlerTest.kt
@@ -9,6 +9,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
@@ -20,6 +22,27 @@ class EngagementStatsModuleHandlerTest {
         engagementDao = engagementDao,
         gson = GsonBuilder().serializeNulls().create()
     )
+
+    @Test
+    fun `export uses stable canonical field names`() = runTest {
+        coEvery { engagementDao.getAllEngagements() } returns listOf(
+            SongEngagementEntity(
+                songId = "song-1",
+                playCount = 3,
+                totalPlayDurationMs = 1200,
+                lastPlayedTimestamp = 100
+            )
+        )
+
+        val payload = handler.export()
+
+        assertTrue(payload.contains("\"songId\""))
+        assertTrue(payload.contains("\"playCount\""))
+        assertTrue(payload.contains("\"totalPlayDurationMs\""))
+        assertTrue(payload.contains("\"lastPlayedTimestamp\""))
+        assertFalse(payload.contains("\"song_id\""))
+        assertFalse(payload.contains("\"play_count\""))
+    }
 
     @Test
     fun `restore sanitizes legacy fields skips malformed rows and merges duplicates`() = runTest {

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/module/FavoritesModuleHandlerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/module/FavoritesModuleHandlerTest.kt
@@ -1,0 +1,64 @@
+package com.theveloper.pixelplay.data.backup.module
+
+import com.google.gson.GsonBuilder
+import com.theveloper.pixelplay.data.database.FavoritesDao
+import com.theveloper.pixelplay.data.database.FavoritesEntity
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoritesModuleHandlerTest {
+
+    private val favoritesDao: FavoritesDao = mockk(relaxed = true)
+    private val handler = FavoritesModuleHandler(
+        favoritesDao = favoritesDao,
+        gson = GsonBuilder().serializeNulls().create()
+    )
+
+    @Test
+    fun `export uses stable canonical field names`() = runTest {
+        coEvery { favoritesDao.getAllFavoritesOnce() } returns listOf(
+            FavoritesEntity(
+                songId = 123L,
+                isFavorite = true,
+                timestamp = 1_700_000_000_000L
+            )
+        )
+
+        val payload = handler.export()
+
+        assertTrue(payload.contains("\"songId\""))
+        assertTrue(payload.contains("\"isFavorite\""))
+        assertTrue(payload.contains("\"timestamp\""))
+        assertFalse(payload.contains("\"song_id\""))
+    }
+
+    @Test
+    fun `restore accepts legacy snake case payload`() = runTest {
+        val payload = """
+            [
+              {"song_id": 123, "is_favorite": true, "added_at": 1700000000000}
+            ]
+        """.trimIndent()
+
+        handler.restore(payload)
+
+        coVerify(exactly = 1) {
+            favoritesDao.replaceAll(
+                listOf(
+                    FavoritesEntity(
+                        songId = 123L,
+                        isFavorite = true,
+                        timestamp = 1_700_000_000_000L
+                    )
+                )
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidatorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/validation/ModuleSchemaValidatorTest.kt
@@ -45,6 +45,13 @@ class ModuleSchemaValidatorTest {
     }
 
     @Test
+    fun `favorites with snake case song id pass validation`() {
+        val payload = """[{"song_id": "123", "added_at": 1700000000000}]"""
+        val result = validator.validate(BackupSection.FAVORITES, payload)
+        assertTrue(result.isValid())
+    }
+
+    @Test
     fun `artist images with non-https URL emits warning`() {
         val payload = """[{"artistName": "Test", "imageUrl": "http://insecure.com/img.jpg"}]"""
         val result = validator.validate(BackupSection.ARTIST_IMAGES, payload)


### PR DESCRIPTION
…entities

- **Database Entities**:
    - Add `@SerializedName` with `alternate` values to `FavoritesEntity`, `SongEngagementEntity`, `LyricsEntity`, `SearchHistoryEntity`, and `TransitionRuleEntity` to support both modern camelCase and legacy snake_case JSON keys.
    - Ensure stable canonical field names during export while maintaining backward compatibility for restoration.
- **Validation**:
    - Update `ModuleSchemaValidator` to recognize both `songId` and `song_id` during the validation of favorites.
- **Testing**:
    - Add `FavoritesModuleHandlerTest` and `EngagementStatsModuleHandlerTest` to verify canonical field export and legacy payload restoration.
    - Add test cases to `ModuleSchemaValidatorTest` for snake_case field validation.
- **ProGuard**:
    - Add keep rules for backup-related database entities to prevent obfuscation of persisted field names.