### PR TITLE
Improve memory efficiency and safety during backup restore and inspec…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/BackupManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/BackupManager.kt
@@ -123,12 +123,17 @@ class BackupManager @Inject constructor(
                 warnings.addAll(manifestValidation.warnings.map { it.message })
             }
 
-            val modulePayloads = backupReader.readAllModulePayloads(uri).getOrThrow()
             plan.availableModules.toList().sortedBy { it.key }.forEach { section ->
-                val payload = modulePayloads[section.key]
-                    ?: throw IllegalArgumentException(
-                        "Backup is missing the payload for ${section.label}."
+                val moduleInfo = plan.manifest.modules[section.key]
+                if (moduleInfo != null && moduleInfo.sizeBytes > BackupReader.MAX_MODULE_PAYLOAD_BYTES) {
+                    warnings.add(
+                        "${section.label}: payload is ${moduleInfo.sizeBytes / (1024 * 1024)}MB, " +
+                            "so preview validation was skipped to avoid running out of memory."
                     )
+                    return@forEach
+                }
+
+                val payload = backupReader.readModulePayload(uri, section.key).getOrThrow()
 
                 val moduleValidation = validationPipeline.validateModulePayload(
                     section = section,

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/format/BackupReader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/format/BackupReader.kt
@@ -8,7 +8,8 @@ import com.theveloper.pixelplay.di.BackupGson
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.Reader
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
 import javax.inject.Inject
@@ -21,23 +22,27 @@ class BackupReader @Inject constructor(
     private val formatDetector: BackupFormatDetector,
     private val legacyAdapter: LegacyPayloadAdapter
 ) {
+    companion object {
+        const val MAX_MANIFEST_BYTES = 512 * 1024
+        const val MAX_MODULE_PAYLOAD_BYTES = 16 * 1024 * 1024
+        const val MAX_LEGACY_BACKUP_BYTES = 32 * 1024 * 1024
+    }
+
     /**
      * Reads only the manifest from a backup file (efficient for inspection/preview).
      */
     suspend fun readManifest(uri: Uri): Result<BackupManifest> = withContext(Dispatchers.IO) {
         runCatching {
-            val rawBytes = readRawBytes(uri)
-            val header = rawBytes.copyOf(minOf(8, rawBytes.size))
-            val format = formatDetector.detect(header)
+            val format = detectFormatInternal(uri)
 
             when (format) {
                 BackupFormatDetector.Format.PXPL_V3_ZIP -> {
-                    readManifestFromZip(rawBytes, BackupFormatDetector.PXPL_MAGIC_SIZE)
+                    readManifestFromZip(uri)
                 }
                 BackupFormatDetector.Format.PXPL_V2_GZIP,
                 BackupFormatDetector.Format.LEGACY_GZIP,
                 BackupFormatDetector.Format.LEGACY_RAW -> {
-                    val json = decompressLegacy(rawBytes, format)
+                    val json = decompressLegacy(uri, format)
                     val (manifest, _) = legacyAdapter.adapt(json, gson)
                     manifest
                 }
@@ -53,19 +58,17 @@ class BackupReader @Inject constructor(
      */
     suspend fun readModulePayload(uri: Uri, moduleKey: String): Result<String> = withContext(Dispatchers.IO) {
         runCatching {
-            val rawBytes = readRawBytes(uri)
-            val header = rawBytes.copyOf(minOf(8, rawBytes.size))
-            val format = formatDetector.detect(header)
+            val format = detectFormatInternal(uri)
 
             when (format) {
                 BackupFormatDetector.Format.PXPL_V3_ZIP -> {
-                    readEntryFromZip(rawBytes, BackupFormatDetector.PXPL_MAGIC_SIZE, "$moduleKey.json")
+                    readEntryFromZip(uri, "$moduleKey.json", MAX_MODULE_PAYLOAD_BYTES)
                         ?: throw IllegalArgumentException("Module '$moduleKey' not found in backup")
                 }
                 BackupFormatDetector.Format.PXPL_V2_GZIP,
                 BackupFormatDetector.Format.LEGACY_GZIP,
                 BackupFormatDetector.Format.LEGACY_RAW -> {
-                    val json = decompressLegacy(rawBytes, format)
+                    val json = decompressLegacy(uri, format)
                     val (_, modules) = legacyAdapter.adapt(json, gson)
                     modules[moduleKey]
                         ?: throw IllegalArgumentException("Module '$moduleKey' not found in legacy backup")
@@ -82,18 +85,16 @@ class BackupReader @Inject constructor(
      */
     suspend fun readAllModulePayloads(uri: Uri): Result<Map<String, String>> = withContext(Dispatchers.IO) {
         runCatching {
-            val rawBytes = readRawBytes(uri)
-            val header = rawBytes.copyOf(minOf(8, rawBytes.size))
-            val format = formatDetector.detect(header)
+            val format = detectFormatInternal(uri)
 
             when (format) {
                 BackupFormatDetector.Format.PXPL_V3_ZIP -> {
-                    readAllEntriesFromZip(rawBytes, BackupFormatDetector.PXPL_MAGIC_SIZE)
+                    readAllEntriesFromZip(uri, MAX_MODULE_PAYLOAD_BYTES)
                 }
                 BackupFormatDetector.Format.PXPL_V2_GZIP,
                 BackupFormatDetector.Format.LEGACY_GZIP,
                 BackupFormatDetector.Format.LEGACY_RAW -> {
-                    val json = decompressLegacy(rawBytes, format)
+                    val json = decompressLegacy(uri, format)
                     val (_, modules) = legacyAdapter.adapt(json, gson)
                     modules
                 }
@@ -109,69 +110,145 @@ class BackupReader @Inject constructor(
      */
     suspend fun detectFormat(uri: Uri): Result<BackupFormatDetector.Format> = withContext(Dispatchers.IO) {
         runCatching {
-            val rawBytes = readRawBytes(uri)
-            val header = rawBytes.copyOf(minOf(8, rawBytes.size))
-            formatDetector.detect(header)
+            detectFormatInternal(uri)
         }
     }
 
-    private fun readRawBytes(uri: Uri): ByteArray {
-        return context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+    private fun detectFormatInternal(uri: Uri): BackupFormatDetector.Format {
+        return context.contentResolver.openInputStream(uri)?.use { input ->
+            val header = formatDetector.readHeader(input)
+            formatDetector.detect(header)
+        }
             ?: throw IllegalStateException("Unable to open backup file")
     }
 
-    private fun readManifestFromZip(rawBytes: ByteArray, offset: Int): BackupManifest {
-        val json = readEntryFromZip(rawBytes, offset, BackupManifest.MANIFEST_FILENAME)
+    private fun readManifestFromZip(uri: Uri): BackupManifest {
+        val json = readEntryFromZip(
+            uri = uri,
+            entryName = BackupManifest.MANIFEST_FILENAME,
+            maxChars = MAX_MANIFEST_BYTES
+        )
             ?: throw IllegalArgumentException("Manifest not found in backup archive")
         return gson.fromJson(json, BackupManifest::class.java)
     }
 
-    private fun readEntryFromZip(rawBytes: ByteArray, offset: Int, entryName: String): String? {
-        val zipBytes = rawBytes.copyOfRange(offset, rawBytes.size)
-        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zip ->
-            var entry = zip.nextEntry
-            while (entry != null) {
-                if (entry.name == entryName) {
-                    return zip.bufferedReader(Charsets.UTF_8).readText()
+    private fun readEntryFromZip(uri: Uri, entryName: String, maxChars: Int): String? {
+        context.contentResolver.openInputStream(uri)?.use { raw ->
+            skipFully(raw, BackupFormatDetector.PXPL_MAGIC_SIZE)
+            ZipInputStream(raw).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    if (entry.name == entryName) {
+                        return zip.bufferedReader(Charsets.UTF_8).use { reader ->
+                            readTextLimited(
+                                reader = reader,
+                                maxChars = maxChars,
+                                sourceLabel = "Backup entry '$entryName'"
+                            )
+                        }
+                    }
+                    zip.closeEntry()
+                    entry = zip.nextEntry
                 }
-                zip.closeEntry()
-                entry = zip.nextEntry
             }
         }
         return null
     }
 
-    private fun readAllEntriesFromZip(rawBytes: ByteArray, offset: Int): Map<String, String> {
+    private fun readAllEntriesFromZip(uri: Uri, maxChars: Int): Map<String, String> {
         val entries = mutableMapOf<String, String>()
-        val zipBytes = rawBytes.copyOfRange(offset, rawBytes.size)
-        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zip ->
-            var entry = zip.nextEntry
-            while (entry != null) {
-                val name = entry.name
-                if (name != BackupManifest.MANIFEST_FILENAME && name.endsWith(".json")) {
-                    val key = name.removeSuffix(".json")
-                    entries[key] = zip.bufferedReader(Charsets.UTF_8).readText()
+        context.contentResolver.openInputStream(uri)?.use { raw ->
+            skipFully(raw, BackupFormatDetector.PXPL_MAGIC_SIZE)
+            ZipInputStream(raw).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    val name = entry.name
+                    if (name != BackupManifest.MANIFEST_FILENAME && name.endsWith(".json")) {
+                        val key = name.removeSuffix(".json")
+                        entries[key] = zip.bufferedReader(Charsets.UTF_8).use { reader ->
+                            readTextLimited(
+                                reader = reader,
+                                maxChars = maxChars,
+                                sourceLabel = "Backup entry '$name'"
+                            )
+                        }
+                    }
+                    zip.closeEntry()
+                    entry = zip.nextEntry
                 }
-                zip.closeEntry()
-                entry = zip.nextEntry
             }
-        }
+        } ?: throw IllegalStateException("Unable to open backup file")
         return entries
     }
 
-    private fun decompressLegacy(rawBytes: ByteArray, format: BackupFormatDetector.Format): String {
-        return when (format) {
-            BackupFormatDetector.Format.PXPL_V2_GZIP -> {
-                val compressed = rawBytes.copyOfRange(BackupFormatDetector.PXPL_MAGIC_SIZE, rawBytes.size)
-                GZIPInputStream(ByteArrayInputStream(compressed)).bufferedReader().use { it.readText() }
+    private fun decompressLegacy(uri: Uri, format: BackupFormatDetector.Format): String {
+        val input = context.contentResolver.openInputStream(uri)
+            ?: throw IllegalStateException("Unable to open backup file")
+
+        return input.use { raw ->
+            val source = when (format) {
+                BackupFormatDetector.Format.PXPL_V2_GZIP -> {
+                    skipFully(raw, BackupFormatDetector.PXPL_MAGIC_SIZE)
+                    GZIPInputStream(raw)
+                }
+                BackupFormatDetector.Format.LEGACY_GZIP -> {
+                    GZIPInputStream(raw)
+                }
+                BackupFormatDetector.Format.LEGACY_RAW -> raw
+                else -> throw IllegalArgumentException("Cannot decompress format: $format")
             }
-            BackupFormatDetector.Format.LEGACY_GZIP -> {
-                GZIPInputStream(ByteArrayInputStream(rawBytes)).bufferedReader().use { it.readText() }
+
+            source.use { stream ->
+                stream.bufferedReader(Charsets.UTF_8).use { reader ->
+                    readTextLimited(
+                        reader = reader,
+                        maxChars = MAX_LEGACY_BACKUP_BYTES,
+                        sourceLabel = "Legacy backup payload"
+                    )
+                }
             }
-            BackupFormatDetector.Format.LEGACY_RAW -> {
-                rawBytes.toString(Charsets.UTF_8)
+        }
+    }
+
+    private fun readTextLimited(
+        reader: Reader,
+        maxChars: Int,
+        sourceLabel: String
+    ): String {
+        val buffer = CharArray(DEFAULT_BUFFER_SIZE)
+        val builder = StringBuilder(minOf(maxChars, DEFAULT_BUFFER_SIZE))
+        var totalChars = 0
+
+        while (true) {
+            val read = reader.read(buffer)
+            if (read == -1) break
+
+            totalChars += read
+            if (totalChars > maxChars) {
+                throw IllegalArgumentException(
+                    "$sourceLabel exceeds the ${maxChars / (1024 * 1024)}MB in-memory safety limit."
+                )
             }
-            else -> throw IllegalArgumentException("Cannot decompress format: $format")
+
+            builder.append(buffer, 0, read)
+        }
+
+        return builder.toString()
+    }
+
+    private fun skipFully(input: InputStream, byteCount: Int) {
+        var remaining = byteCount
+        while (remaining > 0) {
+            val skipped = input.skip(remaining.toLong())
+            if (skipped > 0) {
+                remaining -= skipped.toInt()
+                continue
+            }
+
+            if (input.read() == -1) {
+                throw IllegalArgumentException("Backup file is truncated.")
+            }
+            remaining--
         }
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutor.kt
@@ -32,8 +32,7 @@ class RestoreExecutor @Inject constructor(
         onProgress: (BackupTransferProgressUpdate) -> Unit
     ): RestoreResult = withContext(Dispatchers.IO) {
         val selectedModules = plan.selectedModules.toList().sortedBy { it.key }
-        // 3 overhead steps: snapshot, validate, finalize
-        val totalSteps = selectedModules.size * 3 + 3
+        val totalSteps = selectedModules.size * 2 + 3
         var step = 0
 
         // ---- PHASE 1: SNAPSHOT ----
@@ -52,20 +51,25 @@ class RestoreExecutor @Inject constructor(
             return@withContext RestoreResult.TotalFailure("Failed to capture current state: ${e.message}")
         }
 
-        // ---- PHASE 2: READ & VALIDATE ----
-        reportProgress(onProgress, ++step, totalSteps, "Reading backup data", "Extracting and validating modules.")
+        // ---- PHASE 2: READ, VALIDATE, RESTORE ----
+        reportProgress(onProgress, ++step, totalSteps, "Preparing restore", "Selected modules will be processed one at a time.")
 
-        val modulePayloads = mutableMapOf<BackupSection, String>()
+        val restoredModules = mutableListOf<BackupSection>()
+        var currentSection: BackupSection? = null
         try {
-            val allPayloads = backupReader.readAllModulePayloads(uri).getOrThrow()
-
             selectedModules.forEach { section ->
-                val payload = allPayloads[section.key]
-                if (payload == null) {
+                currentSection = section
+                val moduleInfo = plan.manifest.modules[section.key]
+                if (moduleInfo != null &&
+                    moduleInfo.sizeBytes > BackupReader.MAX_MODULE_PAYLOAD_BYTES
+                ) {
                     throw IllegalStateException(
-                        "Backup is missing the payload for ${section.label}."
+                        "Backup payload for ${section.label} is ${moduleInfo.sizeBytes / (1024 * 1024)}MB, " +
+                            "which exceeds the ${BackupReader.MAX_MODULE_PAYLOAD_BYTES / (1024 * 1024)}MB restore safety limit."
                     )
                 }
+
+                val payload = backupReader.readModulePayload(uri, section.key).getOrThrow()
 
                 // Validate each module payload
                 val validationResult = validationPipeline.validateModulePayload(
@@ -77,25 +81,13 @@ class RestoreExecutor @Inject constructor(
                     )
                 }
 
-                modulePayloads[section] = payload
                 reportProgress(
                     onProgress, ++step, totalSteps,
                     "Validated ${section.label}",
                     section.description,
                     section
                 )
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Validation phase failed", e)
-            return@withContext RestoreResult.TotalFailure("Validation failed: ${e.message}")
-        }
 
-        // ---- PHASE 3: RESTORE ----
-        val restoredModules = mutableListOf<BackupSection>()
-        var currentSection: BackupSection? = null
-        try {
-            modulePayloads.forEach { (section, payload) ->
-                currentSection = section
                 reportProgress(
                     onProgress, ++step, totalSteps,
                     "Restoring ${section.label}",
@@ -109,7 +101,7 @@ class RestoreExecutor @Inject constructor(
                 restoredModules.add(section)
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Restore failed at module, rolling back", e)
+            Log.e(TAG, "Restore failed while processing backup module, rolling back", e)
             // Roll back in reverse restore order, including the module that failed mid-restore.
             var rollbackSuccess = true
             val rollbackOrder = (restoredModules + listOfNotNull(currentSection)).distinct().asReversed()
@@ -142,7 +134,7 @@ class RestoreExecutor @Inject constructor(
             )
         }
 
-        // ---- PHASE 4: FINALIZE ----
+        // ---- PHASE 3: FINALIZE ----
         reportProgress(onProgress, ++step, totalSteps, "Restore complete", "All selected modules were restored successfully.")
 
         RestoreResult.Success

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/BackupFileValidator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/validation/BackupFileValidator.kt
@@ -3,12 +3,14 @@ package com.theveloper.pixelplay.data.backup.validation
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import com.theveloper.pixelplay.data.backup.format.BackupReader
 import com.theveloper.pixelplay.data.backup.format.BackupFormatDetector
+import com.theveloper.pixelplay.data.backup.model.BackupManifest
 import com.theveloper.pixelplay.data.backup.model.BackupValidationResult
 import com.theveloper.pixelplay.data.backup.model.Severity
 import com.theveloper.pixelplay.data.backup.model.ValidationError
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.util.zip.ZipInputStream
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,41 +23,46 @@ class BackupFileValidator @Inject constructor(
     companion object {
         const val MAX_BACKUP_SIZE_BYTES = 50L * 1024 * 1024 // 50 MB
         const val MAX_ZIP_RATIO = 100 // max decompressed/compressed ratio
+        private const val MAX_TOTAL_DECOMPRESSED_BYTES = 256L * 1024 * 1024
     }
 
     fun validate(uri: Uri): BackupValidationResult {
         val errors = mutableListOf<ValidationError>()
+        val docFile = DocumentFile.fromSingleUri(context, uri)
+        val fileName = docFile?.name
+        val fileSize = docFile?.length()?.takeIf { it >= 0L }
 
         // Check URI accessibility
-        val rawBytes = try {
-            context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        val format = try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val header = formatDetector.readHeader(input)
+                if (header.isEmpty()) {
+                    errors.add(ValidationError("FILE_EMPTY", "Backup file is empty or inaccessible."))
+                    return BackupValidationResult.Invalid(errors)
+                }
+                formatDetector.detect(header)
+            }
         } catch (e: Exception) {
             errors.add(ValidationError("FILE_ACCESS", "Cannot open backup file: ${e.message}"))
             return BackupValidationResult.Invalid(errors)
         }
 
-        if (rawBytes == null) {
+        if (format == null) {
             errors.add(ValidationError("FILE_EMPTY", "Backup file is empty or inaccessible."))
             return BackupValidationResult.Invalid(errors)
         }
 
         // Check file size
-        if (rawBytes.size.toLong() > MAX_BACKUP_SIZE_BYTES) {
+        if (fileSize != null && fileSize > MAX_BACKUP_SIZE_BYTES) {
             errors.add(ValidationError("FILE_TOO_LARGE", "Backup file exceeds the ${MAX_BACKUP_SIZE_BYTES / (1024 * 1024)}MB limit."))
             return BackupValidationResult.Invalid(errors)
         }
 
         // Check file name extension (if available)
-        val docFile = DocumentFile.fromSingleUri(context, uri)
-        val fileName = docFile?.name
         if (fileName != null && !fileName.endsWith(".pxpl", ignoreCase = true) &&
             !fileName.endsWith(".gz", ignoreCase = true)) {
             errors.add(ValidationError("FILE_EXTENSION", "File extension is not .pxpl. The file may not be a valid backup.", severity = Severity.WARNING))
         }
-
-        // Detect format
-        val header = rawBytes.copyOf(minOf(8, rawBytes.size))
-        val format = formatDetector.detect(header)
 
         if (format == BackupFormatDetector.Format.UNKNOWN) {
             errors.add(ValidationError("FORMAT_UNKNOWN", "File is not a recognized PixelPlay backup format."))
@@ -64,7 +71,7 @@ class BackupFileValidator @Inject constructor(
 
         // For ZIP format: validate zip structure safety
         if (format == BackupFormatDetector.Format.PXPL_V3_ZIP) {
-            validateZipSafety(rawBytes, BackupFormatDetector.PXPL_MAGIC_SIZE, errors)
+            validateZipSafety(uri, fileSize, BackupFormatDetector.PXPL_MAGIC_SIZE, errors)
         }
 
         return if (errors.any { it.severity == Severity.ERROR }) {
@@ -76,42 +83,101 @@ class BackupFileValidator @Inject constructor(
         }
     }
 
-    private fun validateZipSafety(rawBytes: ByteArray, offset: Int, errors: MutableList<ValidationError>) {
+    private fun validateZipSafety(
+        uri: Uri,
+        fileSize: Long?,
+        offset: Int,
+        errors: MutableList<ValidationError>
+    ) {
         try {
-            val zipBytes = rawBytes.copyOfRange(offset, rawBytes.size)
-            ZipInputStream(ByteArrayInputStream(zipBytes)).use { zip ->
-                var entry = zip.nextEntry
-                var totalDecompressed = 0L
-                while (entry != null) {
-                    val name = entry.name
+            context.contentResolver.openInputStream(uri)?.use { raw ->
+                skipFully(raw, offset)
+                val compressedZipBytes = fileSize?.minus(offset)?.coerceAtLeast(0L)
 
-                    // Path traversal check
-                    if (name.contains("..") || name.startsWith("/") || name.startsWith("\\")) {
-                        errors.add(ValidationError("ZIP_PATH_TRAVERSAL", "Suspicious zip entry path: $name"))
-                        return
+                ZipInputStream(raw).use { zip ->
+                    var entry = zip.nextEntry
+                    var totalDecompressed = 0L
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (entry != null) {
+                        val name = entry.name
+
+                        // Path traversal check
+                        if (name.contains("..") || name.startsWith("/") || name.startsWith("\\")) {
+                            errors.add(ValidationError("ZIP_PATH_TRAVERSAL", "Suspicious zip entry path: $name"))
+                            return
+                        }
+
+                        // Only allow .json files and manifest
+                        if (!name.endsWith(".json")) {
+                            errors.add(ValidationError("ZIP_UNEXPECTED_ENTRY", "Unexpected file in backup: $name", severity = Severity.WARNING))
+                        }
+
+                        val perEntryLimit = if (name == BackupManifest.MANIFEST_FILENAME) {
+                            BackupReader.MAX_MANIFEST_BYTES.toLong()
+                        } else {
+                            BackupReader.MAX_MODULE_PAYLOAD_BYTES.toLong()
+                        }
+
+                        var entryBytes = 0L
+                        while (true) {
+                            val read = zip.read(buffer)
+                            if (read == -1) break
+
+                            entryBytes += read
+                            totalDecompressed += read
+
+                            if (entryBytes > perEntryLimit) {
+                                errors.add(
+                                    ValidationError(
+                                        "ZIP_ENTRY_TOO_LARGE",
+                                        "Backup entry '$name' exceeds the ${perEntryLimit / (1024 * 1024)}MB in-memory safety limit."
+                                    )
+                                )
+                                return
+                            }
+
+                            if (totalDecompressed > MAX_TOTAL_DECOMPRESSED_BYTES) {
+                                errors.add(
+                                    ValidationError(
+                                        "ZIP_TOO_LARGE",
+                                        "Backup file expands beyond the ${MAX_TOTAL_DECOMPRESSED_BYTES / (1024 * 1024)}MB safety limit."
+                                    )
+                                )
+                                return
+                            }
+
+                            if (compressedZipBytes != null &&
+                                compressedZipBytes > 0 &&
+                                totalDecompressed > compressedZipBytes * MAX_ZIP_RATIO
+                            ) {
+                                errors.add(ValidationError("ZIP_BOMB", "Backup file has suspicious compression ratio."))
+                                return
+                            }
+                        }
+
+                        zip.closeEntry()
+                        entry = zip.nextEntry
                     }
-
-                    // Only allow .json files and manifest
-                    if (!name.endsWith(".json")) {
-                        errors.add(ValidationError("ZIP_UNEXPECTED_ENTRY", "Unexpected file in backup: $name", severity = Severity.WARNING))
-                    }
-
-                    // Track decompressed size
-                    val content = zip.readBytes()
-                    totalDecompressed += content.size
-
-                    // Zip bomb detection
-                    if (zipBytes.isNotEmpty() && totalDecompressed > zipBytes.size.toLong() * MAX_ZIP_RATIO) {
-                        errors.add(ValidationError("ZIP_BOMB", "Backup file has suspicious compression ratio."))
-                        return
-                    }
-
-                    zip.closeEntry()
-                    entry = zip.nextEntry
                 }
-            }
+            } ?: errors.add(ValidationError("FILE_ACCESS", "Cannot open backup file."))
         } catch (e: Exception) {
             errors.add(ValidationError("ZIP_CORRUPT", "Backup ZIP archive is corrupted: ${e.message}"))
+        }
+    }
+
+    private fun skipFully(input: InputStream, byteCount: Int) {
+        var remaining = byteCount
+        while (remaining > 0) {
+            val skipped = input.skip(remaining.toLong())
+            if (skipped > 0) {
+                remaining -= skipped.toInt()
+                continue
+            }
+
+            if (input.read() == -1) {
+                throw IllegalArgumentException("Backup file is truncated.")
+            }
+            remaining--
         }
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/BackupManagerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/BackupManagerTest.kt
@@ -65,9 +65,9 @@ class BackupManagerTest {
         )
         coEvery { restorePlanner.buildRestorePlan(backupUri) } returns Result.success(plan)
         every { validationPipeline.validateManifest(plan.manifest) } returns BackupValidationResult.Valid
-        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(
-            mapOf(BackupSection.ENGAGEMENT_STATS.key to """[{"playCount": 1}]""")
-        )
+        coEvery {
+            backupReader.readModulePayload(backupUri, BackupSection.ENGAGEMENT_STATS.key)
+        } returns Result.success("""[{"playCount": 1}]""")
         every {
             validationPipeline.validateModulePayload(
                 BackupSection.ENGAGEMENT_STATS,
@@ -103,23 +103,47 @@ class BackupManagerTest {
         every { validationPipeline.validateFile(backupUri) } returns BackupValidationResult.Valid
         coEvery { restorePlanner.buildRestorePlan(backupUri) } returns Result.success(plan)
         every { validationPipeline.validateManifest(plan.manifest) } returns BackupValidationResult.Valid
-        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(emptyMap())
+        coEvery {
+            backupReader.readModulePayload(backupUri, BackupSection.FAVORITES.key)
+        } returns Result.failure(IllegalArgumentException("Module 'favorites' not found in backup"))
 
         val result = manager.inspectBackup(backupUri)
 
         assertTrue(result.isFailure)
         assertEquals(
-            "Backup is missing the payload for Favorites.",
+            "Module 'favorites' not found in backup",
             result.exceptionOrNull()?.message
         )
     }
 
-    private fun restorePlan(selectedModules: Set<BackupSection>): RestorePlan {
+    @Test
+    fun `inspectBackup skips oversized module preview validation`() = runTest {
+        val oversizedModule = BackupReader.MAX_MODULE_PAYLOAD_BYTES + 1L
+        val plan = restorePlan(
+            selectedModules = setOf(BackupSection.PLAYBACK_HISTORY),
+            moduleSizeBytes = oversizedModule
+        )
+
+        every { validationPipeline.validateFile(backupUri) } returns BackupValidationResult.Valid
+        coEvery { restorePlanner.buildRestorePlan(backupUri) } returns Result.success(plan)
+        every { validationPipeline.validateManifest(plan.manifest) } returns BackupValidationResult.Valid
+
+        val result = manager.inspectBackup(backupUri).getOrThrow()
+
+        assertTrue(
+            result.warnings.any { it.contains("preview validation was skipped", ignoreCase = true) }
+        )
+    }
+
+    private fun restorePlan(
+        selectedModules: Set<BackupSection>,
+        moduleSizeBytes: Long = 32
+    ): RestorePlan {
         val modules = selectedModules.associate { section ->
             section.key to BackupModuleInfo(
                 checksum = "sha256:test",
                 entryCount = 1,
-                sizeBytes = 32
+                sizeBytes = moduleSizeBytes
             )
         }
         return RestorePlan(
@@ -137,7 +161,7 @@ class BackupManagerTest {
             moduleDetails = selectedModules.associateWith {
                 ModuleRestoreDetail(
                     entryCount = 1,
-                    sizeBytes = 32,
+                    sizeBytes = moduleSizeBytes,
                     willOverwrite = true
                 )
             }

--- a/app/src/test/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutorTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/backup/restore/RestoreExecutorTest.kt
@@ -50,12 +50,10 @@ class RestoreExecutorTest {
 
         coEvery { favoritesHandler.snapshot() } returns "favorites-snapshot"
         coEvery { playbackHistoryHandler.snapshot() } returns "history-snapshot"
-        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(
-            mapOf(
-                BackupSection.FAVORITES.key to "favorites-payload",
-                BackupSection.PLAYBACK_HISTORY.key to "history-payload"
-            )
-        )
+        coEvery { backupReader.readModulePayload(backupUri, BackupSection.FAVORITES.key) } returns
+            Result.success("favorites-payload")
+        coEvery { backupReader.readModulePayload(backupUri, BackupSection.PLAYBACK_HISTORY.key) } returns
+            Result.success("history-payload")
         every {
             validationPipeline.validateModulePayload(any(), any(), any())
         } returns BackupValidationResult.Valid
@@ -77,24 +75,45 @@ class RestoreExecutorTest {
         val plan = restorePlan(selectedModules = setOf(BackupSection.FAVORITES))
 
         coEvery { favoritesHandler.snapshot() } returns "favorites-snapshot"
-        coEvery { backupReader.readAllModulePayloads(backupUri) } returns Result.success(emptyMap())
+        coEvery { backupReader.readModulePayload(backupUri, BackupSection.FAVORITES.key) } returns
+            Result.failure(IllegalArgumentException("Module 'favorites' not found in backup"))
 
         val result = executor.execute(backupUri, plan) { }
 
         val failure = assertInstanceOf(RestoreResult.TotalFailure::class.java, result)
         assertEquals(
-            "Validation failed: Backup is missing the payload for Favorites.",
+            "Restore failed at Favorites: Module 'favorites' not found in backup. All applied changes were rolled back.",
             failure.error
         )
         coVerify(exactly = 0) { favoritesHandler.restore(any()) }
     }
 
-    private fun restorePlan(selectedModules: Set<BackupSection>): RestorePlan {
+    @Test
+    fun `execute fails before loading oversized module payload`() = runTest {
+        val plan = restorePlan(
+            selectedModules = setOf(BackupSection.PLAYBACK_HISTORY),
+            moduleSizeBytes = BackupReader.MAX_MODULE_PAYLOAD_BYTES + 1L
+        )
+
+        coEvery { playbackHistoryHandler.snapshot() } returns "history-snapshot"
+
+        val result = executor.execute(backupUri, plan) { }
+
+        val failure = assertInstanceOf(RestoreResult.TotalFailure::class.java, result)
+        assertTrue(failure.error.contains("restore safety limit"))
+        coVerify(exactly = 0) { backupReader.readModulePayload(any(), any()) }
+        coVerify(exactly = 0) { playbackHistoryHandler.restore(any()) }
+    }
+
+    private fun restorePlan(
+        selectedModules: Set<BackupSection>,
+        moduleSizeBytes: Long = 32
+    ): RestorePlan {
         val modules = selectedModules.associate { section ->
             section.key to BackupModuleInfo(
                 checksum = "sha256:test",
                 entryCount = 1,
-                sizeBytes = 32
+                sizeBytes = moduleSizeBytes
             )
         }
         return RestorePlan(
@@ -112,7 +131,7 @@ class RestoreExecutorTest {
             moduleDetails = selectedModules.associateWith {
                 ModuleRestoreDetail(
                     entryCount = 1,
-                    sizeBytes = 32,
+                    sizeBytes = moduleSizeBytes,
                     willOverwrite = true
                 )
             }


### PR DESCRIPTION
…tion

- **BackupReader**:
    - Refactor to stream data directly from `InputStream` instead of loading entire backup files into memory as `ByteArray`.
    - Introduce `MAX_MODULE_PAYLOAD_BYTES` (16MB) and `MAX_MANIFEST_BYTES` (512KB) safety limits to prevent `OutOfMemoryError` during decompression.
    - Implement `readTextLimited` and `skipFully` to safely process large streams with size validation.
    - Replace `readAllModulePayloads` with targeted `readModulePayload` calls in the restore flow.
- **RestoreExecutor**:
    - Update restore logic to process modules sequentially (Read -> Validate -> Restore) rather than loading all payloads upfront.
    - Add pre-check to abort restore if a module's manifest size exceeds safety limits.
    - Improve error logging and rollback messaging when a specific module fails.
- **BackupManager**:
    - Optimize `inspectBackup` to skip preview validation for oversized modules, adding a warning instead of failing.
- **BackupFileValidator**:
    - Update `validateZipSafety` to use streaming validation, checking for zip bombs and entry size limits without full decompression.
- **Unit Tests**:
    - Update `RestoreExecutorTest` and `BackupManagerTest` to reflect streaming changes and verify behavior for oversized modules.