### PR TITLE
Add trusted media item resolution for secure artwork URI granting

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -587,8 +587,11 @@ class MusicService : MediaLibraryService() {
                         }
                     }
                     resolveMediaItemsByIds(mediaItems).also { resolvedItems ->
-                        grantArtworkUriPermissions(controller.packageName, resolvedItems)
-                    }
+                        grantArtworkUriPermissions(
+                            controller.packageName,
+                            resolvedItems.trustedArtworkGrantItems
+                        )
+                    }.mediaItems
                 }
             }
 
@@ -616,13 +619,16 @@ class MusicService : MediaLibraryService() {
                     }
 
                     val resolvedItems = resolveMediaItemsByIds(mediaItems)
-                    grantArtworkUriPermissions(controller.packageName, resolvedItems)
+                    grantArtworkUriPermissions(
+                        controller.packageName,
+                        resolvedItems.trustedArtworkGrantItems
+                    )
                     val safeStartIndex = requestedIndex.coerceIn(
                         0,
-                        (resolvedItems.size - 1).coerceAtLeast(0)
+                        (resolvedItems.mediaItems.size - 1).coerceAtLeast(0)
                     )
                     MediaSession.MediaItemsWithStartPosition(
-                        resolvedItems,
+                        resolvedItems.mediaItems,
                         safeStartIndex,
                         startPositionMs
                     )
@@ -2133,16 +2139,18 @@ class MusicService : MediaLibraryService() {
         )
     }
 
-    private suspend fun resolveMediaItemsByIds(requestedItems: List<MediaItem>): MutableList<MediaItem> {
+    private suspend fun resolveMediaItemsByIds(
+        requestedItems: List<MediaItem>
+    ): TrustedMediaItemsResolution {
         val songIds = requestedItems.map { it.mediaId }
         val songs = musicRepository.getSongsByIds(songIds).first()
         val songMap = songs.associateBy { it.id }
 
-        return requestedItems.map { requestedItem ->
-            songMap[requestedItem.mediaId]?.let { song ->
+        return resolveMediaItemsWithTrustedArtworkGrants(requestedItems) { mediaId ->
+            songMap[mediaId]?.let { song ->
                 MediaItemBuilder.buildForExternalController(this, song)
-            } ?: requestedItem
-        }.toMutableList()
+            }
+        }
     }
 
     private fun grantArtworkUriPermissions(

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/TrustedMediaItemsResolution.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/TrustedMediaItemsResolution.kt
@@ -1,0 +1,32 @@
+package com.theveloper.pixelplay.data.service
+
+import androidx.media3.common.MediaItem
+
+internal data class TrustedMediaItemsResolution(
+    val mediaItems: MutableList<MediaItem>,
+    val trustedArtworkGrantItems: List<MediaItem>,
+)
+
+internal fun resolveMediaItemsWithTrustedArtworkGrants(
+    requestedItems: List<MediaItem>,
+    trustedItemResolver: (String) -> MediaItem?
+): TrustedMediaItemsResolution {
+    val resolvedItems = ArrayList<MediaItem>(requestedItems.size)
+    val trustedArtworkGrantItems = ArrayList<MediaItem>()
+
+    requestedItems.forEach { requestedItem ->
+        val trustedItem = trustedItemResolver(requestedItem.mediaId)
+        if (trustedItem != null) {
+            resolvedItems += trustedItem
+            trustedArtworkGrantItems += trustedItem
+        } else {
+            // Caller-supplied metadata is untrusted and must never drive provider grants.
+            resolvedItems += requestedItem
+        }
+    }
+
+    return TrustedMediaItemsResolution(
+        mediaItems = resolvedItems,
+        trustedArtworkGrantItems = trustedArtworkGrantItems
+    )
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/TrustedMediaItemsResolutionTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/TrustedMediaItemsResolutionTest.kt
@@ -1,0 +1,72 @@
+package com.theveloper.pixelplay.data.service
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class TrustedMediaItemsResolutionTest {
+
+    @Test
+    fun `unresolved caller item stays in queue but is excluded from artwork grants`() {
+        val attackerSuppliedItem = mediaItem(
+            mediaId = "missing-id",
+            artworkUri = "content://com.theveloper.pixelplay.provider/files/private/token.txt"
+        )
+        val trustedItem = mediaItem(
+            mediaId = "known-id",
+            artworkUri = "content://com.theveloper.pixelplay.provider/cache/album.png"
+        )
+
+        val resolution = resolveMediaItemsWithTrustedArtworkGrants(
+            requestedItems = listOf(attackerSuppliedItem, trustedItem)
+        ) { mediaId ->
+            if (mediaId == trustedItem.mediaId) trustedItem else null
+        }
+
+        assertSame(attackerSuppliedItem, resolution.mediaItems[0])
+        assertSame(trustedItem, resolution.mediaItems[1])
+        assertEquals(listOf(trustedItem), resolution.trustedArtworkGrantItems)
+    }
+
+    @Test
+    fun `trusted artwork grants preserve the order of resolved server items`() {
+        val requestedFirst = mediaItem("song-1")
+        val requestedSecond = mediaItem("missing-id")
+        val requestedThird = mediaItem("song-2")
+        val trustedFirst = mediaItem("song-1")
+        val trustedSecond = mediaItem("song-2")
+
+        val resolution = resolveMediaItemsWithTrustedArtworkGrants(
+            requestedItems = listOf(requestedFirst, requestedSecond, requestedThird)
+        ) { mediaId ->
+            when (mediaId) {
+                trustedFirst.mediaId -> trustedFirst
+                trustedSecond.mediaId -> trustedSecond
+                else -> null
+            }
+        }
+
+        assertEquals(
+            listOf(trustedFirst, requestedSecond, trustedSecond),
+            resolution.mediaItems
+        )
+        assertEquals(
+            listOf(trustedFirst, trustedSecond),
+            resolution.trustedArtworkGrantItems
+        )
+    }
+
+    private fun mediaItem(mediaId: String, artworkUri: String? = null): MediaItem {
+        val metadata = MediaMetadata.Builder().apply {
+            artworkUri?.let { setArtworkUri(Uri.parse(it)) }
+        }.build()
+
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(metadata)
+            .build()
+    }
+}


### PR DESCRIPTION
- Introduce `TrustedMediaItemsResolution` and `resolveMediaItemsWithTrustedArtworkGrants` to distinguish between caller-supplied metadata and trusted server-side metadata.
- Ensure that artwork URI permissions are only granted for items successfully resolved via the internal repository, preventing potential unauthorized access through attacker-supplied URIs.
- Refactor `MusicService` to use the new resolution logic when handling `onAddMediaItems` and `onSetMediaItems` from external controllers.
- Add unit tests for `TrustedMediaItemsResolution` to verify correct handling of missing items and preservation of item order.