### PR TITLE
feat: implement custom image artist display in `LibraryScreen`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -3125,7 +3125,14 @@ fun ArtistListItem(artist: Artist, onClick: () -> Unit, isLoading: Boolean = fal
                         .background(MaterialTheme.colorScheme.primaryContainer),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (!artist.imageUrl.isNullOrEmpty()) {
+                    if (!artist.customImageUri.isNullOrEmpty()) {
+                        SmartImage(
+                            model = artist.customImageUri,
+                            contentDescription = artist.name,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else if (!artist.imageUrl.isNullOrEmpty()) {
                         AsyncImage(
                             model = ImageRequest.Builder(LocalContext.current)
                                 .data(artist.imageUrl)


### PR DESCRIPTION
Update `LibraryScreen` artist list to check artist custom image availability and prioritize displaying them above deezer image