### PR TITLE
Implement lyric sync offset for seek-to-line functionality

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -545,7 +545,12 @@ fun LyricsSheet(
                                 accentColor = accentColor,
                                 textStyle = scaledTextStyle,
                                 onLineClick = { syncedLine -> 
-                                    onSeekTo(syncedLine.time.toLong())
+                                    onSeekTo(
+                                        resolveSeekPositionMs(
+                                            lineTimeMs = syncedLine.time.toLong(),
+                                            lyricsSyncOffsetMs = lyricsSyncOffset
+                                        )
+                                    )
                                     resetImmersiveTimer()
                                 },
                                 highlightZoneFraction = highlightZoneFraction,
@@ -1272,6 +1277,11 @@ internal fun resolveHighlightedWordIndex(
     if (positionMs < lineStartTimeMs || positionMs >= lineEndTimeMs) return -1
     return words.indexOfLast { it.time.toLong() <= positionMs }
 }
+
+internal fun resolveSeekPositionMs(
+    lineTimeMs: Long,
+    lyricsSyncOffsetMs: Int
+): Long = (lineTimeMs - lyricsSyncOffsetMs.toLong()).coerceAtLeast(0L)
 
 internal data class HighlightZoneMetrics(
     val topPadding: Dp,

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/components/LyricsSheetLogicTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/components/LyricsSheetLogicTest.kt
@@ -151,4 +151,34 @@ class LyricsSheetLogicTest {
 
         assertEquals(2, idx)
     }
+
+    @Test
+    fun resolveSeekPositionMs_subtractsPositiveLyricsOffset() {
+        val seekPosition = resolveSeekPositionMs(
+            lineTimeMs = 12_000L,
+            lyricsSyncOffsetMs = 750
+        )
+
+        assertEquals(11_250L, seekPosition)
+    }
+
+    @Test
+    fun resolveSeekPositionMs_addsNegativeLyricsOffset() {
+        val seekPosition = resolveSeekPositionMs(
+            lineTimeMs = 12_000L,
+            lyricsSyncOffsetMs = -750
+        )
+
+        assertEquals(12_750L, seekPosition)
+    }
+
+    @Test
+    fun resolveSeekPositionMs_clampsToZeroWhenOffsetWouldGoNegative() {
+        val seekPosition = resolveSeekPositionMs(
+            lineTimeMs = 300L,
+            lyricsSyncOffsetMs = 750
+        )
+
+        assertEquals(0L, seekPosition)
+    }
 }


### PR DESCRIPTION
- **LyricsSheet**:
    - Update `onLineClick` to account for `lyricsSyncOffset` when seeking to a specific line.
    - Introduce `resolveSeekPositionMs` to calculate the final seek position, ensuring it is clamped to a minimum of 0ms.
- **Unit Tests**:
    - Add test cases in `LyricsSheetLogicTest.kt` to verify that positive and negative offsets are correctly applied and that negative results are clamped to zero.