### PR TITLE
fixed hires-flac playback

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DownsamplingAudioSink.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DownsamplingAudioSink.kt
@@ -1,0 +1,151 @@
+package com.theveloper.pixelplay.data.service.player
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import timber.log.Timber
+import java.nio.ByteBuffer
+
+/**
+ * A wrapper that intercepts and downsamples audio whose
+ * sample rate exceeds (192 kHz) before it reaches [DefaultAudioSink].
+ */
+@OptIn(UnstableApi::class)
+class DownsamplingAudioSink(private val inner: DefaultAudioSink) : AudioSink by inner {
+
+    companion object {
+        private const val MAX_RATE = 192_000
+        private const val TAG = "DownsamplingAudioSink"
+    }
+
+    private val resampler = HighResSamplerAudioProcessor()
+    /**
+     * Holds resampled output that couldn't be sent to [inner] on the previous
+     * [handleBuffer] call (inner buffer was full). Drained first on the next call.
+     */
+    private var pendingOutput: ByteBuffer = AudioProcessor.EMPTY_BUFFER
+
+    // -------------------------------------------------------------------------
+    // supportsFormat() — advertise capability for high-rate PCM by checking
+    // at the downsampled rate, so FfmpegAudioRenderer returns FORMAT_HANDLED.
+    //
+    // Background: DefaultAudioSink.supportsFormat() calls
+    // AudioTrack.getMinBufferSize(sampleRate, …) to validate the rate. For
+    // rates > 192 kHz that call returns ERROR_BAD_VALUE → false (unsupported).
+    // -------------------------------------------------------------------------
+
+    override fun supportsFormat(format: Format): Boolean {
+        val rate = format.sampleRate
+        if (rate != Format.NO_VALUE && rate > MAX_RATE) {
+            val factor = (rate + MAX_RATE - 1) / MAX_RATE
+            val cappedFormat = format.buildUpon().setSampleRate(rate / factor).build()
+            return inner.supportsFormat(cappedFormat)
+        }
+        return inner.supportsFormat(format)
+    }
+
+    // -------------------------------------------------------------------------
+    // configure() — intercept before inner sees the format
+    // -------------------------------------------------------------------------
+
+    override fun configure(
+        inputFormat: Format,
+        specifiedBufferSize: Int,
+        outputChannels: IntArray?
+    ) {
+        resampler.reset()
+        pendingOutput = AudioProcessor.EMPTY_BUFFER
+
+        val rate = inputFormat.sampleRate
+        val encoding = inputFormat.pcmEncoding
+
+        val needsDownsample = rate != Format.NO_VALUE
+                && rate > MAX_RATE
+                && encoding != Format.NO_VALUE
+                && encoding != C.ENCODING_INVALID
+
+        if (needsDownsample) {
+            val outputFmt: AudioFormat = resampler.configure(
+                AudioFormat(rate, inputFormat.channelCount, encoding)
+            )
+
+            if (resampler.isActive) {
+                // Tell the inner sink the capped rate so AudioTrack is created correctly
+                val cappedFormat = inputFormat.buildUpon()
+                    .setSampleRate(outputFmt.sampleRate)
+                    .setPcmEncoding(outputFmt.encoding) // always PCM_FLOAT out of the resampler
+                    .build()
+
+                Timber.tag(TAG).i(
+                    "configure: %d Hz → %d Hz (factor %d), encoding %d → %d, %d ch",
+                    rate, outputFmt.sampleRate,
+                    rate / outputFmt.sampleRate,
+                    encoding, outputFmt.encoding,
+                    inputFormat.channelCount
+                )
+
+                inner.configure(cappedFormat, specifiedBufferSize, outputChannels)
+                return
+            }
+        }
+
+        inner.configure(inputFormat, specifiedBufferSize, outputChannels)
+    }
+
+    // -------------------------------------------------------------------------
+    // handleBuffer() — resample before passing to inner
+    // -------------------------------------------------------------------------
+
+    override fun handleBuffer(
+        buffer: ByteBuffer,
+        presentationTimeUs: Long,
+        encodedAccessUnitCount: Int
+    ): Boolean {
+        if (!resampler.isActive) {
+            return inner.handleBuffer(buffer, presentationTimeUs, encodedAccessUnitCount)
+        }
+
+        // 1. Try to drain any output that the inner sink couldn't accept previously.
+        if (pendingOutput.hasRemaining()) {
+            val sent = inner.handleBuffer(pendingOutput, presentationTimeUs, encodedAccessUnitCount)
+            if (!sent) return false // inner still full; caller must retry
+            pendingOutput = AudioProcessor.EMPTY_BUFFER
+        }
+
+        // 2. Resample the new input.
+        if (!buffer.hasRemaining()) return true
+        resampler.queueInput(buffer)
+        val output = resampler.getOutput()
+        if (!output.hasRemaining()) return true
+
+        // 3. Forward resampled data to the inner sink.
+        val sent = inner.handleBuffer(output, presentationTimeUs, encodedAccessUnitCount)
+        if (!sent) {
+            // Inner is full. Save output; signal caller that input *was* consumed so
+            // ExoPlayer advances to the next buffer. Pending output will be drained above.
+            pendingOutput = output
+        }
+        return true // input buffer was fully consumed by the resampler
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle — clear resampler state on flush/reset
+    // -------------------------------------------------------------------------
+
+    override fun flush() {
+        resampler.flush()
+        pendingOutput = AudioProcessor.EMPTY_BUFFER
+        inner.flush()
+    }
+
+    override fun reset() {
+        resampler.reset()
+        pendingOutput = AudioProcessor.EMPTY_BUFFER
+        inner.reset()
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -7,6 +7,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.util.UnstableApi
@@ -14,14 +15,10 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.audio.AudioSink
-import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
-import androidx.media3.common.Format
-import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import android.os.Handler
-import kotlin.math.max
 //import androidx.media3.exoplayer.ffmpeg.FfmpegAudioRenderer
 import com.theveloper.pixelplay.data.model.TransitionSettings
 import com.theveloper.pixelplay.utils.envelope
@@ -280,42 +277,59 @@ class DualPlayerEngine @Inject constructor(
                 eventListener: AudioRendererEventListener,
                 out: ArrayList<Renderer>
             ) {
-                // Use provided sink or create one with Float output enabled
-                // Note: We use the provided audioSink if it works, but here we want to enforce config.
-                // Since super.buildAudioRenderers takes the sink, we can just pass our configured one.
-                // But wait, the parameter 'audioSink' is passed IN. 
-                // We should probably ignore the passed one if we want to enforce ours, OR configure ours and pass it to super.
-                
-                val sink = DefaultAudioSink.Builder(context)
-                    .setEnableFloatOutput(false) // Disable Float output to fix CCodec/Hardware errors on some devices
+                val defaultSink = DefaultAudioSink.Builder(context)
+                    // Float output required: FFmpeg decodes hi-res FLAC to PCM_FLOAT; without
+                    // this the sink force-converts float→16-bit before our resampler can run.
+                    .setEnableFloatOutput(true)
                     .setAudioProcessorChain(
-                        // Custom downmix processor for 6 channel or 8 channel to 2 channel (stereo)
-                        DefaultAudioSink.DefaultAudioProcessorChain(SurroundDownmixProcessor())
+                        DefaultAudioSink.DefaultAudioProcessorChain(
+                            // Downmix 5.1/7.1 surround (16-bit PCM) to stereo.
+                            // HighResSamplerAudioProcessor is NOT here — it lives inside
+                            // DownsamplingAudioSink which intercepts configure() before
+                            // DefaultAudioSink (and AudioTrack) ever see the 384 kHz rate.
+                            SurroundDownmixProcessor()
+                        )
                     )
                     .build()
 
-                out.add(object : MediaCodecAudioRenderer(
-                    context,
-                    mediaCodecSelector,
-                    enableDecoderFallback,
-                    eventHandler,
-                    eventListener,
-                    sink
-                ) {
-                    override fun getCodecMaxInputSize(
-                        codecInfo: MediaCodecInfo,
-                        format: Format,
-                        streamFormats: Array<Format>
-                    ): Int {
-                        // Force minimum 512KB buffer for FLAC/High-res audio
-                        return max(super.getCodecMaxInputSize(codecInfo, format, streamFormats), 512 * 1024)
-                    }
-                })
+                // Wrap the sink so configure() caps sample rates > 192 kHz before
+                // AudioTrack is created. In Media3 1.9.x the processor chain no longer
+                // gates the AudioTrack sample rate, so interception must happen here.
+                // supportsFormat() is also overridden so FfmpegAudioRenderer correctly
+                // reports FORMAT_HANDLED for 384 kHz FLAC (see DownsamplingAudioSink).
+                val sink = DownsamplingAudioSink(defaultSink)
 
-                super.buildAudioRenderers(context, extensionRendererMode, mediaCodecSelector, enableDecoderFallback, sink, eventHandler, eventListener, out)
+                // Custom selector: return an empty codec list for lossless formats (FLAC,
+                // ALAC) so MediaCodecAudioRenderer reports FORMAT_UNSUPPORTED for them.
+                // This forces ExoPlayer to select FfmpegAudioRenderer instead.
+                //
+                // Reason: hardware FLAC/ALAC MediaCodec decoders claim FORMAT_HANDLED for
+                // any sample rate (including 384 kHz+) but silently hang when the rate
+                // exceeds what the chip firmware actually supports. DefaultTrackSelector
+                // prefers hardware renderers when both claim equal support, so without this
+                // block the hardware decoder wins and playback stalls indefinitely.
+                val hiResAwareSelector = MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+                    if (mimeType == MimeTypes.AUDIO_FLAC ||
+                        mimeType == "audio/alac" ||
+                        mimeType == "audio/x-alac"
+                    ) {
+                        emptyList()
+                    } else {
+                        mediaCodecSelector.getDecoderInfos(
+                            mimeType, requiresSecureDecoder, requiresTunnelingDecoder
+                        )
+                    }
+                }
+
+                super.buildAudioRenderers(
+                    context, extensionRendererMode, hiResAwareSelector,
+                    enableDecoderFallback, sink, eventHandler, eventListener, out
+                )
             }
-        }.setEnableAudioFloatOutput(false) // Disable Float output helper
-         .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
+        }   // PREFER: FFmpeg renderer is inserted before MediaCodecAudioRenderer in the list.
+            // For 384kHz FLAC, the hardware decoder claims FORMAT_HANDLED but silently hangs;
+            // FFmpeg correctly decodes it to PCM_FLOAT and feeds it to DownsamplingAudioSink.
+            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER)
 
         val audioAttributes = AudioAttributes.Builder()
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/HighResSamplerAudioProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/HighResSamplerAudioProcessor.kt
@@ -1,0 +1,152 @@
+package com.theveloper.pixelplay.data.service.player
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.util.UnstableApi
+import timber.log.Timber
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * An [AudioProcessor] that downsamples audio whose sample rate exceeds
+ * [MAX_OUTPUT_SAMPLE_RATE] (192 kHz).
+ *
+ * Activates for any PCM encoding ([C.ENCODING_PCM_FLOAT], [C.ENCODING_PCM_32BIT],
+ * [C.ENCODING_PCM_16BIT]) when the sample rate exceeds
+ * the ceiling. Always outputs [C.ENCODING_PCM_FLOAT] so AudioTrack can play it.
+ *
+ * Downsampling method: box-filter decimation (averaging [downsampleFactor] consecutive
+ * input frames).
+ */
+@UnstableApi
+class HighResSamplerAudioProcessor : AudioProcessor {
+
+    companion object {
+        /** Android's AudioTrack.SAMPLE_RATE_HZ_MAX */
+        private const val MAX_OUTPUT_SAMPLE_RATE = 192_000
+
+        private val SUPPORTED_ENCODINGS = setOf(
+            C.ENCODING_PCM_FLOAT,
+            C.ENCODING_PCM_32BIT,
+            C.ENCODING_PCM_16BIT
+        )
+    }
+
+    private var inputFormat: AudioFormat = AudioFormat.NOT_SET
+    private var outputFormat: AudioFormat = AudioFormat.NOT_SET
+    private var outputBuffer: ByteBuffer = AudioProcessor.EMPTY_BUFFER
+    private var inputEnded = false
+    private var downsampleFactor: Int = 1
+
+    override fun configure(inputAudioFormat: AudioFormat): AudioFormat {
+        inputFormat = AudioFormat.NOT_SET
+        outputFormat = AudioFormat.NOT_SET
+
+        if (inputAudioFormat == AudioFormat.NOT_SET) return inputAudioFormat
+
+        val sampleRate = inputAudioFormat.sampleRate
+
+        if (sampleRate <= MAX_OUTPUT_SAMPLE_RATE || inputAudioFormat.encoding !in SUPPORTED_ENCODINGS) {
+            return inputAudioFormat // pass-through
+        }
+
+        downsampleFactor = (sampleRate + MAX_OUTPUT_SAMPLE_RATE - 1) / MAX_OUTPUT_SAMPLE_RATE
+        val outputSampleRate = sampleRate / downsampleFactor
+
+        Timber.tag("HighResSampler").i(
+            "Downsampling %d Hz → %d Hz (factor %d, %d-ch, encoding=%d)",
+            sampleRate, outputSampleRate, downsampleFactor,
+            inputAudioFormat.channelCount, inputAudioFormat.encoding
+        )
+
+        inputFormat = inputAudioFormat
+        // Always output PCM_FLOAT — AudioTrack supports it up to 192 kHz
+        outputFormat = AudioFormat(outputSampleRate, inputAudioFormat.channelCount, C.ENCODING_PCM_FLOAT)
+        return outputFormat
+    }
+
+    override fun isActive(): Boolean = outputFormat != AudioFormat.NOT_SET
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        if (!isActive()) return
+
+        val channels = inputFormat.channelCount
+        val encoding = inputFormat.encoding
+
+        val bytesPerSample = when (encoding) {
+            C.ENCODING_PCM_FLOAT, C.ENCODING_PCM_32BIT -> 4
+            C.ENCODING_PCM_16BIT -> 2
+            else -> return
+        }
+        val bytesPerFrame = channels * bytesPerSample
+        val bytesPerInputGroup = bytesPerFrame * downsampleFactor
+
+        val inputRemaining = inputBuffer.remaining()
+        val outputFrameCount = inputRemaining / bytesPerInputGroup
+        if (outputFrameCount == 0) return
+
+        // Output is always PCM_FLOAT (4 bytes per sample)
+        val requiredCapacity = outputFrameCount * channels * 4
+        if (outputBuffer.capacity() < requiredCapacity) {
+            outputBuffer = ByteBuffer.allocateDirect(requiredCapacity).order(ByteOrder.nativeOrder())
+        } else {
+            outputBuffer.clear()
+        }
+
+        val inputBytes = inputBuffer
+
+        repeat(outputFrameCount) {
+            val sums = FloatArray(channels)
+            repeat(downsampleFactor) {
+                for (ch in 0 until channels) {
+                    sums[ch] += readSampleAsFloat(inputBytes, encoding)
+                }
+            }
+            for (ch in 0 until channels) {
+                outputBuffer.putFloat(sums[ch] / downsampleFactor)
+            }
+        }
+
+        // Note: inputBuffer.position() was already advanced by readSampleAsFloat() calls above.
+        // Do NOT advance it again here.
+        outputBuffer.flip()
+    }
+
+    /**
+     * Reads one sample from [buf] (advancing its position) and converts it to [-1.0, 1.0] float.
+     */
+    private fun readSampleAsFloat(buf: ByteBuffer, encoding: Int): Float {
+        return when (encoding) {
+            C.ENCODING_PCM_FLOAT -> buf.float
+            C.ENCODING_PCM_32BIT -> buf.int / 2147483648f   // / 2^31
+            C.ENCODING_PCM_16BIT -> buf.short / 32768f      // / 2^15
+            else -> 0f
+        }
+    }
+
+    override fun getOutput(): ByteBuffer {
+        val pending = outputBuffer
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        return pending
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun isEnded(): Boolean = inputEnded && outputBuffer === AudioProcessor.EMPTY_BUFFER
+
+    override fun queueEndOfStream() {
+        inputEnded = true
+    }
+
+    override fun flush() {
+        outputBuffer = AudioProcessor.EMPTY_BUFFER
+        inputEnded = false
+    }
+
+    override fun reset() {
+        flush()
+        inputFormat = AudioFormat.NOT_SET
+        outputFormat = AudioFormat.NOT_SET
+        downsampleFactor = 1
+    }
+}


### PR DESCRIPTION
This is the solution i described in [1419](https://github.com/theovilardo/PixelPlayer/issues/1419).

This down samples every track with a sample rate higher than 192khz. This keeps the player from freezing and solves some crashes (at least the ones I had).

It's not perfect but it at least works for now.