### PR TITLE
Defer `recentlyPlayedSongs` updates on `HomeScreen` until off-screen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
@@ -42,6 +43,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -64,6 +66,9 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.preferences.CollagePattern
@@ -124,6 +129,7 @@ fun HomeScreen(
     val dailyMixSongs by playerViewModel.dailyMixSongs.collectAsStateWithLifecycle()
     val curatedYourMixSongs by playerViewModel.yourMixSongs.collectAsStateWithLifecycle()
     val playbackHistory by playerViewModel.playbackHistory.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val yourMixSongs = remember(curatedYourMixSongs, dailyMixSongs, allSongs) {
         when {
@@ -132,13 +138,36 @@ fun HomeScreen(
             else -> allSongs.toImmutableList()
         }
     }
-    val recentlyPlayedSongs = remember(playbackHistory, allSongs) {
+    val latestRecentlyPlayedSongs = remember(playbackHistory, allSongs) {
         mapRecentlyPlayedSongs(
             playbackHistory = playbackHistory,
             songs = allSongs,
             maxItems = 64
         )
     }
+    // Keep the visible Home snapshot stable and only refresh it once the screen is off-screen.
+    var recentlyPlayedSongs by remember { mutableStateOf(latestRecentlyPlayedSongs) }
+    val latestRecentlyPlayedSongsState = rememberUpdatedState(latestRecentlyPlayedSongs)
+
+    LaunchedEffect(latestRecentlyPlayedSongs, lifecycleOwner) {
+        val isHomeVisible = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+        if (recentlyPlayedSongs.isEmpty() || !isHomeVisible) {
+            recentlyPlayedSongs = latestRecentlyPlayedSongs
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) {
+                recentlyPlayedSongs = latestRecentlyPlayedSongsState.value
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     val recentlyPlayedQueue = remember(recentlyPlayedSongs) {
         recentlyPlayedSongs.map { it.song }.toImmutableList()
     }


### PR DESCRIPTION
- Prevent the "Recently Played" list from shifting or updating while the user is actively viewing the Home screen.
- Introduce a `LifecycleEventObserver` to capture the latest playback history updates only when the screen is not visible (`ON_STOP`).
- Update `recentlyPlayedSongs` immediately only if the current list is empty or the screen is not in a started state.
- Utilize `DisposableEffect` and `rememberUpdatedState` to safely manage lifecycle-aware state transitions.