### PR TITLE
Add support for granting artwork URI permissions to external media co…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -366,6 +366,10 @@ class MusicService : MediaLibraryService() {
                 val sessionCommandsBuilder = SessionCommands.Builder()
                     .addSessionCommands(defaultResult.availableSessionCommands.commands)
                 customCommands.forEach { sessionCommandsBuilder.add(it) }
+                grantArtworkUriPermissions(
+                    controller.packageName,
+                    listOfNotNull(session.player.currentMediaItem)
+                )
 
                 return MediaSession.ConnectionResult.accept(
                     sessionCommandsBuilder.build(),
@@ -501,6 +505,7 @@ class MusicService : MediaLibraryService() {
                     try {
                         rememberLastBrowsedParent(browser, parentId)
                         val children = autoMediaBrowseTree.getChildren(parentId, page, pageSize)
+                        grantArtworkUriPermissions(browser.packageName, children)
                         LibraryResult.ofItemList(children, params)
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "onGetChildren failed for parentId=$parentId")
@@ -518,6 +523,7 @@ class MusicService : MediaLibraryService() {
                     try {
                         val item = autoMediaBrowseTree.getItem(mediaId)
                         if (item != null) {
+                            grantArtworkUriPermissions(browser.packageName, listOf(item))
                             LibraryResult.ofItem(item, null)
                         } else {
                             LibraryResult.ofError(SessionError.ERROR_BAD_VALUE)
@@ -559,6 +565,7 @@ class MusicService : MediaLibraryService() {
                             .drop(offset)
                             .take(effectivePageSize)
 
+                        grantArtworkUriPermissions(browser.packageName, pagedResults)
                         LibraryResult.ofItemList(pagedResults, params)
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "onGetSearchResult failed for query=$query")
@@ -575,10 +582,13 @@ class MusicService : MediaLibraryService() {
                 return serviceScope.future {
                     if (mediaItems.size == 1) {
                         resolveContextQueueForRequestedItem(mediaItems.first(), controller)?.let { queue ->
+                            grantArtworkUriPermissions(controller.packageName, queue.mediaItems)
                             return@future queue.mediaItems
                         }
                     }
-                    resolveMediaItemsByIds(mediaItems)
+                    resolveMediaItemsByIds(mediaItems).also { resolvedItems ->
+                        grantArtworkUriPermissions(controller.packageName, resolvedItems)
+                    }
                 }
             }
 
@@ -597,6 +607,7 @@ class MusicService : MediaLibraryService() {
                         resolveContextQueueForRequestedItem(it, controller)
                     }
                     if (contextQueue != null) {
+                        grantArtworkUriPermissions(controller.packageName, contextQueue.mediaItems)
                         return@future MediaSession.MediaItemsWithStartPosition(
                             contextQueue.mediaItems,
                             contextQueue.startIndex,
@@ -605,6 +616,7 @@ class MusicService : MediaLibraryService() {
                     }
 
                     val resolvedItems = resolveMediaItemsByIds(mediaItems)
+                    grantArtworkUriPermissions(controller.packageName, resolvedItems)
                     val safeStartIndex = requestedIndex.coerceIn(
                         0,
                         (resolvedItems.size - 1).coerceAtLeast(0)
@@ -1439,7 +1451,8 @@ class MusicService : MediaLibraryService() {
         snapshotItem.title?.takeIf { it.isNotBlank() }?.let { metadataBuilder.setTitle(it) }
         snapshotItem.artist?.takeIf { it.isNotBlank() }?.let { metadataBuilder.setArtist(it) }
         snapshotItem.albumTitle?.takeIf { it.isNotBlank() }?.let { metadataBuilder.setAlbumTitle(it) }
-        MediaItemBuilder.artworkUri(snapshotItem.artworkUri)?.let { metadataBuilder.setArtworkUri(it) }
+        MediaItemBuilder.externalControllerArtworkUri(this, snapshotItem.artworkUri)
+            ?.let { metadataBuilder.setArtworkUri(it) }
 
         val extras = Bundle().apply {
             putBoolean(
@@ -2111,7 +2124,7 @@ class MusicService : MediaLibraryService() {
         }
 
         val queueMediaItems = queueSongs.map { song ->
-            MediaItemBuilder.build(song)
+            MediaItemBuilder.buildForExternalController(this, song)
         }.toMutableList()
 
         return ContextQueueResolution(
@@ -2127,9 +2140,35 @@ class MusicService : MediaLibraryService() {
 
         return requestedItems.map { requestedItem ->
             songMap[requestedItem.mediaId]?.let { song ->
-                MediaItemBuilder.build(song)
+                MediaItemBuilder.buildForExternalController(this, song)
             } ?: requestedItem
         }.toMutableList()
+    }
+
+    private fun grantArtworkUriPermissions(
+        targetPackage: String,
+        mediaItems: List<MediaItem>
+    ) {
+        if (targetPackage.isBlank()) return
+
+        val providerAuthority = "$packageName.provider"
+        mediaItems.forEach { mediaItem ->
+            val artworkUri = resolveArtworkUri(mediaItem.mediaMetadata) ?: return@forEach
+            if (artworkUri.scheme?.lowercase() != "content" || artworkUri.authority != providerAuthority) {
+                return@forEach
+            }
+
+            runCatching {
+                grantUriPermission(targetPackage, artworkUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }.onFailure { error ->
+                Timber.tag(TAG).w(
+                    error,
+                    "Failed to grant artwork URI permission to package=%s uri=%s",
+                    targetPackage,
+                    artworkUri
+                )
+            }
+        }
     }
 
     private fun resolveAutoContextFromParentId(parentId: String): Pair<String, String?>? {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/auto/AutoMediaBrowseTree.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/auto/AutoMediaBrowseTree.kt
@@ -1,5 +1,6 @@
 package com.theveloper.pixelplay.data.service.auto
 
+import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import androidx.media3.common.MediaItem
@@ -12,12 +13,14 @@ import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.preferences.PlaylistPreferencesRepository
 import com.theveloper.pixelplay.data.repository.MusicRepository
 import com.theveloper.pixelplay.utils.MediaItemBuilder
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class AutoMediaBrowseTree @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val musicRepository: MusicRepository,
     private val playlistPreferencesRepository: PlaylistPreferencesRepository,
     private val engagementDao: EngagementDao
@@ -289,7 +292,8 @@ class AutoMediaBrowseTree @Inject constructor(
         if (!contextExtras.isEmpty) {
             metadata.setExtras(contextExtras)
         }
-        MediaItemBuilder.artworkUri(song.albumArtUriString)?.let { metadata.setArtworkUri(it) }
+        MediaItemBuilder.externalControllerArtworkUri(context, song.albumArtUriString)
+            ?.let { metadata.setArtworkUri(it) }
 
         return MediaItem.Builder()
             .setMediaId(song.id)
@@ -304,7 +308,8 @@ class AutoMediaBrowseTree @Inject constructor(
             .setIsBrowsable(true)
             .setIsPlayable(false)
             .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_ALBUMS)
-        MediaItemBuilder.artworkUri(album.albumArtUriString)?.let { metadata.setArtworkUri(it) }
+        MediaItemBuilder.externalControllerArtworkUri(context, album.albumArtUriString)
+            ?.let { metadata.setArtworkUri(it) }
 
         return MediaItem.Builder()
             .setMediaId(ALBUM_PREFIX + album.id)
@@ -318,7 +323,8 @@ class AutoMediaBrowseTree @Inject constructor(
             .setIsBrowsable(true)
             .setIsPlayable(false)
             .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_ARTISTS)
-        MediaItemBuilder.artworkUri(artist.effectiveImageUrl)?.let { metadata.setArtworkUri(it) }
+        MediaItemBuilder.externalControllerArtworkUri(context, artist.effectiveImageUrl)
+            ?.let { metadata.setArtworkUri(it) }
 
         return MediaItem.Builder()
             .setMediaId(ARTIST_PREFIX + artist.id)
@@ -332,7 +338,8 @@ class AutoMediaBrowseTree @Inject constructor(
             .setIsBrowsable(true)
             .setIsPlayable(false)
             .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_PLAYLISTS)
-        MediaItemBuilder.artworkUri(playlist.coverImageUri)?.let { metadata.setArtworkUri(it) }
+        MediaItemBuilder.externalControllerArtworkUri(context, playlist.coverImageUri)
+            ?.let { metadata.setArtworkUri(it) }
 
         return MediaItem.Builder()
             .setMediaId(PLAYLIST_PREFIX + playlist.id)

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
@@ -1,7 +1,9 @@
 package com.theveloper.pixelplay.utils
 
+import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -37,6 +39,19 @@ object MediaItemBuilder {
             .setMediaId(song.id)
             .setUri(playbackUri(song.contentUriString))
             .setMediaMetadata(buildMediaMetadataForSong(song))
+            .build()
+    }
+
+    fun buildForExternalController(context: Context, song: Song): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(song.id)
+            .setUri(playbackUri(song.contentUriString))
+            .setMediaMetadata(
+                buildMediaMetadataForSong(
+                    song = song,
+                    exposedArtworkUri = externalControllerArtworkUri(context, song.albumArtUriString)
+                )
+            )
             .build()
     }
 
@@ -78,13 +93,29 @@ object MediaItemBuilder {
         }
     }
 
-    private fun buildMediaMetadataForSong(song: Song): MediaMetadata {
+    fun externalControllerArtworkUri(context: Context, rawArtworkUri: String?): Uri? {
+        val normalizedUri = artworkUri(rawArtworkUri) ?: return null
+        return when (normalizedUri.scheme?.lowercase()) {
+            "file" -> normalizedUri.path
+                ?.takeIf { it.isNotBlank() }
+                ?.let(::File)
+                ?.let { file -> providerBackedArtworkUri(context, file) ?: normalizedUri }
+                ?: normalizedUri
+            null -> null
+            else -> normalizedUri
+        }
+    }
+
+    private fun buildMediaMetadataForSong(
+        song: Song,
+        exposedArtworkUri: Uri? = artworkUri(song.albumArtUriString)
+    ): MediaMetadata {
         val metadataBuilder = MediaMetadata.Builder()
             .setTitle(song.title)
             .setArtist(song.displayArtist)
             .setAlbumTitle(song.album)
 
-        artworkUri(song.albumArtUriString)?.let { artworkUri ->
+        exposedArtworkUri?.let { artworkUri ->
             metadataBuilder.setArtworkUri(artworkUri)
         }
 
@@ -93,7 +124,9 @@ object MediaItemBuilder {
             putString(EXTERNAL_EXTRA_ALBUM, song.album)
             putLong(EXTERNAL_EXTRA_DURATION, song.duration)
             putString(EXTERNAL_EXTRA_CONTENT_URI, song.contentUriString)
-            song.albumArtUriString?.let { putString(EXTERNAL_EXTRA_ALBUM_ART, it) }
+            (exposedArtworkUri?.toString() ?: song.albumArtUriString)?.let {
+                putString(EXTERNAL_EXTRA_ALBUM_ART, it)
+            }
             song.genre?.let { putString(EXTERNAL_EXTRA_GENRE, it) }
             putInt(EXTERNAL_EXTRA_TRACK, song.trackNumber)
             putInt(EXTERNAL_EXTRA_YEAR, song.year)
@@ -106,5 +139,25 @@ object MediaItemBuilder {
 
         metadataBuilder.setExtras(extras)
         return metadataBuilder.build()
+    }
+
+    private fun providerBackedArtworkUri(context: Context, file: File): Uri? {
+        val canonicalFile = runCatching { file.canonicalFile }.getOrElse { file.absoluteFile }
+        if (!isInsideAppStorage(context, canonicalFile)) {
+            return null
+        }
+
+        return runCatching {
+            FileProvider.getUriForFile(context, "${context.packageName}.provider", canonicalFile)
+        }.getOrNull()
+    }
+
+    private fun isInsideAppStorage(context: Context, file: File): Boolean {
+        val storageRoots = listOf(context.cacheDir, context.filesDir)
+            .mapNotNull { root -> runCatching { root.canonicalFile }.getOrNull() }
+
+        return storageRoots.any { root ->
+            file.path == root.path || file.path.startsWith(root.path + File.separator)
+        }
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -4,4 +4,7 @@
     <cache-path
         name="cache"
         path="." />
+    <files-path
+        name="files"
+        path="." />
 </paths>


### PR DESCRIPTION
…ntrollers

- **MusicService**:
    - Implement `grantArtworkUriPermissions` to provide read access for artwork content URIs to calling packages.
    - Apply permission grants during connection, media browsing, searching, and item resolution.
    - Use `FileProvider` backed URIs when serving media items to external controllers.
- **AutoMediaBrowseTree**:
    - Update browse tree items (songs, albums, artists, playlists) to use provider-backed artwork URIs for better compatibility with Android Auto and other external controllers.
- **MediaItemBuilder**:
    - Add `buildForExternalController` and `externalControllerArtworkUri` to handle URI normalization and `FileProvider` conversion.
    - Implement `isInsideAppStorage` check to safely expose internal cache and files directory images via `FileProvider`.
- **Configuration**:
    - Update `file_paths.xml` to include `<files-path>` for broader internal storage access via the app's provider.