### PR TITLE
Include `song_count` in album database queries

### DIFF
--- a/app/src/androidTest/java/com/theveloper/pixelplay/data/database/MusicDaoTest.kt
+++ b/app/src/androidTest/java/com/theveloper/pixelplay/data/database/MusicDaoTest.kt
@@ -92,8 +92,11 @@ class MusicDaoTest {
     @Test
     @Throws(Exception::class)
     fun insertAndGetAlbums() = runTest {
-        val song = createSongEntity(1L, "Song A", "Artist 1", "Album X", "/path/a/songA.mp3")
-        musicDao.insertSongs(listOf(song)) // Needed for inner join in getAlbums
+        val songs = listOf(
+            createSongEntity(1L, "Song A", "Artist 1", "Album X", "/path/a/songA.mp3"),
+            createSongEntity(2L, "Song B", "Artist 1", "Album X", "/path/a/songB.mp3")
+        )
+        musicDao.insertSongs(songs) // Needed for inner join in getAlbums
 
         val albumList = listOf(
             createAlbumEntity(201L, "Album X"), // Matches song's albumId 201L default
@@ -101,13 +104,14 @@ class MusicDaoTest {
         )
         musicDao.insertAlbums(albumList)
         
-        val retrievedAlbums = musicDao.getAlbums(emptyList(), false).first()
+        val retrievedAlbums = musicDao.getAlbums(emptyList(), false, 0).first()
         // getAlbums uses INNER JOIN with songs, so only albums with songs are returned
         // My createSongEntity uses albumId 201L (Album X).
         // So Album Y (202L) should NOT be returned if logic holds (INNER JOIN songs ON albums.id = songs.album_id)
         
         assertEquals(1, retrievedAlbums.size)
         assertEquals("Album X", retrievedAlbums[0].title)
+        assertEquals(2, retrievedAlbums[0].songCount)
     }
 
     @Test
@@ -199,4 +203,3 @@ class MusicDaoTest {
         assertEquals(listOf("Cool Song", "Coolest Song Ever"), titles)
     }
 }
-

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -671,7 +671,15 @@ interface MusicDao {
 
     // --- Album Queries ---
     @Query("""
-        SELECT DISTINCT albums.* FROM albums
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            COUNT(songs.id) AS song_count,
+            albums.year AS year
+        FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
         WHERE (:applyDirectoryFilter = 0 OR songs.id < 0 OR songs.parent_directory_path IN (:allowedParentDirs))
         AND (
@@ -695,6 +703,13 @@ interface MusicDao {
                 )
             )
         )
+        GROUP BY
+            albums.id,
+            albums.title,
+            albums.artist_name,
+            albums.artist_id,
+            albums.album_art_uri_string,
+            albums.year
         ORDER BY albums.title ASC
     """)
     fun getAlbums(
@@ -703,10 +718,42 @@ interface MusicDao {
         filterMode: Int
     ): Flow<List<AlbumEntity>>
 
-    @Query("SELECT * FROM albums WHERE id = :albumId")
+    @Query("""
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            (
+                SELECT COUNT(*)
+                FROM songs
+                WHERE songs.album_id = albums.id
+            ) AS song_count,
+            albums.year AS year
+        FROM albums
+        WHERE albums.id = :albumId
+        LIMIT 1
+    """)
     fun getAlbumById(albumId: Long): Flow<AlbumEntity?>
 
-    @Query("SELECT * FROM albums WHERE title LIKE '%' || :query || '%' ORDER BY title ASC")
+    @Query("""
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            (
+                SELECT COUNT(*)
+                FROM songs
+                WHERE songs.album_id = albums.id
+            ) AS song_count,
+            albums.year AS year
+        FROM albums
+        WHERE albums.title LIKE '%' || :query || '%'
+        ORDER BY albums.title ASC
+    """)
     fun searchAlbums(query: String): Flow<List<AlbumEntity>>
 
     @Query("SELECT COUNT(*) FROM albums")
@@ -714,9 +761,24 @@ interface MusicDao {
 
     // Version of getAlbums that returns a List for one-shot reads
     @Query("""
-        SELECT DISTINCT albums.* FROM albums
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            COUNT(songs.id) AS song_count,
+            albums.year AS year
+        FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
         WHERE (:applyDirectoryFilter = 0 OR songs.id < 0 OR songs.parent_directory_path IN (:allowedParentDirs))
+        GROUP BY
+            albums.id,
+            albums.title,
+            albums.artist_name,
+            albums.artist_id,
+            albums.album_art_uri_string,
+            albums.year
         ORDER BY albums.title ASC
     """)
     suspend fun getAllAlbumsList(
@@ -724,14 +786,49 @@ interface MusicDao {
         applyDirectoryFilter: Boolean
     ): List<AlbumEntity>
 
-    @Query("SELECT * FROM albums WHERE artist_id = :artistId ORDER BY title ASC")
+    @Query("""
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            COUNT(songs.id) AS song_count,
+            albums.year AS year
+        FROM albums
+        LEFT JOIN songs ON albums.id = songs.album_id
+        WHERE albums.artist_id = :artistId
+        GROUP BY
+            albums.id,
+            albums.title,
+            albums.artist_name,
+            albums.artist_id,
+            albums.album_art_uri_string,
+            albums.year
+        ORDER BY albums.title ASC
+    """)
     fun getAlbumsByArtistId(artistId: Long): Flow<List<AlbumEntity>>
 
     @Query("""
-        SELECT DISTINCT albums.* FROM albums
+        SELECT
+            albums.id AS id,
+            albums.title AS title,
+            albums.artist_name AS artist_name,
+            albums.artist_id AS artist_id,
+            albums.album_art_uri_string AS album_art_uri_string,
+            COUNT(songs.id) AS song_count,
+            albums.year AS year
+        FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
         WHERE (:applyDirectoryFilter = 0 OR songs.id < 0 OR songs.parent_directory_path IN (:allowedParentDirs))
         AND (albums.title LIKE '%' || :query || '%' OR albums.artist_name LIKE '%' || :query || '%')
+        GROUP BY
+            albums.id,
+            albums.title,
+            albums.artist_name,
+            albums.artist_id,
+            albums.album_art_uri_string,
+            albums.year
         ORDER BY albums.title ASC
     """)
     fun searchAlbums(


### PR DESCRIPTION
- **MusicDao**:
    - Update SQL queries for `getAlbums`, `getAlbumById`, `searchAlbums`, `getAllAlbumsList`, and `getAlbumsByArtistId` to calculate and return a `song_count` field.
    - Implement `GROUP BY` clauses and subqueries where necessary to aggregate song counts per album.
    - Transition from `SELECT DISTINCT albums.*` to explicit column selection to accommodate the new `song_count` mapping.
- **MusicDaoTest**:
    - Update `insertAndGetAlbums` test case to verify that the `songCount` is correctly calculated when multiple songs are associated with an album.
    - Adjust `getAlbums` call signature in tests to match updated parameter requirements.