### PR TITLE
Ensure stable sorting for cache eviction in `AlbumArtCacheManager`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtCacheManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtCacheManager.kt
@@ -56,6 +56,12 @@ object AlbumArtCacheManager {
      * Minimum interval between cleanups (5 minutes)
      */
     private const val MIN_CLEANUP_INTERVAL_MS = 5 * 60 * 1000L
+
+    private data class CacheEvictionCandidate(
+        val file: File,
+        val lastModifiedSnapshot: Long,
+        val absolutePathSnapshot: String
+    )
     
     /**
      * Cleans the cache if it exceeds the maximum size.
@@ -92,10 +98,13 @@ object AlbumArtCacheManager {
             
             Log.d(TAG, "Cache size ${currentSize / 1024 / 1024}MB exceeds limit, cleaning...")
             
-            // Sort by lastModified (oldest first) and delete oldest 25%
-            val filesToDelete = artFiles
-                .sortedBy { it.lastModified() }
-                .take((artFiles.size * CLEANUP_PERCENTAGE).toInt().coerceAtLeast(1))
+            // Snapshot lastModified before sorting. The timestamp is mutated elsewhere to
+            // implement LRU reads, so re-reading it during TimSort can violate comparator
+            // transitivity and crash with "Comparison method violates its general contract!".
+            val filesToDelete = snapshotFilesForCleanup(
+                artFiles = artFiles,
+                cleanupPercentage = CLEANUP_PERCENTAGE
+            )
             
             var deletedCount = 0
             var freedBytes = 0L
@@ -218,6 +227,31 @@ object AlbumArtCacheManager {
             file.name.startsWith(CACHE_PREFIX) &&
             !file.name.contains(NO_ART_SUFFIX)
         }?.toList() ?: emptyList()
+    }
+
+    internal fun snapshotFilesForCleanup(
+        artFiles: List<File>,
+        cleanupPercentage: Double
+    ): List<File> {
+        if (artFiles.isEmpty()) return emptyList()
+
+        val deleteCount = (artFiles.size * cleanupPercentage).toInt().coerceAtLeast(1)
+
+        return artFiles.asSequence()
+            .map { file ->
+                CacheEvictionCandidate(
+                    file = file,
+                    lastModifiedSnapshot = file.lastModified(),
+                    absolutePathSnapshot = file.absolutePath
+                )
+            }
+            .sortedWith(
+                compareBy<CacheEvictionCandidate> { it.lastModifiedSnapshot }
+                    .thenBy { it.absolutePathSnapshot }
+            )
+            .take(deleteCount)
+            .map(CacheEvictionCandidate::file)
+            .toList()
     }
     
     /**

--- a/app/src/test/java/com/theveloper/pixelplay/utils/AlbumArtCacheManagerTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/AlbumArtCacheManagerTest.kt
@@ -1,0 +1,70 @@
+package com.theveloper.pixelplay.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+class AlbumArtCacheManagerTest {
+
+    @Test
+    fun snapshotFilesForCleanup_usesStableLastModifiedSnapshots() {
+        val oldest = FlakyLastModifiedFile(
+            path = "/tmp/song_art_oldest.jpg",
+            timestamps = longArrayOf(10L, 10_000L, 10_000L)
+        )
+        val middle = FlakyLastModifiedFile(
+            path = "/tmp/song_art_middle.jpg",
+            timestamps = longArrayOf(20L, 0L, 0L)
+        )
+        val newest = FlakyLastModifiedFile(
+            path = "/tmp/song_art_newest.jpg",
+            timestamps = longArrayOf(30L, -1L, -1L)
+        )
+
+        val sorted = AlbumArtCacheManager.snapshotFilesForCleanup(
+            artFiles = listOf(newest, middle, oldest),
+            cleanupPercentage = 1.0
+        )
+
+        assertThat(sorted.map(File::getAbsolutePath)).containsExactly(
+            oldest.absolutePath,
+            middle.absolutePath,
+            newest.absolutePath
+        ).inOrder()
+    }
+
+    @Test
+    fun snapshotFilesForCleanup_breaksTimestampTiesByPath() {
+        val zFile = FlakyLastModifiedFile(
+            path = "/tmp/song_art_z.jpg",
+            timestamps = longArrayOf(50L)
+        )
+        val aFile = FlakyLastModifiedFile(
+            path = "/tmp/song_art_a.jpg",
+            timestamps = longArrayOf(50L)
+        )
+
+        val sorted = AlbumArtCacheManager.snapshotFilesForCleanup(
+            artFiles = listOf(zFile, aFile),
+            cleanupPercentage = 1.0
+        )
+
+        assertThat(sorted.map(File::getAbsolutePath)).containsExactly(
+            aFile.absolutePath,
+            zFile.absolutePath
+        ).inOrder()
+    }
+
+    private class FlakyLastModifiedFile(
+        path: String,
+        private val timestamps: LongArray
+    ) : File(path) {
+        private var index = 0
+
+        override fun lastModified(): Long {
+            val safeIndex = index.coerceAtMost(timestamps.lastIndex)
+            index++
+            return timestamps[safeIndex]
+        }
+    }
+}


### PR DESCRIPTION
- **AlbumArtCacheManager**:
    - Introduce `snapshotFilesForCleanup` to capture `lastModified` timestamps before sorting. This prevents "Comparison method violates its general contract!" crashes caused by timestamps mutating during the sort process.
    - Implement a secondary sort criterion using the file's absolute path to ensure stable tie-breaking.
    - Use a internal `CacheEvictionCandidate` data class to store immutable snapshots of file metadata for the duration of the cleanup logic.
- **Unit Tests**:
    - Add `AlbumArtCacheManagerTest.kt` to verify that the cleanup logic remains stable even when file timestamps are flaky/mutating and that ties are correctly broken by file path.