### PR TITLE
Hide creation mode selector in playlist edit flow

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
@@ -794,6 +794,7 @@ fun EditPlaylistContent(
              onStarRotationChange = { starRotation = it },
              starScale = starScale,
              onStarScaleChange = { starScale = it },
+             showCreationModeSelector = false,
              creationMode = PlaylistCreationMode.MANUAL,
              onCreationModeChange = { },
              selectedSmartRule = SmartPlaylistRule.TOP_PLAYED,
@@ -837,6 +838,7 @@ private fun PlaylistFormContent(
     onStarRotationChange: (Float) -> Unit,
     starScale: Float,
     onStarScaleChange: (Float) -> Unit,
+    showCreationModeSelector: Boolean = true,
     creationMode: PlaylistCreationMode,
     onCreationModeChange: (PlaylistCreationMode) -> Unit,
     selectedSmartRule: SmartPlaylistRule,
@@ -1065,24 +1067,26 @@ private fun PlaylistFormContent(
             
             Spacer(modifier = Modifier.height(8.dp))
 
-            SingleChoiceSegmentedButtonRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 22.dp)
-            ) {
-                SegmentedButton(
-                    selected = creationMode == PlaylistCreationMode.MANUAL,
-                    onClick = { onCreationModeChange(PlaylistCreationMode.MANUAL) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+            if (showCreationModeSelector) {
+                SingleChoiceSegmentedButtonRow(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 22.dp)
                 ) {
-                    Text("Manual")
-                }
-                SegmentedButton(
-                    selected = creationMode == PlaylistCreationMode.SMART,
-                    onClick = { onCreationModeChange(PlaylistCreationMode.SMART) },
-                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                ) {
-                    Text("Smart")
+                    SegmentedButton(
+                        selected = creationMode == PlaylistCreationMode.MANUAL,
+                        onClick = { onCreationModeChange(PlaylistCreationMode.MANUAL) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                    ) {
+                        Text("Manual")
+                    }
+                    SegmentedButton(
+                        selected = creationMode == PlaylistCreationMode.SMART,
+                        onClick = { onCreationModeChange(PlaylistCreationMode.SMART) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                    ) {
+                        Text("Smart")
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- Add a `showCreationModeSelector` flag to `PlaylistFormContent` (default `true`) to control visibility of the Manual/Smart segmented selector.
- Set `showCreationModeSelector = false` in `EditPlaylistContent` so editing an existing playlist no longer shows creation mode switching.
- Keep create flow behavior unchanged by preserving the default selector visibility.

## Testing
- Not run (no automated tests were executed for this change).
- Manual check: open **Create Playlist** and verify the Manual/Smart segmented control is visible.
- Manual check: open **Edit Playlist** and verify the Manual/Smart segmented control is hidden.
- Manual check: confirm existing edit interactions (name, icon, star controls, and save behavior) still work as before.