### PR TITLE
fix: resolve crash on launch, artist navigation, and random playback pauses

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -458,9 +458,20 @@ abstract class PixelPlayDatabase : RoomDatabase() {
 
         /**
          * Add missing indexes for frequently filtered and sorted queries.
+         *
+         * Safety: the `date_added` column may be absent on databases that were
+         * created before it was part of the songs schema and later restored via
+         * Android auto-backup, so we add it defensively before indexing.
          */
         val MIGRATION_23_24 = object : Migration(23, 24) {
             override fun migrate(db: SupportSQLiteDatabase) {
+                // Ensure date_added column exists before creating its index.
+                try {
+                    db.execSQL("ALTER TABLE songs ADD COLUMN date_added INTEGER NOT NULL DEFAULT 0")
+                } catch (_: Exception) {
+                    // Column already exists — expected for normal upgrade paths.
+                }
+
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_songs_content_uri_string ON songs(content_uri_string)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_songs_date_added ON songs(date_added)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_songs_duration ON songs(duration)")

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/TransitionController.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/TransitionController.kt
@@ -112,8 +112,10 @@ class TransitionController @Inject constructor(
     }
 
     private fun scheduleTransitionFor(currentMediaItem: MediaItem) {
-        // Cancel any existing job first
+        // Cancel any existing job first and reset pauseAtEnd so a stale `true`
+        // from the previous job doesn't cause an unexpected pause.
         transitionSchedulerJob?.cancel()
+        engine.setPauseAtEndOfMediaItems(false)
 
         transitionSchedulerJob = scope.launch {
             // WAIT for any active transition to finish.

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PlayerArtistNavigationEffect.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PlayerArtistNavigationEffect.kt
@@ -22,7 +22,15 @@ internal fun PlayerArtistNavigationEffect(
             playerViewModel.collapsePlayerSheet()
 
             navController.navigateSafely(Screen.ArtistDetail.createRoute(artistId)) {
-                launchSingleTop = true
+                // Allow navigating from one artist detail to another by replacing
+                // the current instance instead of blocking with launchSingleTop.
+                launchSingleTop = false
+                // Pop the existing ArtistDetail (if any) so screens don't stack.
+                navController.currentBackStackEntry?.destination?.route?.let { currentRoute ->
+                    if (currentRoute == Screen.ArtistDetail.route) {
+                        popUpTo(Screen.ArtistDetail.route) { inclusive = true }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Fixes #1428** — App crashes on launch with `SQLiteException: no such column: date_added` for users with databases restored via Android auto-backup. Added defensive `ALTER TABLE` in `MIGRATION_23_24` to ensure the column exists before indexing.
- **Fixes #1431 (bug 2)** — Navigating to a different artist from the now playing screen while already viewing an artist detail page now works correctly. Replaced `launchSingleTop = true` with `popUpTo` to swap the current artist screen instead of blocking navigation.
- **Fixes #1431 (bug 3)** — Random playback pauses caused by a stale `pauseAtEndOfMediaItems = true` flag when the crossfade transition scheduler job was cancelled before cleanup. Now resets the flag immediately on cancellation.

> **Note on #1431 (bug 1)** — Artist bottom sheet not appearing: the code logic is correct (`currentSongArtists.size > 1` triggers the picker). This is likely data-dependent — a library rescan should repopulate the `song_artist_cross_ref` table with multi-artist entries.

## Test plan

- [ ] Fresh install on a device that previously had an older version (or restore from backup) — verify no crash on launch
- [ ] Play a song with multiple artists → tap artist name → verify bottom sheet appears (after library rescan)
- [ ] From an artist detail screen, open now playing → tap a different artist → verify navigation works
- [ ] Play tracks with crossfade enabled → skip/change queue mid-transition → verify no unexpected pauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)