### PR TITLE
Ensure critical preferences are preserved during cleanup and backup r…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -1472,7 +1472,7 @@ constructor(
         if (keyNames.isEmpty()) return
         dataStore.edit { preferences ->
             preferences.asMap().keys
-                .filter { key -> key.name in keyNames }
+                .filter { key -> key.name in keyNames && key.name !in backupExcludedKeyNames }
                 .forEach { key ->
                     @Suppress("UNCHECKED_CAST")
                     preferences.remove(key as Preferences.Key<Any>)
@@ -1481,9 +1481,10 @@ constructor(
     }
 
     suspend fun clearPreferencesExceptKeys(excludedKeyNames: Set<String>) {
+        val protectedKeyNames = excludedKeyNames + backupExcludedKeyNames
         dataStore.edit { preferences ->
             preferences.asMap().keys
-                .filterNot { key -> key.name in excludedKeyNames }
+                .filterNot { key -> key.name in protectedKeyNames }
                 .forEach { key ->
                     @Suppress("UNCHECKED_CAST")
                     preferences.remove(key as Preferences.Key<Any>)
@@ -1548,7 +1549,12 @@ constructor(
     ) {
         dataStore.edit { preferences ->
             if (clearExisting) {
-                preferences.clear()
+                preferences.asMap().keys
+                    .filterNot { key -> key.name in backupExcludedKeyNames }
+                    .forEach { key ->
+                        @Suppress("UNCHECKED_CAST")
+                        preferences.remove(key as Preferences.Key<Any>)
+                    }
             }
 
             entries.forEach { entry ->

--- a/app/src/test/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepositoryTest.kt
@@ -1,0 +1,70 @@
+package com.theveloper.pixelplay.data.preferences
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+
+class UserPreferencesRepositoryTest {
+
+    @Test
+    fun `clearPreferencesExceptKeys preserves initial setup completion`() = runTest {
+        val tempDir = Files.createTempDirectory("user-preferences-repository-test")
+        try {
+            val repository = UserPreferencesRepository(
+                dataStore = PreferenceDataStoreFactory.create(
+                    scope = backgroundScope,
+                    produceFile = { tempDir.resolve("settings.preferences_pb").toFile() }
+                ),
+                json = Json
+            )
+
+            repository.setInitialSetupDone(true)
+            repository.setNavBarStyle("compact")
+
+            repository.clearPreferencesExceptKeys(emptySet())
+
+            assertTrue(repository.initialSetupDoneFlow.first())
+            assertEquals(NavBarStyle.DEFAULT, repository.navBarStyleFlow.first())
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `importPreferencesFromBackup clearExisting preserves initial setup completion`() = runTest {
+        val tempDir = Files.createTempDirectory("user-preferences-repository-test")
+        try {
+            val repository = UserPreferencesRepository(
+                dataStore = PreferenceDataStoreFactory.create(
+                    scope = backgroundScope,
+                    produceFile = { tempDir.resolve("settings.preferences_pb").toFile() }
+                ),
+                json = Json
+            )
+
+            repository.setInitialSetupDone(true)
+            repository.setNavBarStyle("compact")
+
+            repository.importPreferencesFromBackup(
+                entries = listOf(
+                    PreferenceBackupEntry(
+                        key = "nav_bar_style",
+                        type = "string",
+                        stringValue = "restored"
+                    )
+                ),
+                clearExisting = true
+            )
+
+            assertTrue(repository.initialSetupDoneFlow.first())
+            assertEquals("restored", repository.navBarStyleFlow.first())
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+}


### PR DESCRIPTION
…estoration

- **UserPreferencesRepository**:
    - Update `clearPreferencesExceptKeys` and `clearSpecificPreferences` to respect `backupExcludedKeyNames`, ensuring essential flags like initial setup completion are not wiped.
    - Refactor `importPreferencesFromBackup` to selectively clear existing preferences instead of calling `clear()`, protecting excluded keys during backup restoration.
- **Tests**:
    - Add `UserPreferencesRepositoryTest` to verify that initial setup completion is preserved when clearing preferences or restoring from a backup.