### PR TITLE
feat: sync Navidrome library songs directly from server albums

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeDao.kt
@@ -67,6 +67,12 @@ interface NavidromeDao {
     @Query("SELECT COUNT(*) FROM navidrome_playlists")
     suspend fun getPlaylistCount(): Int
 
+    @Query("SELECT DISTINCT navidrome_id FROM navidrome_songs")
+    suspend fun getAllDistinctNavidromeIds(): List<String>
+
+    @Query("DELETE FROM navidrome_songs WHERE playlist_id = '__library__'")
+    suspend fun clearLibrarySongs()
+
     // ─── Clear All ─────────────────────────────────────────────────────
 
     @Query("DELETE FROM navidrome_songs")

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -63,6 +63,7 @@ class NavidromeRepository @Inject constructor(
         private const val NAVIDROME_PARENT_DIRECTORY = "/Cloud/Navidrome"
         private const val NAVIDROME_GENRE = "Navidrome"
         private const val NAVIDROME_PLAYLIST_PREFIX = "navidrome_playlist:"
+        private const val LIBRARY_PLAYLIST_ID = "__library__"
     }
 
     private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -331,27 +332,114 @@ class NavidromeRepository @Inject constructor(
     }
 
     /**
-     * Sync all playlists and their songs.
+     * Sync all songs from the server library by fetching all albums.
+     */
+    suspend fun syncLibrarySongs(): Result<Int> {
+        if (!isLoggedIn) {
+            return Result.failure(Exception("Not logged in"))
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                Timber.d("$TAG: Syncing library songs from server")
+                val allSongs = mutableListOf<NavidromeSong>()
+                val pageSize = 500
+                val fetchedAlbums = fetchAllAlbums(pageSize)
+
+                // Fetch songs for each album
+                for (albumJson in fetchedAlbums) {
+                    val albumId = albumJson.optString("id", "")
+                    if (albumId.isBlank()) continue
+
+                    val songsResult = api.getAlbum(albumId)
+                    songsResult.fold(
+                        onSuccess = { songJsons ->
+                            val songs = NavidromeResponseParser.parseSongs(songJsons)
+                            allSongs.addAll(songs)
+                        },
+                        onFailure = {
+                            Timber.w(it, "$TAG: Failed to fetch songs for album $albumId")
+                        }
+                    )
+                }
+
+                if (allSongs.isEmpty()) {
+                    Timber.d("$TAG: No library songs found on server")
+                    return@withContext Result.success(0)
+                }
+
+                // Deduplicate by song ID
+                val uniqueSongs = allSongs.distinctBy { it.id }
+
+                val entities = uniqueSongs.map { song ->
+                    song.toEntity(LIBRARY_PLAYLIST_ID)
+                }
+
+                // Replace all library songs
+                dao.clearLibrarySongs()
+                dao.insertSongs(entities)
+
+                Timber.d("$TAG: Synced ${entities.size} library songs from ${fetchedAlbums.size} albums")
+                Result.success(entities.size)
+            } catch (e: Exception) {
+                Timber.e(e, "$TAG: Failed to sync library songs")
+                Result.failure(e)
+            }
+        }
+    }
+
+    /**
+     * Fetch all albums from server with pagination.
+     */
+    private suspend fun fetchAllAlbums(pageSize: Int): List<JSONObject> {
+        val allAlbums = mutableListOf<JSONObject>()
+        var offset = 0
+
+        while (true) {
+            val albumsResult = api.getAlbumList(
+                type = "alphabeticalByName",
+                size = pageSize,
+                offset = offset
+            )
+
+            val albumJsons = albumsResult.getOrNull()
+            if (albumJsons.isNullOrEmpty()) break
+
+            allAlbums.addAll(albumJsons)
+            offset += albumJsons.size
+            if (albumJsons.size < pageSize) break
+        }
+
+        return allAlbums
+    }
+
+    /**
+     * Sync all playlists and their songs, plus library songs.
      */
     suspend fun syncAllPlaylistsAndSongs(): Result<BulkSyncResult> {
         return withContext(Dispatchers.IO) {
-            val playlistResult = syncPlaylists().getOrElse {
-                return@withContext Result.failure(it)
-            }
+            var syncedSongCount = 0
+            var failedPlaylistCount = 0
 
-            if (playlistResult.isEmpty()) {
+            // Sync library songs (all albums)
+            val libResult = syncLibrarySongs()
+            libResult.fold(
+                onSuccess = { count -> syncedSongCount += count },
+                onFailure = { Timber.w(it, "$TAG: Failed syncing library songs") }
+            )
+
+            // Sync playlists
+            val playlistResult = syncPlaylists().getOrElse {
+                // Playlists failed but library songs may have synced
                 syncUnifiedLibrarySongsFromNavidrome()
                 return@withContext Result.success(
                     BulkSyncResult(
                         playlistCount = 0,
-                        syncedSongCount = 0,
+                        syncedSongCount = syncedSongCount,
                         failedPlaylistCount = 0
                     )
                 )
             }
-
-            var syncedSongCount = 0
-            var failedPlaylistCount = 0
 
             playlistResult.forEach { playlist ->
                 val songSyncResult = syncPlaylistSongs(playlist.id)
@@ -364,7 +452,7 @@ class NavidromeRepository @Inject constructor(
                 )
             }
 
-            // Sync to unified library once after all playlists are synced
+            // Sync to unified library once after everything is synced
             syncUnifiedLibrarySongsFromNavidrome()
 
             Result.success(

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -1610,13 +1610,22 @@ constructor(
     }
 
     private suspend fun syncNavidromeData() {
-        Log.i(TAG, "Syncing Navidrome songs to main database from local cache (Non-network mode)...")
+        Log.i(TAG, "Syncing Navidrome data from server...")
         try {
-            // This only syncs what is already in our Navidrome database to the Unified library.
-            // It does NOT connect to the server or refresh from remote.
-            navidromeRepository.syncUnifiedLibrarySongsFromNavidrome()
+            // Fetch playlists and songs from the Navidrome server, then sync to unified library
+            val result = navidromeRepository.syncAllPlaylistsAndSongs()
+            result.fold(
+                onSuccess = { summary ->
+                    Log.i(TAG, "Navidrome sync complete: ${summary.playlistCount} playlists, ${summary.syncedSongCount} songs synced (${summary.failedPlaylistCount} failed)")
+                },
+                onFailure = { e ->
+                    Log.w(TAG, "Navidrome server sync failed, falling back to local cache sync", e)
+                    // Fallback: at least sync what we already have cached
+                    navidromeRepository.syncUnifiedLibrarySongsFromNavidrome()
+                }
+            )
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to sync Navidrome local data to unified library", e)
+            Log.e(TAG, "Failed to sync Navidrome data", e)
         }
     }
 }


### PR DESCRIPTION
  Previously, Navidrome songs were only fetched through playlists. If a
  user had no playlists, no songs would be synced despite having music
  on the server. Now syncAllPlaylistsAndSongs() also fetches all albums
  via getAlbumList2/getAlbum and stores them as library songs, ensuring
  the full server library is available regardless of playlist state.

  Also fixes SyncWorker to call syncAllPlaylistsAndSongs() instead of
  only syncing from local cache, so "Sync Library" actually fetches
  data from the Navidrome/Subsonic server
