### PR TITLE
fix: apply ReplayGain volume after crossfade transitions

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -127,6 +127,7 @@ class MusicService : MediaLibraryService() {
     private var replayGainRequestToken = 0L
     private var userSelectedVolume = 1f
     private var expectedReplayGainVolume: Float? = null
+    private var pendingReplayGainVolume: Float? = null
 
     private var favoriteSongIds = emptySet<String>()
     private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
@@ -212,6 +213,10 @@ class MusicService : MediaLibraryService() {
         }
     }
 
+    private val transitionFinishedListener: () -> Unit = {
+        onTransitionFinished()
+    }
+
     override fun onCreate() {
         // Media3's Cast SDK callback path (MediaSessionImpl$$ExternalSyntheticLambda →
         // Util.postOrRun → MediaNotificationManager.updateNotificationInternal) calls
@@ -241,6 +246,7 @@ class MusicService : MediaLibraryService() {
 
         // Handle player swaps (crossfade) to keep MediaSession in sync
         engine.addPlayerSwapListener(playerSwapListener)
+        engine.addTransitionFinishedListener(transitionFinishedListener)
 
         controller.initialize()
         initializeCastWearSync()
@@ -1010,6 +1016,7 @@ class MusicService : MediaLibraryService() {
         }
 
         if (!replayGainEnabled) {
+            pendingReplayGainVolume = null
             if (!engine.isTransitionRunning()) {
                 setPlayerVolume(player, userSelectedVolume)
             }
@@ -1050,8 +1057,13 @@ class MusicService : MediaLibraryService() {
                 useAlbumGain = useAlbumGain
             )
 
-            // Only apply if we're not mid-crossfade
-            if (!engine.isTransitionRunning()) {
+            if (engine.isTransitionRunning()) {
+                // Store for application after transition completes
+                pendingReplayGainVolume = volume
+                Timber.tag(TAG).d("ReplayGain: Stored pending volume=%.2f for %s (transition running)",
+                    volume, mediaItem.mediaMetadata?.title)
+            } else {
+                pendingReplayGainVolume = null
                 setPlayerVolume(player, volume)
                 Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
                     volume, mediaItem.mediaMetadata?.title)
@@ -1063,6 +1075,27 @@ class MusicService : MediaLibraryService() {
         val clampedVolume = volume.coerceIn(0f, 1f)
         expectedReplayGainVolume = clampedVolume
         player.volume = clampedVolume
+    }
+
+    private fun onTransitionFinished() {
+        val player = engine.masterPlayer
+        val pending = pendingReplayGainVolume
+        pendingReplayGainVolume = null
+
+        if (!replayGainEnabled) {
+            setPlayerVolume(player, userSelectedVolume)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, RG disabled — restored userSelectedVolume=%.2f", userSelectedVolume)
+            return
+        }
+
+        if (pending != null) {
+            setPlayerVolume(player, pending)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, applied pending volume=%.2f", pending)
+        } else {
+            // No pending volume was computed during transition, trigger full computation
+            applyReplayGain(mediaSession?.player?.currentMediaItem)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, no pending volume — triggering full recomputation")
+        }
     }
 
     private fun initializeCastWearSync() {
@@ -1201,6 +1234,7 @@ class MusicService : MediaLibraryService() {
         replayGainJob?.cancel()
 
         engine.removePlayerSwapListener(playerSwapListener)
+        engine.removeTransitionFinishedListener(transitionFinishedListener)
         engine.masterPlayer.removeListener(playerListener)
 
         mediaSession?.run {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -70,6 +70,7 @@ class DualPlayerEngine @Inject constructor(
     private lateinit var playerB: ExoPlayer
 
     private val onPlayerSwappedListeners = mutableListOf<(Player) -> Unit>()
+    private val onTransitionFinishedListeners = mutableListOf<() -> Unit>()
     
     // Active Audio Session ID Flow
     private val _activeAudioSessionId = kotlinx.coroutines.flow.MutableStateFlow(0)
@@ -179,6 +180,14 @@ class DualPlayerEngine @Inject constructor(
 
     fun removePlayerSwapListener(listener: (Player) -> Unit) {
         onPlayerSwappedListeners.remove(listener)
+    }
+
+    fun addTransitionFinishedListener(listener: () -> Unit) {
+        onTransitionFinishedListeners.add(listener)
+    }
+
+    fun removeTransitionFinishedListener(listener: () -> Unit) {
+        onTransitionFinishedListeners.remove(listener)
     }
 
     /** The master player instance that should be connected to the MediaSession. */
@@ -607,6 +616,7 @@ class DualPlayerEngine @Inject constructor(
                 playerB.stop()
             } finally {
                 transitionRunning = false
+                onTransitionFinishedListeners.forEach { it() }
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Fixed ReplayGain toggle having no effect** — after crossfade transitions, `applyReplayGain` was called but the computed volume was silently discarded because `isTransitionRunning()` was true. After the transition finished (`playerA.volume = 1f`), nothing re-triggered the application. Now the computed volume is stored during transitions and applied immediately when the crossfade completes.
- **Fixed volume spikes during crossfade with ReplayGain** — same root cause. The crossfade hardcoded `playerA.volume = 1f` at the end, and the RG-adjusted volume was never re-applied. The new transition-finished callback applies the correct volume without IO delay.

Fixes #1427

## Changes
- `DualPlayerEngine.kt`: Added `onTransitionFinishedListeners` callback list, fired in the `finally` block of `performTransition` after `transitionRunning = false`
- `MusicService.kt`: Added `pendingReplayGainVolume` field to store RG volume computed during crossfade; added `onTransitionFinished()` handler that applies the pending volume immediately when the crossfade ends (or restores `userSelectedVolume` if RG is disabled)

## Test plan
- [ ] Enable ReplayGain, play a track with RG tags, verify volume is normalized
- [ ] Toggle ReplayGain off mid-playback — volume should return to full
- [ ] Enable ReplayGain + crossfade, let tracks transition — no volume spike at the crossfade boundary
- [ ] Disable ReplayGain while crossfade is active — volume should restore after transition completes
- [ ] Skip tracks rapidly with crossfade enabled — no stuck volumes or crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)