### PR TITLE
Add haptic feedback to seeker and migrate playback icons to Material …

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -51,9 +51,11 @@ import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
-import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.*
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.*
@@ -73,8 +75,6 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.material.icons.rounded.SkipNext
-import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.animation.core.Animatable
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Offset
@@ -697,10 +697,13 @@ fun LyricsSheet(
                             .size(78.dp)
                             .clip(RoundedCornerShape(playPauseCornerRadius))
                             .background(tertiaryColor)
-                            .clickable(onClick = onPlayPause),
+                            .clickable {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                onPlayPause()
+                            },
                         contentAlignment = Alignment.Center
                     ) {
-                         AnimatedContent(
+                        AnimatedContent(
                             targetState = isPlaying,
                             label = "playPauseIconAnimation"
                         ) { playing ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -86,6 +86,9 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.ClearAll
 import androidx.compose.material.icons.filled.LibraryAdd
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -1754,7 +1757,7 @@ private fun QueueMiniPlayer(
                 modifier = Modifier.size(44.dp),
             ) {
                 Icon(
-                    painter = if (isPlaying) painterResource(R.drawable.rounded_pause_24) else painterResource(R.drawable.rounded_play_arrow_24),
+                    imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                     contentDescription = if (isPlaying) "Pausar" else "Reproducir",
                 )
             }
@@ -1771,7 +1774,7 @@ private fun QueueMiniPlayer(
                 modifier = Modifier.size(44.dp),
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.rounded_skip_next_24),
+                    imageVector = Icons.Rounded.SkipNext,
                     contentDescription = "Siguiente",
                 )
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -35,6 +35,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CircularWavyProgressIndicator
@@ -74,7 +79,6 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -857,7 +861,7 @@ internal fun MiniPlayerContentInternal(
             contentAlignment = Alignment.Center
         ) {
             Icon(
-                painter = painterResource(R.drawable.rounded_skip_previous_24),
+                imageVector = Icons.Rounded.SkipPrevious,
                 contentDescription = "Anterior",
                 tint = LocalMaterialTheme.current.primary,
                 modifier = Modifier.size(22.dp)
@@ -882,7 +886,7 @@ internal fun MiniPlayerContentInternal(
             contentAlignment = Alignment.Center
         ) {
             Icon(
-                painter = if (isPlaying) painterResource(R.drawable.rounded_pause_24) else painterResource(R.drawable.rounded_play_arrow_24),
+                imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                 contentDescription = if (isPlaying) "Pausar" else "Reproducir",
                 tint = LocalMaterialTheme.current.onPrimary,
                 modifier = Modifier.size(22.dp)
@@ -904,7 +908,7 @@ internal fun MiniPlayerContentInternal(
             contentAlignment = Alignment.Center
         ) {
             Icon(
-                painter = painterResource(R.drawable.rounded_skip_next_24),
+                imageVector = Icons.Rounded.SkipNext,
                 contentDescription = "Siguiente",
                 tint = LocalMaterialTheme.current.primary,
                 modifier = Modifier.size(22.dp)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
@@ -19,6 +19,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
+import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -34,10 +39,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.presentation.components.LocalMaterialTheme
 import kotlinx.coroutines.delay
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
@@ -146,7 +149,7 @@ fun AnimatedPlaybackControls(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.rounded_skip_previous_24),
+                    imageVector = Icons.Rounded.SkipPrevious,
                     contentDescription = "Anterior",
                     tint = tintPreviousIcon,
                     modifier = Modifier.size(iconSize)
@@ -214,7 +217,7 @@ fun AnimatedPlaybackControls(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    painter = painterResource(R.drawable.rounded_skip_next_24),
+                    imageVector = Icons.Rounded.SkipNext,
                     contentDescription = "Siguiente",
                     tint = tintNextIcon,
                     modifier = Modifier.size(iconSize)
@@ -236,9 +239,7 @@ private fun MorphingPlayPauseIcon(
         label = "playPauseCrossfade"
     ) { playing ->
         Icon(
-            painter = painterResource(
-                if (playing) R.drawable.rounded_pause_24 else R.drawable.rounded_play_arrow_24
-            ),
+            imageVector = if (playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
             contentDescription = if (playing) "Pausar" else "Reproducir",
             tint = tint,
             modifier = Modifier.size(size)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/PlayerSeekBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/PlayerSeekBar.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -46,6 +48,7 @@ fun PlayerSeekBar(
     isPlaying: Boolean,
     modifier: Modifier = Modifier
 ) {
+    val hapticFeedback = LocalHapticFeedback.current
     val progressFraction = remember(currentPosition, totalDuration) {
         if (totalDuration > 0) {
             (currentPosition.toFloat() / totalDuration.toFloat()).coerceIn(0f, 1f)
@@ -56,6 +59,7 @@ fun PlayerSeekBar(
 
     var isUserSeeking by remember { mutableStateOf(false) }
     var seekFraction by remember { mutableFloatStateOf(progressFraction) }
+    val lastHapticStep = remember { intArrayOf(-1) }
 
     LaunchedEffect(progressFraction) {
         if (!isUserSeeking) {
@@ -94,6 +98,11 @@ fun PlayerSeekBar(
             onValueChange = { newFraction ->
                 isUserSeeking = true
                 seekFraction = newFraction
+                val quantized = (newFraction.coerceIn(0f, 1f) * 20f).toInt()
+                if (quantized != lastHapticStep[0]) {
+                    lastHapticStep[0] = quantized
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                }
             },
             onValueChangeFinished = {
                 onSeek((seekFraction * totalDuration).roundToLong())


### PR DESCRIPTION
…Icons

- **PlayerSeekBar**: Implement haptic feedback increments while seeking to provide tactile response during progress adjustment.
- **Icons**: Replace custom drawable resources with `Icons.Rounded` equivalents (Play, Pause, SkipNext, SkipPrevious) across `AnimatedPlaybackControls`, `QueueBottomSheet`, and `UnifiedPlayerSheet`.
- **LyricsSheet**: Add haptic feedback to the play/pause button interaction and clean up unused icon imports.