### PR TITLE
Ensure stable sorting for cache eviction in `AlbumArtCacheManager`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/equalizer/EqualizerManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/equalizer/EqualizerManager.kt
@@ -35,6 +35,12 @@ class EqualizerManager @Inject constructor() {
 
     val isAttached: Boolean
         get() = equalizer != null && currentAudioSessionId != 0
+
+    val hasAnyEnabledEffects: Boolean
+        get() = _isEnabled.value ||
+            _bassBoostEnabled.value ||
+            _virtualizerEnabled.value ||
+            _loudnessEnhancerEnabled.value
     
     // Normalized band levels (-15 to +15 for UI)
     private val _bandLevels = MutableStateFlow(List(NUM_BANDS) { 0 })
@@ -239,6 +245,18 @@ class EqualizerManager @Inject constructor() {
             release()
         }
     }
+
+    suspend fun attachToAudioSessionIfNeeded(audioSessionId: Int) {
+        if (!hasAnyEnabledEffects) {
+            Timber.tag(TAG).d(
+                "Skipping attachToAudioSession($audioSessionId): all audio effects are disabled"
+            )
+            releaseIfUnused()
+            return
+        }
+
+        attachToAudioSession(audioSessionId)
+    }
     
     /**
      * Enables or disables the equalizer.
@@ -251,6 +269,7 @@ class EqualizerManager @Inject constructor() {
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to set equalizer enabled state")
         }
+        releaseIfUnused()
     }
     
     /**
@@ -288,6 +307,7 @@ class EqualizerManager @Inject constructor() {
     fun setBassBoostEnabled(enabled: Boolean) {
         if (!isBassBoostSupportedGlobal) {
             _bassBoostEnabled.value = false
+            releaseIfUnused()
             return
         }
         _bassBoostEnabled.value = enabled
@@ -296,6 +316,7 @@ class EqualizerManager @Inject constructor() {
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to set bass boost enabled")
         }
+        releaseIfUnused()
     }
     
     /**
@@ -325,6 +346,7 @@ class EqualizerManager @Inject constructor() {
     fun setVirtualizerEnabled(enabled: Boolean) {
         if (!isVirtualizerSupportedGlobal) {
             _virtualizerEnabled.value = false
+            releaseIfUnused()
             return
         }
         _virtualizerEnabled.value = enabled
@@ -333,6 +355,7 @@ class EqualizerManager @Inject constructor() {
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to set virtualizer enabled")
         }
+        releaseIfUnused()
     }
     
     /**
@@ -366,6 +389,7 @@ class EqualizerManager @Inject constructor() {
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to set loudness enhancer enabled")
         }
+        releaseIfUnused()
     }
 
     /**
@@ -417,9 +441,20 @@ class EqualizerManager @Inject constructor() {
         
         // Apply if already attached
         if (equalizer != null) {
+            if (!hasAnyEnabledEffects) {
+                releaseIfUnused()
+                return
+            }
             equalizer?.enabled = enabled
             applyBandLevels(preset.bandLevels)
             applyCurrentEffectStateToAttachedEffects()
+        }
+    }
+
+    private fun releaseIfUnused() {
+        if (!hasAnyEnabledEffects && isAttached) {
+            Timber.tag(TAG).d("Releasing audio effects because all effect toggles are disabled")
+            release()
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -252,8 +252,8 @@ class MusicService : MediaLibraryService() {
         initializeCastWearSync()
         registerHeadsetReconnectMonitor()
 
-        // Restore equalizer state from preferences and attach to audio session.
-        // This ensures the equalizer is active even before the user opens the EQ screen.
+        // Restore equalizer state from preferences and only attach audio effects when
+        // the user actually has at least one effect enabled for the current session.
         serviceScope.launch {
             val eqEnabled = equalizerPreferencesRepository.equalizerEnabledFlow.first()
             val presetName = equalizerPreferencesRepository.equalizerPresetFlow.first()
@@ -274,13 +274,13 @@ class MusicService : MediaLibraryService() {
 
             val sessionId = engine.getAudioSessionId()
             if (sessionId != 0) {
-                equalizerManager.attachToAudioSession(sessionId)
+                equalizerManager.attachToAudioSessionIfNeeded(sessionId)
             }
 
             // Re-attach equalizer whenever the active audio session changes (e.g. crossfade)
             engine.activeAudioSessionId.collect { newSessionId ->
                 if (newSessionId != 0) {
-                    equalizerManager.attachToAudioSession(newSessionId)
+                    equalizerManager.attachToAudioSessionIfNeeded(newSessionId)
                 }
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/EqualizerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/EqualizerViewModel.kt
@@ -145,7 +145,7 @@ class EqualizerViewModel @Inject constructor(
                 
                 val initialSessionId = dualPlayerEngine.getAudioSessionId()
                 if (initialSessionId != 0) {
-                    equalizerManager.attachToAudioSession(initialSessionId)
+                    equalizerManager.attachToAudioSessionIfNeeded(initialSessionId)
                 }
             } else {
                 Timber.tag(TAG).d("Equalizer already attached by service, skipping restore.")
@@ -264,6 +264,7 @@ class EqualizerViewModel @Inject constructor(
             current.copy(isEnabled = enabled)
         }
         viewModelScope.launch {
+            equalizerManager.attachToAudioSessionIfNeeded(dualPlayerEngine.getAudioSessionId())
             equalizerPreferencesRepository.setEqualizerEnabled(enabled)
         }
     }
@@ -360,6 +361,7 @@ class EqualizerViewModel @Inject constructor(
             current.copy(bassBoostEnabled = enabled)
         }
         viewModelScope.launch {
+            equalizerManager.attachToAudioSessionIfNeeded(dualPlayerEngine.getAudioSessionId())
             equalizerPreferencesRepository.setBassBoostEnabled(enabled)
         }
     }
@@ -384,6 +386,7 @@ class EqualizerViewModel @Inject constructor(
             current.copy(virtualizerEnabled = enabled)
         }
         viewModelScope.launch {
+            equalizerManager.attachToAudioSessionIfNeeded(dualPlayerEngine.getAudioSessionId())
             equalizerPreferencesRepository.setVirtualizerEnabled(enabled)
         }
     }
@@ -408,6 +411,7 @@ class EqualizerViewModel @Inject constructor(
             current.copy(loudnessEnhancerEnabled = enabled)
         }
         viewModelScope.launch {
+            equalizerManager.attachToAudioSessionIfNeeded(dualPlayerEngine.getAudioSessionId())
             equalizerPreferencesRepository.setLoudnessEnhancerEnabled(enabled)
         }
     }
@@ -478,7 +482,7 @@ class EqualizerViewModel @Inject constructor(
         viewModelScope.launch {
             val audioSessionId = dualPlayerEngine.getAudioSessionId()
             Timber.tag(TAG).d("Reattaching equalizer to new audio session: $audioSessionId")
-            equalizerManager.attachToAudioSession(audioSessionId)
+            equalizerManager.attachToAudioSessionIfNeeded(audioSessionId)
         }
     }
     


### PR DESCRIPTION
- **AlbumArtCacheManager**:
    - Introduce `snapshotFilesForCleanup` to capture `lastModified` timestamps before sorting. This prevents "Comparison method violates its general contract!" crashes caused by timestamps mutating during the sort process.
    - Implement a secondary sort criterion using the file's absolute path to ensure stable tie-breaking.
    - Use a internal `CacheEvictionCandidate` data class to store immutable snapshots of file metadata for the duration of the cleanup logic.
- **Unit Tests**:
    - Add `AlbumArtCacheManagerTest.kt` to verify that the cleanup logic remains stable even when file timestamps are flaky/mutating and that ties are correctly broken by file path.