### PR TITLE
Add keep screen on toggle for lyrics sheet

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -195,6 +195,7 @@ constructor(
         val HAPTICS_ENABLED = booleanPreferencesKey("haptics_enabled")
         val IMMERSIVE_LYRICS_ENABLED = booleanPreferencesKey("immersive_lyrics_enabled")
         val IMMERSIVE_LYRICS_TIMEOUT = longPreferencesKey("immersive_lyrics_timeout")
+        val KEEP_SCREEN_ON_FOR_LYRICS = booleanPreferencesKey("keep_screen_on_for_lyrics")
         val USE_ANIMATED_LYRICS = booleanPreferencesKey("use_animated_lyrics")
         val ANIMATED_LYRICS_BLUR_ENABLED = booleanPreferencesKey("animated_lyrics_blur_enabled")
         val ANIMATED_LYRICS_BLUR_STRENGTH = androidx.datastore.preferences.core.floatPreferencesKey("animated_lyrics_blur_strength")
@@ -561,6 +562,17 @@ constructor(
     suspend fun setImmersiveLyricsTimeout(timeout: Long) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.IMMERSIVE_LYRICS_TIMEOUT] = timeout
+        }
+    }
+
+    val keepScreenOnForLyricsFlow: Flow<Boolean> =
+            dataStore.data.map { preferences ->
+                preferences[PreferencesKeys.KEEP_SCREEN_ON_FOR_LYRICS] ?: false
+            }
+
+    suspend fun setKeepScreenOnForLyrics(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.KEEP_SCREEN_ON_FOR_LYRICS] = enabled
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -165,6 +165,8 @@ fun LyricsSheet(
     immersiveLyricsTimeout: Long,
     isImmersiveTemporarilyDisabled: Boolean,
     onSetImmersiveTemporarilyDisabled: (Boolean) -> Unit,
+    keepScreenOnForLyrics: Boolean,
+    onKeepScreenOnForLyricsChange: (Boolean) -> Unit,
     // BottomToggleRow Params
     isShuffleEnabled: Boolean,
     repeatMode: Int,
@@ -181,6 +183,20 @@ fun LyricsSheet(
     BackHandler { onBackClick() }
     val stablePlayerState by stablePlayerStateFlow.collectAsStateWithLifecycle()
     val playbackPosition by playbackPositionFlow.collectAsStateWithLifecycle(initialValue = 0L)
+
+    // Keep screen on while lyrics are visible and the preference is enabled
+    val activity = LocalContext.current as? android.app.Activity
+    DisposableEffect(activity, keepScreenOnForLyrics) {
+        val shouldKeep = keepScreenOnForLyrics && activity != null
+        if (shouldKeep) {
+            activity!!.window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            if (shouldKeep) {
+                activity!!.window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+    }
 
     val isLoadingLyrics by remember { derivedStateOf { stablePlayerState.isLoadingLyrics } }
     val lyrics by remember { derivedStateOf { stablePlayerState.lyrics } }
@@ -791,6 +807,8 @@ fun LyricsSheet(
                         resetImmersiveTimer()
                         onSetImmersiveTemporarilyDisabled(it)
                     },
+                    keepScreenOnForLyrics = keepScreenOnForLyrics,
+                    onKeepScreenOnForLyricsChange = onKeepScreenOnForLyricsChange,
                     isShuffleEnabled = isShuffleEnabled,
                     repeatMode = repeatMode,
                     isFavoriteProvider = isFavoriteProvider,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -210,6 +210,7 @@ fun FullPlayerContent(
     val immersiveLyricsEnabled = fullPlayerSlice.immersiveLyricsEnabled
     val immersiveLyricsTimeout = fullPlayerSlice.immersiveLyricsTimeout
     val isImmersiveTemporarilyDisabled = fullPlayerSlice.isImmersiveTemporarilyDisabled
+    val keepScreenOnForLyrics = fullPlayerSlice.keepScreenOnForLyrics
     val isRemotePlaybackActive = fullPlayerSlice.isRemotePlaybackActive
     val selectedRouteName = fullPlayerSlice.selectedRouteName
     val isBluetoothEnabled = fullPlayerSlice.isBluetoothEnabled
@@ -896,6 +897,8 @@ fun FullPlayerContent(
             immersiveLyricsTimeout = immersiveLyricsTimeout,
             isImmersiveTemporarilyDisabled = isImmersiveTemporarilyDisabled,
             onSetImmersiveTemporarilyDisabled = { playerViewModel.setImmersiveTemporarilyDisabled(it) },
+            keepScreenOnForLyrics = keepScreenOnForLyrics,
+            onKeepScreenOnForLyricsChange = { playerViewModel.setKeepScreenOnForLyrics(it) },
             isShuffleEnabled = isShuffleEnabled,
             repeatMode = repeatMode,
             isFavoriteProvider = isFavoriteProvider,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.LightMode
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -60,6 +61,8 @@ fun LyricsMoreBottomSheet(
     onToggleSyncControls: () -> Unit,
     isImmersiveTemporarilyDisabled: Boolean,
     onSetImmersiveTemporarilyDisabled: (Boolean) -> Unit,
+    keepScreenOnForLyrics: Boolean,
+    onKeepScreenOnForLyricsChange: (Boolean) -> Unit,
     // BottomToggleRow params
     isShuffleEnabled: Boolean,
     repeatMode: Int,
@@ -159,6 +162,52 @@ fun LyricsMoreBottomSheet(
                     colors = ListItemDefaults.colors(
                         containerColor = Color.Transparent,
                         headlineColor = contentColor,
+                        leadingIconColor = contentColor
+                    )
+                )
+            }
+
+            // Keep Screen On toggle
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(start = 6.dp, bottom = 6.dp),
+                    text = stringResource(R.string.display),
+                    color = accentColor,
+                    style = MaterialTheme.typography.bodyLargeEmphasized
+                )
+                ListItem(
+                    headlineContent = { Text(stringResource(R.string.keep_screen_on)) },
+                    supportingContent = { Text(stringResource(R.string.keep_screen_on_description)) },
+                    leadingContent = {
+                        Icon(
+                            imageVector = Icons.Rounded.LightMode,
+                            contentDescription = null
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = keepScreenOnForLyrics,
+                            onCheckedChange = onKeepScreenOnForLyricsChange,
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = onAccentColor,
+                                checkedTrackColor = accentColor,
+                                uncheckedThumbColor = contentColor,
+                                uncheckedTrackColor = contentColor.copy(alpha = 0.3f)
+                            )
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(24.dp))
+                        .background(itemBackgroundColor),
+                    colors = ListItemDefaults.colors(
+                        containerColor = Color.Transparent,
+                        headlineColor = contentColor,
+                        supportingColor = contentColor.copy(alpha = 0.6f),
                         leadingIconColor = contentColor
                     )
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -482,6 +482,15 @@ class PlayerViewModel @Inject constructor(
         _isImmersiveTemporarilyDisabled.value = disabled
     }
 
+    private val keepScreenOnForLyrics: StateFlow<Boolean> = userPreferencesRepository.keepScreenOnForLyricsFlow
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    fun setKeepScreenOnForLyrics(enabled: Boolean) {
+        viewModelScope.launch {
+            userPreferencesRepository.setKeepScreenOnForLyrics(enabled)
+        }
+    }
+
     val albumArtQuality: StateFlow<AlbumArtQuality> = userPreferencesRepository.albumArtQualityFlow
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AlbumArtQuality.MEDIUM)
 
@@ -819,6 +828,7 @@ class PlayerViewModel @Inject constructor(
         val immersiveLyricsEnabled: Boolean = false,
         val immersiveLyricsTimeout: Long = 4000L,
         val isImmersiveTemporarilyDisabled: Boolean = false,
+        val keepScreenOnForLyrics: Boolean = false,
         val isRemotePlaybackActive: Boolean = false,
         val selectedRouteName: String? = null,
         val isBluetoothEnabled: Boolean = false,
@@ -847,13 +857,14 @@ class PlayerViewModel @Inject constructor(
     private val fullPlayerSlicePart2 = combine(
         immersiveLyricsEnabled,
         immersiveLyricsTimeout,
-        isImmersiveTemporarilyDisabled,
+        combine(isImmersiveTemporarilyDisabled, keepScreenOnForLyrics) { dis, screenOn -> dis to screenOn },
         isRemotePlaybackActive,
         combine(selectedRouteName, bluetoothSlice) { route, bt -> route to bt }
-    ) { immersive: Boolean, immersiveTimeout: Long, immersiveDisabled: Boolean,
+    ) { immersive: Boolean, immersiveTimeout: Long, immersiveAndScreenOn: Pair<Boolean, Boolean>,
         remotePb: Boolean, routeAndBt: Pair<String?, BluetoothSlice> ->
+        val (immersiveDisabled, screenOn) = immersiveAndScreenOn
         val (routeName, bt) = routeAndBt
-        FullPlayerSlicePart2(immersive, immersiveTimeout, immersiveDisabled, remotePb, routeName, bt.enabled, bt.name)
+        FullPlayerSlicePart2(immersive, immersiveTimeout, immersiveDisabled, screenOn, remotePb, routeName, bt.enabled, bt.name)
     }
 
     private data class FullPlayerSlicePart1(
@@ -868,6 +879,7 @@ class PlayerViewModel @Inject constructor(
         val immersiveLyricsEnabled: Boolean,
         val immersiveLyricsTimeout: Long,
         val isImmersiveTemporarilyDisabled: Boolean,
+        val keepScreenOnForLyrics: Boolean,
         val isRemotePlaybackActive: Boolean,
         val selectedRouteName: String?,
         val isBluetoothEnabled: Boolean,
@@ -887,6 +899,7 @@ class PlayerViewModel @Inject constructor(
             immersiveLyricsEnabled = p2.immersiveLyricsEnabled,
             immersiveLyricsTimeout = p2.immersiveLyricsTimeout,
             isImmersiveTemporarilyDisabled = p2.isImmersiveTemporarilyDisabled,
+            keepScreenOnForLyrics = p2.keepScreenOnForLyrics,
             isRemotePlaybackActive = p2.isRemotePlaybackActive,
             selectedRouteName = p2.selectedRouteName,
             isBluetoothEnabled = p2.isBluetoothEnabled,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,7 @@
     <string name="widget_control_4x2_desc">Full controls with shuffle and repeat</string>
     <string name="widget_grid_2x2_desc">Minimalist square player</string>
     <string name="service_processing_action">Processing playback action…</string>
+    <string name="display">Display</string>
+    <string name="keep_screen_on">Keep screen on</string>
+    <string name="keep_screen_on_description">Prevents the display from sleeping while lyrics are open.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a persistent `Keep screen on` toggle to the lyrics more sheet
- keep the device awake only while the lyrics sheet is visible
- wire the preference through DataStore and the full player state flow

Closes #1411