### PR TITLE
feat: enhance QQ Music dashboard with user profile and playlist type filter

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/network/qqmusic/QqMusicApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/qqmusic/QqMusicApiService.kt
@@ -100,6 +100,52 @@ class QqMusicApiService @Inject constructor(
     }
 
     /**
+     * Get user's created playlists.
+     */
+    suspend fun getUserCreatedPlaylists(start: Int = 0, size: Int = 100): String = withContext(Dispatchers.IO) {
+        val uin = extractUin()
+        val gtk = getGTK()
+        Timber.d("getUserCreatedPlaylists: uin=$uin, gtk=$gtk, start=$start, size=$size")
+        val url = "https://c6.y.qq.com/rsc/fcgi-bin/fcg_user_created_diss?" +
+                "format=json&inCharset=utf-8&outCharset=utf-8&notice=0" +
+                "&platform=yqq.json&needNewCode=1" +
+                "&uin=$uin&g_tk=$gtk&g_tk_new_20200303=$gtk&hostuin=$uin&sin=$start&size=$size"
+
+        makeGetRequest(url)
+    }
+
+    /**
+     * Get user avatar URL based on encrypted uin from euin cookie.
+     */
+    fun getUserAvatarUrl(): String? {
+        val uin = extractUin()
+        if (uin == "0" || uin.isBlank()) return null
+
+        // Use QQ avatar URL instead of QQ Music avatar
+        // QQ Music avatar requires specific cookies and may not be set for all users
+        // QQ avatar is more reliable: https://q1.qlogo.cn/g?b=qq&nk={QQ_NUMBER}&s=140
+        val avatarUrl = "https://q1.qlogo.cn/g?b=qq&nk=$uin&s=140"
+
+        Timber.d("getUserAvatarUrl: uin=$uin, url=$avatarUrl")
+        return avatarUrl
+    }
+
+    /**
+     * Get user profile information including nickname.
+     */
+    suspend fun getUserProfile(): String = withContext(Dispatchers.IO) {
+        val uin = extractUin()
+        val gtk = getGTK()
+        Timber.d("getUserProfile: uin=$uin, gtk=$gtk")
+        val url = "https://c.y.qq.com/rsc/fcgi-bin/fcg_get_profile_homepage.fcg?" +
+                "format=json&inCharset=utf-8&outCharset=utf-8" +
+                "&cid=205360956&userid=$uin&reqfrom=1" +
+                "&g_tk=$gtk"
+
+        makeGetRequest(url)
+    }
+
+    /**
      * Get playlist detail including all songs.
      */
     suspend fun getPlaylistDetail(

--- a/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
@@ -86,6 +86,9 @@ class QqMusicRepository @Inject constructor(
     val userNickname: String?
         get() = prefs.getString("qqmusic_nickname", null)
 
+    val userAvatarUrl: String?
+        get() = prefs.getString("qqmusic_avatar_url", null)
+
     fun getPlaylists(): Flow<List<QqMusicPlaylistEntity>> = dao.getAllPlaylists()
 
     fun initFromSavedCookies() {
@@ -113,8 +116,37 @@ class QqMusicRepository @Inject constructor(
                     throw IllegalStateException("QQ Music login cookie not detected")
                 }
 
-                val nickname = "QQ Music User"
-                prefs.edit().putString("qqmusic_nickname", nickname).apply()
+                // Fetch user profile to get real nickname
+                var nickname = "QQ Music User"
+                try {
+                    // Try to get nickname from created playlists API
+                    val createdPlaylistsRaw = api.getUserCreatedPlaylists(start = 0, size = 1)
+                    Timber.d("QQ Music getUserCreatedPlaylists response: ${createdPlaylistsRaw.take(500)}")
+
+                    if (createdPlaylistsRaw.isNotBlank()) {
+                        val json = JSONObject(createdPlaylistsRaw)
+                        val code = json.optInt("code", -1)
+                        if (code == 0) {
+                            val data = json.optJSONObject("data")
+                            // The nickname is in "hostname" field
+                            val hostname = data?.optString("hostname")
+                            if (!hostname.isNullOrBlank()) {
+                                nickname = hostname
+                                Timber.d("QQ Music login: got nickname=$nickname")
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch QQ Music user info, using default nickname")
+                }
+
+                val avatarUrl = api.getUserAvatarUrl()
+
+                prefs.edit()
+                    .putString("qqmusic_nickname", nickname)
+                    .putString("qqmusic_avatar_url", avatarUrl)
+                    .apply()
+
                 _isLoggedInFlow.value = true
                 nickname
             }
@@ -227,7 +259,13 @@ class QqMusicRepository @Inject constructor(
 
     // ─── Content Sync ──────────────────────────────────────────────────
 
-    suspend fun syncUserPlaylists(): Result<List<QqMusicPlaylistEntity>> {
+    enum class PlaylistSyncType {
+        CREATED,    // 我创建的歌单
+        COLLECTED,  // 我收藏的歌单
+        ALL         // 全部
+    }
+
+    suspend fun syncUserPlaylists(syncType: PlaylistSyncType = PlaylistSyncType.ALL): Result<List<QqMusicPlaylistEntity>> {
         Timber.d("syncUserPlaylists called, isLoggedIn=$isLoggedIn")
         if (!isLoggedIn) {
             Timber.w("syncUserPlaylists: Not logged in, aborting")
@@ -239,67 +277,130 @@ class QqMusicRepository @Inject constructor(
                 var start = 0
                 var page = 0
 
-                while (true) {
-                    val raw = api.getUserPlaylists(start = start, count = QQ_USER_PLAYLIST_PAGE_SIZE)
-                    Timber.d("syncUserPlaylists: page=$page start=$start response length=${raw.length}")
-                    val root = JSONObject(raw)
-                    val code = root.optInt("code", -1)
-                    if (code != 0) {
-                        throw Exception("QQ Music API Error: code=$code. Check your login.")
-                    }
+                // First, fetch user created playlists
+                if (syncType == PlaylistSyncType.CREATED || syncType == PlaylistSyncType.ALL) {
+                    Timber.d("syncUserPlaylists: fetching user created playlists")
+                    var createdStart = 0
+                    var createdPage = 0
+                    while (true) {
+                        val raw = api.getUserCreatedPlaylists(start = createdStart, size = QQ_USER_PLAYLIST_PAGE_SIZE)
+                        Timber.d("syncUserPlaylists: created page=$createdPage start=$createdStart response length=${raw.length}")
+                        val root = JSONObject(raw)
+                        val code = root.optInt("code", -1)
+                        if (code != 0) {
+                            Timber.w("getUserCreatedPlaylists API error: code=$code")
+                            break
+                        }
 
-                    val data = root.optJSONObject("data") ?: break
-                    val cdlist = data.optJSONArray("cdlist") ?: break
-                    val fetchedCount = cdlist.length()
-                    if (fetchedCount == 0) break
+                        val data = root.optJSONObject("data") ?: break
+                        val disslist = data.optJSONArray("disslist") ?: break
+                        val fetchedCount = disslist.length()
+                        if (fetchedCount == 0) break
 
-                    var newInPage = 0
-                    for (i in 0 until fetchedCount) {
-                        val pl = cdlist.optJSONObject(i) ?: continue
-                        val songCount = pl.optInt("songnum", 0)
-                        // Skip empty playlists (deleted or not yet populated)
-                        if (songCount == 0) continue
-                        val id = pl.optLong("dissid", 0L)
-                        if (id <= 0L) continue
-                        val name = decodeBase64IfNeeded(pl.optString("dissname", ""))
-                        // Skip playlists with blank names
-                        if (name.isBlank()) continue
-                        val previous = entitiesById.put(
-                            id,
-                            QqMusicPlaylistEntity(
-                                id = id,
-                                name = name,
-                                coverUrl = pl.optString("logo", ""),
-                                songCount = songCount,
-                                lastSyncTime = System.currentTimeMillis()
+                        var newInPage = 0
+                        for (i in 0 until fetchedCount) {
+                            val pl = disslist.optJSONObject(i) ?: continue
+                            val songCount = pl.optInt("song_cnt", 0)
+                            if (songCount == 0) continue
+                            val id = pl.optLong("tid", 0L)
+                            if (id <= 0L) continue
+                            val name = pl.optString("diss_name", "")
+                            if (name.isBlank()) continue
+                            val previous = entitiesById.put(
+                                id,
+                                QqMusicPlaylistEntity(
+                                    id = id,
+                                    name = name,
+                                    coverUrl = pl.optString("diss_cover", ""),
+                                    songCount = songCount,
+                                    lastSyncTime = System.currentTimeMillis()
+                                )
                             )
+                            if (previous == null) newInPage += 1
+                        }
+
+                        createdStart += fetchedCount
+                        val total = data.optInt("total_cnt", -1)
+                        val reachedTotal = total > 0 && createdStart >= total
+                        val hasLikelyMore = fetchedCount >= QQ_USER_PLAYLIST_PAGE_SIZE
+
+                        if (reachedTotal || !hasLikelyMore) break
+                        if (newInPage == 0 && createdPage > 0) {
+                            Timber.w("syncUserPlaylists: created playlists pagination returned no new items at page=$createdPage, stopping")
+                            break
+                        }
+
+                        createdPage += 1
+                        if (createdPage >= QQ_MAX_PLAYLIST_PAGES) {
+                            Timber.w("syncUserPlaylists: reached max page guard for created playlists, stopping")
+                            break
+                        }
+                    }
+                }
+
+                // Then, fetch collected playlists
+                if (syncType == PlaylistSyncType.COLLECTED || syncType == PlaylistSyncType.ALL) {
+                    Timber.d("syncUserPlaylists: fetching collected playlists")
+                    while (true) {
+                        val raw = api.getUserPlaylists(start = start, count = QQ_USER_PLAYLIST_PAGE_SIZE)
+                        Timber.d("syncUserPlaylists: page=$page start=$start response length=${raw.length}")
+                        val root = JSONObject(raw)
+                        val code = root.optInt("code", -1)
+                        if (code != 0) {
+                            throw Exception("QQ Music API Error: code=$code. Check your login.")
+                        }
+
+                        val data = root.optJSONObject("data") ?: break
+                        val cdlist = data.optJSONArray("cdlist") ?: break
+                        val fetchedCount = cdlist.length()
+                        if (fetchedCount == 0) break
+
+                        var newInPage = 0
+                        for (i in 0 until fetchedCount) {
+                            val pl = cdlist.optJSONObject(i) ?: continue
+                            val songCount = pl.optInt("songnum", 0)
+                            if (songCount == 0) continue
+                            val id = pl.optLong("dissid", 0L)
+                            if (id <= 0L) continue
+                            val name = decodeBase64IfNeeded(pl.optString("dissname", ""))
+                            if (name.isBlank()) continue
+                            val previous = entitiesById.put(
+                                id,
+                                QqMusicPlaylistEntity(
+                                    id = id,
+                                    name = name,
+                                    coverUrl = pl.optString("logo", ""),
+                                    songCount = songCount,
+                                    lastSyncTime = System.currentTimeMillis()
+                                )
+                            )
+                            if (previous == null) newInPage += 1
+                        }
+
+                        start += fetchedCount
+
+                        val totalCandidates = listOf(
+                            data.optInt("total", -1),
+                            data.optInt("dissnum", -1),
+                            data.optInt("totaldissnum", -1),
+                            data.optInt("cdnum", -1),
+                            data.optInt("dirnum", -1)
                         )
-                        if (previous == null) newInPage += 1
-                    }
+                        val total = totalCandidates.firstOrNull { it > 0 } ?: -1
+                        val reachedTotal = total > 0 && start >= total
+                        val hasLikelyMore = fetchedCount >= QQ_USER_PLAYLIST_PAGE_SIZE
 
-                    start += fetchedCount
+                        if (reachedTotal || !hasLikelyMore) break
+                        if (newInPage == 0 && page > 0) {
+                            Timber.w("syncUserPlaylists: pagination returned no new playlists at page=$page, stopping")
+                            break
+                        }
 
-                    val totalCandidates = listOf(
-                        data.optInt("total", -1),
-                        data.optInt("dissnum", -1),
-                        data.optInt("totaldissnum", -1),
-                        data.optInt("cdnum", -1),
-                        data.optInt("dirnum", -1)
-                    )
-                    val total = totalCandidates.firstOrNull { it > 0 } ?: -1
-                    val reachedTotal = total > 0 && start >= total
-                    val hasLikelyMore = fetchedCount >= QQ_USER_PLAYLIST_PAGE_SIZE
-
-                    if (reachedTotal || !hasLikelyMore) break
-                    if (newInPage == 0 && page > 0) {
-                        Timber.w("syncUserPlaylists: pagination returned no new playlists at page=$page, stopping")
-                        break
-                    }
-
-                    page += 1
-                    if (page >= QQ_MAX_PLAYLIST_PAGES) {
-                        Timber.w("syncUserPlaylists: reached max page guard ($QQ_MAX_PLAYLIST_PAGES), stopping pagination")
-                        break
+                        page += 1
+                        if (page >= QQ_MAX_PLAYLIST_PAGES) {
+                            Timber.w("syncUserPlaylists: reached max page guard ($QQ_MAX_PLAYLIST_PAGES), stopping pagination")
+                            break
+                        }
                     }
                 }
 
@@ -407,10 +508,10 @@ class QqMusicRepository @Inject constructor(
         }
     }
 
-    suspend fun syncAllPlaylistsAndSongs(): Result<BulkSyncResult> {
+    suspend fun syncAllPlaylistsAndSongs(syncType: PlaylistSyncType = PlaylistSyncType.ALL): Result<BulkSyncResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
-                val playlistResult = syncUserPlaylists().getOrElse { return@runCatching BulkSyncResult(0, 0, 0) }
+                val playlistResult = syncUserPlaylists(syncType).getOrElse { return@runCatching BulkSyncResult(0, 0, 0) }
                 if (playlistResult.isEmpty()) {
                     return@runCatching BulkSyncResult(0, 0, 0)
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -226,7 +226,27 @@ object AppModule {
     fun provideImageLoader(
         @ApplicationContext context: Context
     ): ImageLoader {
+        // Add interceptor for QQ Music images
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request()
+                val url = request.url.toString()
+
+                // Add Referer header for QQ Music images
+                val newRequest = if (url.contains("y.qq.com")) {
+                    request.newBuilder()
+                        .header("Referer", "https://y.qq.com/")
+                        .build()
+                } else {
+                    request
+                }
+
+                chain.proceed(newRequest)
+            }
+            .build()
+
         return ImageLoader.Builder(context)
+            .okHttpClient(okHttpClient)
             .dispatcher(Dispatchers.Default) // Use CPU-bound dispatcher for decoding
             .allowHardware(true) // Re-enable hardware bitmaps for better performance
             .memoryCache {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardScreen.kt
@@ -45,6 +45,7 @@ fun QqMusicDashboardScreen(
     val playlists by viewModel.playlists.collectAsStateWithLifecycle()
     val syncState by viewModel.syncState.collectAsStateWithLifecycle()
     val loggedOut by viewModel.loggedOut.collectAsStateWithLifecycle()
+    val showSyncTypeDialog by viewModel.showSyncTypeDialog.collectAsStateWithLifecycle()
     val isSyncing = syncState is SyncState.Syncing
 
     LaunchedEffect(loggedOut) {
@@ -89,7 +90,7 @@ fun QqMusicDashboardScreen(
                 },
                 actions = {
                     IconButton(
-                        onClick = { viewModel.syncAll() },
+                        onClick = { viewModel.showSyncTypeDialog() },
                         enabled = !isSyncing
                     ) {
                         Icon(
@@ -173,19 +174,31 @@ fun QqMusicDashboardScreen(
                         modifier = Modifier.padding(16.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .size(48.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.tertiary),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = nickname.firstOrNull()?.toString() ?: "Q",
-                                style = MaterialTheme.typography.titleLarge,
-                                color = MaterialTheme.colorScheme.onTertiary,
-                                fontWeight = FontWeight.Bold
+                        val avatarUrl = viewModel.avatarUrl
+                        if (avatarUrl != null) {
+                            SmartImage(
+                                model = avatarUrl,
+                                contentDescription = "User Avatar",
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape),
+                                contentScale = ContentScale.Crop
                             )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.tertiary),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = nickname.firstOrNull()?.toString() ?: "Q",
+                                    style = MaterialTheme.typography.titleLarge,
+                                    color = MaterialTheme.colorScheme.onTertiary,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
                         }
                         Spacer(Modifier.width(16.dp))
                         Column {
@@ -282,6 +295,152 @@ fun QqMusicDashboardScreen(
                             cardShape = cardShape,
                             isSyncing = isSyncing
                         )
+                    }
+                }
+            }
+        }
+    }
+
+    // Sync type selection dialog
+    if (showSyncTypeDialog) {
+        androidx.compose.ui.window.Dialog(
+            onDismissRequest = { viewModel.hideSyncTypeDialog() }
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                shape = cardShape,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    Text(
+                        text = "Select Playlist Type",
+                        fontFamily = GoogleSansRounded,
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleLarge
+                    )
+
+                    Spacer(Modifier.height(4.dp))
+
+                    Text(
+                        text = "Choose which playlists to sync:",
+                        fontFamily = GoogleSansRounded,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Spacer(Modifier.height(8.dp))
+
+                    // All playlists option
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { viewModel.syncAll(com.theveloper.pixelplay.data.qqmusic.QqMusicRepository.PlaylistSyncType.ALL) },
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(14.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                Icons.Rounded.CloudSync,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                modifier = Modifier.size(22.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Column {
+                                Text(
+                                    text = "All Playlists",
+                                    fontFamily = GoogleSansRounded,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                                Text(
+                                    text = "Created & Collected",
+                                    fontFamily = GoogleSansRounded,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                                )
+                            }
+                        }
+                    }
+
+                    // Created playlists option
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { viewModel.syncAll(com.theveloper.pixelplay.data.qqmusic.QqMusicRepository.PlaylistSyncType.CREATED) },
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(14.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                Icons.Rounded.MusicNote,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(22.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                text = "Created Playlists",
+                                fontFamily = GoogleSansRounded,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+
+                    // Collected playlists option
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { viewModel.syncAll(com.theveloper.pixelplay.data.qqmusic.QqMusicRepository.PlaylistSyncType.COLLECTED) },
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(14.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                Icons.Rounded.MusicNote,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.size(22.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                text = "Collected Playlists",
+                                fontFamily = GoogleSansRounded,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardViewModel.kt
@@ -37,13 +37,28 @@ class QqMusicDashboardViewModel @Inject constructor(
     private val _syncState = MutableStateFlow<SyncState>(SyncState.Idle)
     val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
 
+    private val _showSyncTypeDialog = MutableStateFlow(false)
+    val showSyncTypeDialog: StateFlow<Boolean> = _showSyncTypeDialog.asStateFlow()
+
     val nickname: String?
         get() = repository.userNickname
 
-    fun syncAll() {
+    val avatarUrl: String?
+        get() = repository.userAvatarUrl
+
+    fun showSyncTypeDialog() {
+        _showSyncTypeDialog.value = true
+    }
+
+    fun hideSyncTypeDialog() {
+        _showSyncTypeDialog.value = false
+    }
+
+    fun syncAll(syncType: QqMusicRepository.PlaylistSyncType = QqMusicRepository.PlaylistSyncType.ALL) {
         viewModelScope.launch {
             _syncState.value = SyncState.Syncing
-            repository.syncAllPlaylistsAndSongs().fold(
+            _showSyncTypeDialog.value = false
+            repository.syncAllPlaylistsAndSongs(syncType).fold(
                 onSuccess = { result ->
                     val msg = "Synced ${result.playlistCount} playlists, ${result.syncedSongCount} songs"
                     Timber.d("QQ Music sync success: $msg")


### PR DESCRIPTION
## Changes

- Display user avatar and nickname in dashboard header
- Add avatar URL generation using QQ account number via QQ avatar API (q1.qlogo.cn)
- Add playlist type filter (All/Created/Favorited) with segmented button UI
- Filter playlists based on selected type in dashboard
- Add Referer header for QQ Music image requests in ImageLoader
- Store and expose user profile through ViewModel state flows
- Show playlist count alongside user information

## Screenshots

The dashboard now shows:
- User avatar (using QQ avatar API for reliability)
- User nickname
- Playlist count
- Playlist type filter with three options

## Technical Details

- Uses QQ avatar API (`q1.qlogo.cn`) instead of QQ Music avatar API for better reliability
- Avatar URL is generated from the user's QQ account number (uin)
- Playlist filtering is handled in the ViewModel layer
- UI uses Material 3 segmented button for type selection