### PR TITLE
Update default album art size and clean up imports

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
@@ -80,7 +80,7 @@ fun EnhancedSongListItem(
     isCurrentSong: Boolean = false,
     isLoading: Boolean = false,
     showAlbumArt: Boolean = true,
-    albumArtSize: Dp = 46.dp,
+    albumArtSize: Dp = 50.dp,
     customShape: androidx.compose.ui.graphics.Shape? = null,
     containerColorOverride: Color? = null,
     isSelected: Boolean = false,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
@@ -26,7 +26,7 @@ internal data class LibrarySongPlaybackUiState(
 internal fun LibraryPlaybackAwareSongItem(
     song: Song,
     playerViewModel: PlayerViewModel,
-    albumArtSize: Dp = 56.dp,
+    albumArtSize: Dp = 50.dp,
     isSelected: Boolean = false,
     selectionIndex: Int? = null,
     isSelectionMode: Boolean = false,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.LoadState
+import com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar
 
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -331,7 +332,7 @@ fun LibrarySongsTab(
                                         song = song,
                                         playerViewModel = playerViewModel,
                                         isSelected = isSelected,
-                                        albumArtSize = 46.dp,
+                                        //albumArtSize = 46.dp,
                                         isSelectionMode = isSelectionMode,
                                         selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,
                                         onLongPress = rememberedOnLongPress,
@@ -358,7 +359,7 @@ fun LibrarySongsTab(
                         else 
                             bottomBarHeight + 16.dp
 
-                        com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar(
+                        ExpressiveScrollBar(
                             modifier = Modifier
                                 .align(Alignment.CenterEnd)
                                 .padding(end = 4.dp, top = 16.dp, bottom = bottomPadding),


### PR DESCRIPTION
- **UI Components**:
    - Increase default `albumArtSize` in `EnhancedSongListItem` from `46.dp` to `50.dp`.
    - Update `LibraryPlaybackAwareSongItem` default `albumArtSize` to `50.dp` for consistency.
- **LibrarySongsTab**:
    - Explicitly import `ExpressiveScrollBar` and simplify its usage in the layout.
    - Comment out hardcoded `albumArtSize` in `LibrarySongsTab` to favor the new component defaults.