### PR TITLE
feat: collapsing library header, brand colors for streaming providers…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/AlbumArtPaletteStyle.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/AlbumArtPaletteStyle.kt
@@ -7,8 +7,7 @@ enum class AlbumArtPaletteStyle(
     TONAL_SPOT("tonal_spot", "Tonal Spot"),
     VIBRANT("vibrant", "Vibrant"),
     EXPRESSIVE("expressive", "Expressive"),
-    FRUIT_SALAD("fruit_salad", "Fruit Salad"),
-    MONOCHROME("monochrome", "Monochrome");
+    FRUIT_SALAD("fruit_salad", "Fruit Salad");
 
     companion object {
         val default: AlbumArtPaletteStyle = TONAL_SPOT

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
@@ -54,8 +54,23 @@ fun StreamingProviderSheet(
     )
 ) {
     val context = LocalContext.current
-    val providerContainerColor = MaterialTheme.colorScheme.secondaryContainer
-    val providerContentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    val isDark = com.theveloper.pixelplay.ui.theme.LocalPixelPlayDarkTheme.current
+
+    // Brand colors for each provider
+    val telegramContainerColor = if (isDark) Color(0xFF1B3A4B) else Color(0xFFD6EEFB)
+    val telegramContentColor = if (isDark) Color(0xFF59B3E8) else Color(0xFF1B6FA0)
+
+    val googleDriveContainerColor = if (isDark) Color(0xFF2A3A2A) else Color(0xFFE0F0D8)
+    val googleDriveContentColor = if (isDark) Color(0xFF7BC67B) else Color(0xFF2E7D32)
+
+    val subsonicContainerColor = if (isDark) Color(0xFF3B2A1A) else Color(0xFFFDE8D0)
+    val subsonicContentColor = if (isDark) Color(0xFFE8A54B) else Color(0xFFB06A1A)
+
+    val neteaseContainerColor = if (isDark) Color(0xFF3B1A1A) else Color(0xFFFDD8D8)
+    val neteaseContentColor = if (isDark) Color(0xFFE85959) else Color(0xFFBF1B1B)
+
+    val qqMusicContainerColor = if (isDark) Color(0xFF1A3B2A) else Color(0xFFD0F5E0)
+    val qqMusicContentColor = if (isDark) Color(0xFF4BCB7B) else Color(0xFF1A8A40)
 
     val cardShape = AbsoluteSmoothCornerShape(
         cornerRadiusTR = 20.dp, cornerRadiusTL = 20.dp,
@@ -118,9 +133,9 @@ fun StreamingProviderSheet(
                 icon = Icons.Rounded.Cloud,
                 title = "Telegram",
                 subtitle = "Stream from channels & chats",
-                containerColor = providerContainerColor,
-                contentColor = providerContentColor,
-                iconColor = providerContentColor,
+                containerColor = telegramContainerColor,
+                contentColor = telegramContentColor,
+                iconColor = telegramContentColor,
                 shape = cardShape,
                 onClick = {
                     context.startActivity(Intent(context, TelegramLoginActivity::class.java))
@@ -136,9 +151,9 @@ fun StreamingProviderSheet(
                 iconPainter = painterResource(R.drawable.rounded_drive_export_24),
                 title = "Google Drive",
                 subtitle = "Coming soon",
-                containerColor = providerContainerColor,
-                contentColor = providerContentColor,
-                iconColor = providerContentColor,
+                containerColor = googleDriveContainerColor,
+                contentColor = googleDriveContentColor,
+                iconColor = googleDriveContentColor,
                 shape = cardShape,
                 enabled = false,
                 onClick = { }
@@ -155,9 +170,9 @@ fun StreamingProviderSheet(
                     "✓ Connected (Navidrome/Airsonic)"
                 else
                     "Connect Navidrome & others",
-                containerColor = providerContainerColor,
-                contentColor = providerContentColor,
-                iconColor = providerContentColor,
+                containerColor = subsonicContainerColor,
+                contentColor = subsonicContentColor,
+                iconColor = subsonicContentColor,
                 shape = cardShape,
                 onClick = {
                     if (isNavidromeLoggedIn) {
@@ -185,9 +200,9 @@ fun StreamingProviderSheet(
                         "✓ Connected"
                     else
                         "Sign in",
-                    containerColor = providerContainerColor,
-                    contentColor = providerContentColor,
-                    iconColor = providerContentColor,
+                    containerColor = neteaseContainerColor,
+                    contentColor = neteaseContentColor,
+                    iconColor = neteaseContentColor,
                     shape = neteaseCardShape,
                     onClick = {
                         if (isNeteaseLoggedIn) {
@@ -208,9 +223,9 @@ fun StreamingProviderSheet(
                         "✓ Connected"
                     else
                         "Sign in",
-                    containerColor = providerContainerColor,
-                    contentColor = providerContentColor,
-                    iconColor = providerContentColor,
+                    containerColor = qqMusicContainerColor,
+                    contentColor = qqMusicContentColor,
+                    iconColor = qqMusicContentColor,
                     shape = qqCardShape,
                     onClick = {
                         if (isQqMusicLoggedIn) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -98,6 +98,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -761,136 +763,109 @@ fun LibraryScreen(
     val currentTab = tabTitles.getOrNull(currentTabIndex)?.toLibraryTabIdOrNull() ?: currentTabId
     val currentTabTitle = currentTab.displayTitle()
 
-    Scaffold(
-        modifier = Modifier.background(brush = gradientBrush),
-        topBar = {
-            TopAppBar(
-                title = {
-                    if (isCompactNavigation) {
-                        LibraryNavigationPill(
-                            modifier = Modifier,
-                            title = currentTabTitle,
-                            isExpanded = showTabSwitcherSheet,
-                            showIcon = !isSendingToWatch,
-                            iconRes = currentTab.iconRes(),
-                            pageIndex = pagerState.currentPage,
-                            compressForWatchTransfer = isSendingToWatch,
-                            onClick = {
-                                showTabSwitcherSheet = true
-                            },
-                            onArrowClick = { showTabSwitcherSheet = true }
-                        )
-                    } else {
-                        Text(
-                            modifier = Modifier.padding(start = 8.dp),
-                            text = "Library",
-                            fontFamily = GoogleSansRounded,
-                            //style = ExpTitleTypography.titleMedium,
-                            fontWeight = FontWeight.ExtraBold,
-                            color = MaterialTheme.colorScheme.primary,
-                            fontSize = 40.sp,
-                            letterSpacing = 1.sp
-                        )
-                    }
-                },
-                actions = {
-                    if (isSendingToWatch) {
-                        val watchTransferProgress = activeWatchTransfer?.progress ?: 0f
-                        val watchTransferPercent = (watchTransferProgress * 100f).toInt().coerceIn(0, 100)
-                        Surface(
-                            modifier = Modifier
-                                .padding(end = 8.dp)
-                                .wrapContentWidth()
-                                .height(40.dp)
-                                .clip(CircleShape)
-                                .clickable(enabled = activeWatchTransfer != null) {
-                                    showWatchTransferDialog = true
-                                },
-                            shape = CircleShape,
-                            color = MaterialTheme.colorScheme.secondaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .padding(horizontal = 8.dp),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    painter = painterResource(R.drawable.rounded_watch_arrow_down_24),
-                                    contentDescription = "Watch transfer",
-                                    modifier = Modifier.size(20.dp)
-                                )
-                                Text(
-                                    text = "$watchTransferPercent%",
-                                    style = MaterialTheme.typography.labelMedium,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                        }
-                    }
-                    FilledIconButton(
-                        modifier = Modifier.padding(end = 14.dp),
-                        colors = IconButtonDefaults.filledIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                        ),
-                        onClick = {
-                            navController.navigateSafely(Screen.Settings.route)
-                        }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.rounded_settings_24),
-                            contentDescription = "Ajustes"
-                        )
-                    }
-//                    FilledTonalIconButton(
-//                        modifier = Modifier.padding(end = 14.dp),
-//                        onClick = { /* TODO: User profile action */ },
-//                        colors = IconButtonDefaults.filledTonalIconButtonColors(
-//                            containerColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
-//                        )
-//                    ) {
-//                        Icon(
-//                            imageVector = Icons.Rounded.Person,
-//                            contentDescription = "User Profile",
-//                            tint = MaterialTheme.colorScheme.primary
-//                        )
-//                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
-                )
-            )
-        }
-    ) { innerScaffoldPadding ->
-        val playerUiState by remember(playerViewModel) {
-            playerViewModel.playerUiState
-                .map { uiState -> uiState.toLibraryScreenProjection() }
-                .distinctUntilChanged()
-        }.collectAsStateWithLifecycle(initialValue = LibraryScreenPlayerProjection())
-        val isLibraryContentEmpty by remember(playerViewModel) {
-            combine(
-                playerViewModel.allSongsFlow,
-                playerViewModel.albumsFlow,
-                playerViewModel.artistsFlow
-            ) { allSongs, albums, artists ->
-                allSongs.isEmpty() && albums.isEmpty() && artists.isEmpty()
-            }.distinctUntilChanged()
-        }.collectAsStateWithLifecycle(initialValue = true)
+    val headerContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
-        Box( // Box para permitir superposición del indicador de carga
-            modifier = Modifier
-                .padding(top = innerScaffoldPadding.calculateTopPadding())
-                .fillMaxSize()
-        ) {
+    Scaffold(
+        modifier = Modifier
+            .background(brush = gradientBrush)
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            val collapsedFraction = if (scrollBehavior.state.heightOffsetLimit != 0f) {
+                (scrollBehavior.state.heightOffset / scrollBehavior.state.heightOffsetLimit).coerceIn(0f, 1f)
+            } else 0f
+
             Column(
                 modifier = Modifier
-                    // .padding(innerScaffoldPadding) // El padding ya está en el Box contenedor
-//                    .background(brush = Brush.verticalGradient(gradientColors))
-                    .background(color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f))
-                    .fillMaxSize()
+                    .background(headerContainerColor)
             ) {
+                TopAppBar(
+                    title = {
+                        if (isCompactNavigation) {
+                            LibraryNavigationPill(
+                                modifier = Modifier,
+                                title = currentTabTitle,
+                                isExpanded = showTabSwitcherSheet,
+                                showIcon = !isSendingToWatch,
+                                iconRes = currentTab.iconRes(),
+                                pageIndex = pagerState.currentPage,
+                                compressForWatchTransfer = isSendingToWatch,
+                                onClick = {
+                                    showTabSwitcherSheet = true
+                                },
+                                onArrowClick = { showTabSwitcherSheet = true }
+                            )
+                        } else {
+                            Text(
+                                modifier = Modifier.padding(start = 8.dp),
+                                text = "Library",
+                                fontFamily = GoogleSansRounded,
+                                fontWeight = FontWeight.ExtraBold,
+                                color = MaterialTheme.colorScheme.primary,
+                                fontSize = 40.sp,
+                                letterSpacing = 1.sp
+                            )
+                        }
+                    },
+                    actions = {
+                        if (isSendingToWatch) {
+                            val watchTransferProgress = activeWatchTransfer?.progress ?: 0f
+                            val watchTransferPercent = (watchTransferProgress * 100f).toInt().coerceIn(0, 100)
+                            Surface(
+                                modifier = Modifier
+                                    .padding(end = 8.dp)
+                                    .wrapContentWidth()
+                                    .height(40.dp)
+                                    .clip(CircleShape)
+                                    .clickable(enabled = activeWatchTransfer != null) {
+                                        showWatchTransferDialog = true
+                                    },
+                                shape = CircleShape,
+                                color = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .padding(horizontal = 8.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.rounded_watch_arrow_down_24),
+                                        contentDescription = "Watch transfer",
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                    Text(
+                                        text = "$watchTransferPercent%",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                }
+                            }
+                        }
+                        FilledIconButton(
+                            modifier = Modifier.padding(end = 14.dp),
+                            colors = IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                            ),
+                            onClick = {
+                                navController.navigateSafely(Screen.Settings.route)
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.rounded_settings_24),
+                                contentDescription = "Ajustes"
+                            )
+                        }
+                    },
+                    scrollBehavior = scrollBehavior,
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = Color.Transparent,
+                        scrolledContainerColor = Color.Transparent
+                    )
+                )
+                AnimatedVisibility(visible = collapsedFraction < 0.5f) {
                 if (!isCompactNavigation) {
                     val showTabIndicator = false
                     PrimaryScrollableTabRow(
@@ -935,8 +910,7 @@ fun LibraryScreen(
                             }
                         }
                         TabAnimation(
-//                        modifier = Modifier.aspectRatio(1f),
-                            index = -1, // A non-matching index to keep it unselected
+                            index = -1,
                             title = "Edit",
                             selectedIndex = currentTabIndex,
                             onClick = { showReorderTabsSheet = true }
@@ -955,7 +929,35 @@ fun LibraryScreen(
                         modifier = Modifier.padding(top = 8.dp, bottom = 10.dp)
                     )
                 }
+                }
+            }
+        }
+    ) { innerScaffoldPadding ->
+        val playerUiState by remember(playerViewModel) {
+            playerViewModel.playerUiState
+                .map { uiState -> uiState.toLibraryScreenProjection() }
+                .distinctUntilChanged()
+        }.collectAsStateWithLifecycle(initialValue = LibraryScreenPlayerProjection())
+        val isLibraryContentEmpty by remember(playerViewModel) {
+            combine(
+                playerViewModel.allSongsFlow,
+                playerViewModel.albumsFlow,
+                playerViewModel.artistsFlow
+            ) { allSongs, albums, artists ->
+                allSongs.isEmpty() && albums.isEmpty() && artists.isEmpty()
+            }.distinctUntilChanged()
+        }.collectAsStateWithLifecycle(initialValue = true)
 
+        Box(
+            modifier = Modifier
+                .padding(top = innerScaffoldPadding.calculateTopPadding())
+                .fillMaxSize()
+        ) {
+            Column(
+                modifier = Modifier
+                    .background(color = headerContainerColor)
+                    .fillMaxSize()
+            ) {
                 Surface(
                     modifier = Modifier
                         .fillMaxSize()
@@ -3125,10 +3127,10 @@ fun ArtistListItem(artist: Artist, onClick: () -> Unit, isLoading: Boolean = fal
                         .background(MaterialTheme.colorScheme.primaryContainer),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (!artist.imageUrl.isNullOrEmpty()) {
+                    if (!artist.effectiveImageUrl.isNullOrEmpty()) {
                         AsyncImage(
                             model = ImageRequest.Builder(LocalContext.current)
-                                .data(artist.imageUrl)
+                                .data(artist.effectiveImageUrl)
                                 .crossfade(true)
                                 .build(),
                             contentDescription = artist.name,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PaletteStyleSettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PaletteStyleSettingsScreen.kt
@@ -566,6 +566,5 @@ private fun AlbumArtPaletteStyle.description(): String {
         AlbumArtPaletteStyle.VIBRANT -> "High saturation accents."
         AlbumArtPaletteStyle.EXPRESSIVE -> "Bold hue shifts and contrast."
         AlbumArtPaletteStyle.FRUIT_SALAD -> "Playful rotated accents."
-        AlbumArtPaletteStyle.MONOCHROME -> "Near-neutral interpretation."
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
@@ -713,7 +713,8 @@ fun GeminiApiKeyItem(
                 onValueChange = { localApiKey = it },
                 modifier = Modifier.fillMaxWidth(),
                 placeholder = { Text("Enter API Key") },
-                singleLine = true
+                singleLine = true,
+                visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation()
             )
             Spacer(modifier = Modifier.height(12.dp))
             Row(

--- a/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
@@ -13,7 +13,6 @@ import com.google.android.material.color.utilities.MathUtils
 import com.google.android.material.color.utilities.QuantizerCelebi
 import com.google.android.material.color.utilities.SchemeExpressive
 import com.google.android.material.color.utilities.SchemeFruitSalad
-import com.google.android.material.color.utilities.SchemeMonochrome
 import com.google.android.material.color.utilities.SchemeTonalSpot
 import com.google.android.material.color.utilities.SchemeVibrant
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
@@ -53,7 +52,7 @@ private const val HIGH_CHROMA_THRESHOLD = 18.0
 private const val REQUIRED_NEUTRAL_POPULATION = 0.92
 private const val MAX_HIGH_CHROMA_POPULATION = 0.03
 private const val MAX_WEIGHTED_CHROMA_FOR_NEUTRAL = 9.0
-private const val MAX_GRAYSCALE_CHANNEL_DELTA = 14
+private const val MAX_GRAYSCALE_CHANNEL_DELTA = 10
 
 fun clearExtractedColorCache() {
     extractedColorCache.evictAll()
@@ -111,8 +110,7 @@ fun generateColorSchemeFromSeed(
     return runCatching {
         val seedArgb = seedColor.toArgb()
         val sourceHct = Hct.fromInt(seedArgb)
-        val shouldForceNeutral = paletteStyle != AlbumArtPaletteStyle.MONOCHROME &&
-            shouldUseNeutralArtworkScheme(seedArgb, sourceHct)
+        val shouldForceNeutral = shouldUseNeutralArtworkScheme(seedArgb, sourceHct)
 
         val lightScheme = createDynamicScheme(
             sourceHct = sourceHct,
@@ -229,7 +227,6 @@ private fun createDynamicScheme(
         AlbumArtPaletteStyle.VIBRANT -> SchemeVibrant(sourceHct, isDark, 0.0)
         AlbumArtPaletteStyle.EXPRESSIVE -> SchemeExpressive(sourceHct, isDark, 0.0)
         AlbumArtPaletteStyle.FRUIT_SALAD -> SchemeFruitSalad(sourceHct, isDark, 0.0)
-        AlbumArtPaletteStyle.MONOCHROME -> SchemeMonochrome(sourceHct, isDark, 0.0)
     }
 }
 

--- a/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
@@ -8,7 +8,6 @@ import com.google.android.material.color.utilities.DynamicScheme
 import com.google.android.material.color.utilities.Hct
 import com.google.android.material.color.utilities.SchemeExpressive
 import com.google.android.material.color.utilities.SchemeFruitSalad
-import com.google.android.material.color.utilities.SchemeMonochrome
 import com.google.android.material.color.utilities.SchemeTonalSpot
 import com.google.android.material.color.utilities.SchemeVibrant
 import com.google.common.truth.Truth.assertThat
@@ -16,15 +15,12 @@ import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
 import org.junit.Test
 
 class ColorRolesTest {
-    private val nonMonochromeStyles = AlbumArtPaletteStyle.entries.filterNot {
-        it == AlbumArtPaletteStyle.MONOCHROME
-    }
 
     @Test
     fun generateColorSchemeFromSeed_autoNeutralOutputIsPureGrayscale() {
         val seed = Color(0xFF7F7F7F)
 
-        nonMonochromeStyles.forEach { style ->
+        AlbumArtPaletteStyle.entries.forEach { style ->
             val actual = generateColorSchemeFromSeed(seed, style)
             val nonGrayscaleLight = actual.light.toArgbList().filterNot(::isGrayscaleArgb)
             val nonGrayscaleDark = actual.dark.toArgbList().filterNot(::isGrayscaleArgb)
@@ -39,7 +35,7 @@ class ColorRolesTest {
         val seed = Color(0xFF556B2F)
         val sourceHct = Hct.fromInt(seed.toArgb())
 
-        nonMonochromeStyles.forEach { style ->
+        AlbumArtPaletteStyle.entries.forEach { style ->
             val actual = generateColorSchemeFromSeed(seed, style)
 
             assertThat(actual.light.toArgbList())
@@ -55,24 +51,6 @@ class ColorRolesTest {
         }
     }
 
-    @Test
-    fun generateColorSchemeFromSeed_keepsMonochromeStyleExplicit() {
-        val seed = Color(0xFF7F7F7F)
-        val sourceHct = Hct.fromInt(seed.toArgb())
-        val actual = generateColorSchemeFromSeed(seed, AlbumArtPaletteStyle.MONOCHROME)
-
-        assertThat(actual.light.toArgbList())
-            .containsExactlyElementsIn(
-                SchemeMonochrome(sourceHct, false, 0.0).toArgbList()
-            )
-            .inOrder()
-        assertThat(actual.dark.toArgbList())
-            .containsExactlyElementsIn(
-                SchemeMonochrome(sourceHct, true, 0.0).toArgbList()
-            )
-            .inOrder()
-    }
-
     private fun expectedScheme(
         style: AlbumArtPaletteStyle,
         sourceHct: Hct,
@@ -83,7 +61,6 @@ class ColorRolesTest {
             AlbumArtPaletteStyle.VIBRANT -> SchemeVibrant(sourceHct, isDark, 0.0)
             AlbumArtPaletteStyle.EXPRESSIVE -> SchemeExpressive(sourceHct, isDark, 0.0)
             AlbumArtPaletteStyle.FRUIT_SALAD -> SchemeFruitSalad(sourceHct, isDark, 0.0)
-            AlbumArtPaletteStyle.MONOCHROME -> SchemeMonochrome(sourceHct, isDark, 0.0)
         }
     }
 


### PR DESCRIPTION
…, artist image fix, and monochrome theme removal

  - Auto-collapse TopAppBar and tab row on scroll in LibraryScreen
  - Use brand-specific colors for each streaming provider in CloudStream sheet
  - Fix artist tab showing Deezer image instead of custom image (effectiveImageUrl)
  - Remove broken Monochrome palette style entirely
  - Hide Gemini API key in settings with PasswordVisualTransformation
  - Lower grayscale channel delta threshold for better green color extraction