### PR TITLE
Implement optimistic UI for full player carousel transitions

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
@@ -37,6 +37,7 @@ fun AlbumCarouselSection(
     currentSong: Song?,
     queue: ImmutableList<Song>,
     expansionFraction: Float,
+    requestedScrollIndex: Int? = null,
     onSongSelected: (Song) -> Unit,
     modifier: Modifier = Modifier,
     carouselStyle: String = CarouselStyle.NO_PEEK,
@@ -83,12 +84,26 @@ fun AlbumCarouselSection(
                 .takeIf { it >= 0 }
                 ?: 0
     }
+    val requestedTargetIndex = remember(requestedScrollIndex, queue) {
+        requestedScrollIndex?.takeIf { it in queue.indices }
+    }
+    val effectiveTargetIndex = requestedTargetIndex ?: currentSongIndex
     val smoothCarouselSpec = remember { tween<Float>(durationMillis = 360, easing = FastOutSlowInEasing) }
-    LaunchedEffect(currentSongIndex, queue) {
+    var ignoreNextSettledSelectionForPage by remember { mutableStateOf<Int?>(null) }
+    var programmaticScrollInProgress by remember { mutableStateOf(false) }
+    LaunchedEffect(effectiveTargetIndex, requestedTargetIndex, queue) {
         snapshotFlow { carouselState.pagerState.isScrollInProgress }
             .first { !it }
-        if (carouselState.pagerState.currentPage != currentSongIndex) {
-            carouselState.animateScrollToItem(currentSongIndex, animationSpec = smoothCarouselSpec)
+        if (carouselState.pagerState.currentPage != effectiveTargetIndex) {
+            if (requestedTargetIndex != null) {
+                ignoreNextSettledSelectionForPage = effectiveTargetIndex
+            }
+            programmaticScrollInProgress = true
+            try {
+                carouselState.animateScrollToItem(effectiveTargetIndex, animationSpec = smoothCarouselSpec)
+            } finally {
+                programmaticScrollInProgress = false
+            }
         }
     }
 
@@ -100,6 +115,10 @@ fun AlbumCarouselSection(
             .filter { !it }
             .collect {
                 val settled = carouselState.pagerState.currentPage
+                if (ignoreNextSettledSelectionForPage == settled) {
+                    ignoreNextSettledSelectionForPage = null
+                    return@collect
+                }
                 if (settled != currentSongIndex) {
                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                     queue.getOrNull(settled)?.let(onSongSelected)
@@ -117,6 +136,7 @@ fun AlbumCarouselSection(
             modifier = Modifier.fillMaxSize(), // Fill the space provided by the parent's modifier
             itemSpacing = itemSpacing,
             itemCornerRadius = corner,
+            suppressNoPeekSettleCorrection = requestedTargetIndex != null || programmaticScrollInProgress,
             carouselStyle = if (carouselState.pagerState.pageCount == 1) CarouselStyle.NO_PEEK else carouselStyle, // Handle single-item case
             carouselWidth = availableWidth // Pass the full width for layout calculations
         ) { index ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/Beta05CleanInstallDisclaimerDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/Beta05CleanInstallDisclaimerDialog.kt
@@ -88,7 +88,7 @@ fun Beta05CleanInstallDisclaimerDialog(
                                 color = MaterialTheme.colorScheme.secondaryContainer,
                             ) {
                                 Text(
-                                    text = "Beta 0.5 upgrade",
+                                    text = "Beta 0.5.0 upgrade",
                                     modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
                                     style = MaterialTheme.typography.labelMedium,
                                     fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/RoundedParallaxCarousell.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/RoundedParallaxCarousell.kt
@@ -143,6 +143,7 @@ fun RoundedHorizontalMultiBrowseCarousel(
     ),
     userScrollEnabled: Boolean = true,
     itemCornerRadius: Dp = 16.dp,
+    suppressNoPeekSettleCorrection: Boolean = false,
     carouselStyle: String,
     carouselWidth: Dp,
     content: @Composable CarouselItemScope.(itemIndex: Int) -> Unit,
@@ -157,7 +158,7 @@ fun RoundedHorizontalMultiBrowseCarousel(
         else -> 1 // Default to one peek
     }
 
-    if (carouselStyle == CarouselStyle.NO_PEEK) {
+    if (carouselStyle == CarouselStyle.NO_PEEK && !suppressNoPeekSettleCorrection) {
         val settleEpsilon = 0.001f
         LaunchedEffect(state.pagerState) {
             snapshotFlow {
@@ -1142,6 +1143,13 @@ private suspend fun LazyLayoutScrollScope.animateScrollToPage(
     val delta = value - prev
         val consumed = scrollBy(delta)
         prev += consumed
+    }
+
+    // Programmatic page changes do not go through the pager's fling snap path,
+    // so leave the state exactly on the target page to avoid a visible end-of-motion
+    // wobble when the final consumed delta undershoots by a fraction.
+    if (pagerState.currentPage != targetPage || abs(pagerState.currentPageOffsetFraction) > 0.0001f) {
+        snapToItem(targetPage, 0)
     }
 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -71,6 +71,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -130,6 +131,15 @@ import java.util.Locale
 import kotlin.math.roundToLong
 import com.theveloper.pixelplay.presentation.components.WavySliderExpressive
 import com.theveloper.pixelplay.presentation.components.ToggleSegmentButton
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+
+private const val PREVIOUS_TRACK_RESTART_THRESHOLD_MS = 10_000L
+private const val SPAM_SKIP_SERIALIZATION_MS = 360L
+private const val NO_TARGET_SKIP_SERIALIZATION_MS = 140L
+
+private enum class SkipDirection { PREVIOUS, NEXT }
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @SuppressLint("StateFlowValueCalledInComposition")
@@ -337,6 +347,94 @@ fun FullPlayerContent(
         }
     }
 
+    var pendingCarouselSongId by remember { mutableStateOf<String?>(null) }
+    val pendingCarouselIndex = remember(pendingCarouselSongId, currentPlaybackQueue) {
+        pendingCarouselSongId?.let { targetSongId ->
+            currentPlaybackQueue.indexOfFirst { it.id == targetSongId }
+                .takeIf { it >= 0 }
+        }
+    }
+    val skipRequests = remember {
+        MutableSharedFlow<SkipDirection>(
+            extraBufferCapacity = 16,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST
+        )
+    }
+    val latestQueue by rememberUpdatedState(currentPlaybackQueue)
+    val latestSongId by rememberUpdatedState(song.id)
+    val latestRepeatMode by rememberUpdatedState(repeatMode)
+    val latestIsRemotePlaybackActive by rememberUpdatedState(isRemotePlaybackActive)
+    val latestCurrentPositionProvider by rememberUpdatedState(currentPositionProvider)
+    val latestOnNext by rememberUpdatedState(onNext)
+    val latestOnPrevious by rememberUpdatedState(onPrevious)
+
+    LaunchedEffect(song.id, pendingCarouselSongId) {
+        if (pendingCarouselSongId == song.id) {
+            pendingCarouselSongId = null
+        }
+    }
+
+    LaunchedEffect(pendingCarouselSongId, song.id) {
+        val targetSongId = pendingCarouselSongId ?: return@LaunchedEffect
+        kotlinx.coroutines.delay(900)
+        if (pendingCarouselSongId == targetSongId && song.id != targetSongId) {
+            pendingCarouselSongId = null
+        }
+    }
+
+    LaunchedEffect(skipRequests) {
+        skipRequests.collect { direction ->
+            val queueSnapshot = latestQueue
+            val baseSongId = pendingCarouselSongId ?: latestSongId
+            val predictedTargetIndex = when (direction) {
+                SkipDirection.NEXT -> predictSkipNextCarouselIndex(
+                    currentSongId = baseSongId,
+                    queue = queueSnapshot,
+                    repeatMode = latestRepeatMode,
+                    isRemotePlaybackActive = latestIsRemotePlaybackActive
+                )
+                SkipDirection.PREVIOUS -> predictSkipPreviousCarouselIndex(
+                    currentSongId = baseSongId,
+                    queue = queueSnapshot,
+                    currentPositionMs = latestCurrentPositionProvider(),
+                    repeatMode = latestRepeatMode,
+                    isRemotePlaybackActive = latestIsRemotePlaybackActive
+                )
+            }
+            val predictedTargetSongId = predictedTargetIndex
+                ?.let(queueSnapshot::getOrNull)
+                ?.id
+
+            if (predictedTargetSongId != null) {
+                pendingCarouselSongId = predictedTargetSongId
+
+                // Start the pager motion before MediaController listeners fan out
+                // the full track transition state updates through the player UI.
+                withFrameNanos { }
+            }
+
+            when (direction) {
+                SkipDirection.NEXT -> latestOnNext()
+                SkipDirection.PREVIOUS -> latestOnPrevious()
+            }
+
+            kotlinx.coroutines.delay(
+                if (predictedTargetSongId != null) SPAM_SKIP_SERIALIZATION_MS
+                else NO_TARGET_SKIP_SERIALIZATION_MS
+            )
+        }
+    }
+
+    val onNextWithOptimisticCarousel = {
+        skipRequests.tryEmit(SkipDirection.NEXT)
+        Unit
+    }
+
+    val onPreviousWithOptimisticCarousel = {
+        skipRequests.tryEmit(SkipDirection.PREVIOUS)
+        Unit
+    }
+
     val albumCoverSection: @Composable (Modifier) -> Unit = { modifier ->
         FullPlayerAlbumCoverSection(
             song = song,
@@ -351,6 +449,7 @@ fun FullPlayerContent(
             placeholderColor = placeholderColor,
             placeholderOnColor = placeholderOnColor,
             albumArtQuality = albumArtQuality,
+            requestedScrollIndex = pendingCarouselIndex,
             onSongSelected = onAlbumSongSelected,
             modifier = modifier
         )
@@ -387,9 +486,9 @@ fun FullPlayerContent(
             placeholderColor = placeholderColor,
             placeholderOnColor = placeholderOnColor,
             isPlayingProvider = isPlayingProvider,
-            onPrevious = onPrevious,
+            onPrevious = onPreviousWithOptimisticCarousel,
             onPlayPause = onPlayPause,
-            onNext = onNext,
+            onNext = onNextWithOptimisticCarousel,
             playerSecondaryAccentColor = playerSecondaryAccentColor,
             playerAccentColor = playerAccentColor,
             playerOnAccentColor = playerOnAccentColor,
@@ -862,6 +961,7 @@ private fun FullPlayerAlbumCoverSection(
     placeholderColor: Color,
     placeholderOnColor: Color,
     albumArtQuality: AlbumArtQuality,
+    requestedScrollIndex: Int?,
     onSongSelected: (Song) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -928,6 +1028,7 @@ private fun FullPlayerAlbumCoverSection(
                 currentSong = song,
                 queue = currentPlaybackQueue,
                 expansionFraction = 1f,
+                requestedScrollIndex = requestedScrollIndex,
                 onSongSelected = { newSong ->
                     if (newSong.id != song.id) {
                         onSongSelected(newSong)
@@ -1078,6 +1179,44 @@ private fun FullPlayerProgressSection(
         isSheetDragGestureActive = isSheetDragGestureActive,
         loadingTweaks = loadingTweaks
     )
+}
+
+private fun predictSkipNextCarouselIndex(
+    currentSongId: String,
+    queue: ImmutableList<Song>,
+    repeatMode: Int,
+    isRemotePlaybackActive: Boolean
+): Int? {
+    if (isRemotePlaybackActive || queue.size <= 1) return null
+
+    val currentIndex = queue.indexOfFirst { it.id == currentSongId }
+    if (currentIndex == -1) return null
+
+    return when {
+        currentIndex < queue.lastIndex -> currentIndex + 1
+        repeatMode == Player.REPEAT_MODE_ALL -> 0
+        else -> null
+    }
+}
+
+private fun predictSkipPreviousCarouselIndex(
+    currentSongId: String,
+    queue: ImmutableList<Song>,
+    currentPositionMs: Long,
+    repeatMode: Int,
+    isRemotePlaybackActive: Boolean
+): Int? {
+    if (isRemotePlaybackActive || queue.size <= 1) return null
+    if (currentPositionMs > PREVIOUS_TRACK_RESTART_THRESHOLD_MS) return null
+
+    val currentIndex = queue.indexOfFirst { it.id == currentSongId }
+    if (currentIndex == -1) return null
+
+    return when {
+        currentIndex > 0 -> currentIndex - 1
+        repeatMode == Player.REPEAT_MODE_ALL -> queue.lastIndex
+        else -> null
+    }
 }
 
 @androidx.annotation.OptIn(UnstableApi::class)


### PR DESCRIPTION
- **Optimistic UI Updates**:
    - Add `pendingCarouselSongId` to predict and trigger carousel scrolls immediately upon skip next/previous actions.
    - Implement `predictSkipNextCarouselIndex` and `predictSkipPreviousCarouselIndex` to calculate target indices based on queue state and repeat modes.
    - Use `MutableSharedFlow` to handle skip requests with debouncing/serialization to prevent spamming.
- **Carousel Components**:
    - Update `AlbumCarouselSelection` and `RoundedParallaxCarousell` to support `requestedScrollIndex` for programmatic, non-flickering scrolls.
    - Add `suppressNoPeekSettleCorrection` to `RoundedParallaxCarousell` to prevent layout corrections during programmatic transitions.
    - Hardened `animateScrollToItem` to snap exactly to the target page to avoid sub-pixel wobbling at the end of motion.
- **UI Tweaks**:
    - Update version string in `Beta05CleanInstallDisclaimerDialog` from "Beta 0.5" to "Beta 0.5.0".