### PR TITLE
Improve song hydration and lyrics loading in `PlayerViewModel`

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/media/MediaMapper.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/MediaMapper.kt
@@ -37,6 +37,12 @@ class MediaMapper @Inject constructor(
         val albumId = -1L
         val duration = extras?.getLong(MediaItemBuilder.EXTERNAL_EXTRA_DURATION) ?: 0L
         val dateAdded = extras?.getLong(MediaItemBuilder.EXTERNAL_EXTRA_DATE_ADDED) ?: System.currentTimeMillis()
+        val filePath = extras?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH)
+            ?.takeIf { it.isNotBlank() }
+            ?: mediaItem.localConfiguration?.uri
+                ?.takeIf { it.scheme.equals("file", ignoreCase = true) }
+                ?.path
+                .orEmpty()
         val id = mediaItem.mediaId
 
         // Note: This creates a partial Song object. 
@@ -48,7 +54,7 @@ class MediaMapper @Inject constructor(
             artistId = -1L, // unknown from just MediaItem typically
             album = album,
             albumId = albumId,
-            path = "", // local path unknown from URI usually
+            path = filePath,
             contentUriString = contentUri,
             albumArtUriString = metadata.artworkUri?.toString(),
             duration = duration,

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
@@ -777,6 +777,16 @@ class LyricsRepositoryImpl @Inject constructor(
      * Load embedded lyrics from audio file metadata
      */
     private suspend fun loadLyricsFromStorage(song: Song): Lyrics? = withContext(Dispatchers.IO) {
+        song.lyrics
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { rawLyrics ->
+                val parsedLyrics = LyricsUtils.parseLyrics(rawLyrics)
+                if (parsedLyrics.isValid()) {
+                    return@withContext parsedLyrics.copy(areFromRemote = false)
+                }
+            }
+
         // First check database for persisted lyrics (was user-imported or cached)
         val persisted = lyricsDao.getLyrics(song.id.toLong())
         if (persisted != null && !persisted.content.isBlank()) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -74,6 +74,7 @@ import com.theveloper.pixelplay.data.worker.SyncManager
 import com.theveloper.pixelplay.utils.AppShortcutManager
 import com.theveloper.pixelplay.utils.QueueUtils
 import com.theveloper.pixelplay.utils.MediaItemBuilder
+import com.theveloper.pixelplay.utils.LyricsUtils
 import com.theveloper.pixelplay.utils.StorageType
 import com.theveloper.pixelplay.utils.StorageUtils
 import com.theveloper.pixelplay.utils.ZipShareHelper
@@ -149,7 +150,7 @@ private data class AiUiSnapshot(
 
 @UnstableApi
 @SuppressLint("LogNotTimber")
-@OptIn(coil.annotation.ExperimentalCoilApi::class)
+@OptIn(coil.annotation.ExperimentalCoilApi::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
@@ -634,6 +635,52 @@ class PlayerViewModel @Inject constructor(
         lyricsStateHolder.messageEvents
             .onEach { msg: String -> _toastEvents.emit(msg) }
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            stablePlayerState
+                .map { it.currentSong?.id }
+                .distinctUntilChanged()
+                .flatMapLatest { songId ->
+                    if (songId.isNullOrBlank()) flowOf(null)
+                    else musicRepository.getSong(songId)
+                }
+                .collect { repositorySong ->
+                    val currentState = playbackStateHolder.stablePlayerState.value
+                    val currentSong = currentState.currentSong ?: return@collect
+                    if (repositorySong == null || repositorySong.id != currentSong.id) {
+                        return@collect
+                    }
+
+                    val hydratedSong = currentSong.withRepositoryHydration(repositorySong)
+                    val persistedLyrics = parsePersistedLyrics(hydratedSong.lyrics)
+                    val shouldApplyPersistedLyrics = currentState.lyrics == null && persistedLyrics != null
+                    val shouldRefreshSong = hydratedSong != currentSong
+                    val shouldReloadLyrics =
+                        !shouldApplyPersistedLyrics &&
+                            currentState.lyrics == null &&
+                            hydratedSong.improvesLyricsLookupComparedTo(currentSong)
+
+                    if (shouldApplyPersistedLyrics || shouldReloadLyrics) {
+                        lyricsStateHolder.cancelLoading()
+                    }
+
+                    if (shouldRefreshSong || shouldApplyPersistedLyrics) {
+                        updateSongInStates(
+                            updatedSong = hydratedSong,
+                            newLyrics = if (shouldApplyPersistedLyrics) persistedLyrics else null,
+                            isLoadingLyrics = if (shouldApplyPersistedLyrics) false else null
+                        )
+
+                        if (_selectedSongForInfo.value?.id == hydratedSong.id) {
+                            _selectedSongForInfo.value = hydratedSong
+                        }
+                    }
+
+                    if (shouldReloadLyrics) {
+                        lyricsStateHolder.loadLyricsForSong(hydratedSong, lyricsSourcePreference.value)
+                    }
+                }
+        }
     }
 
     fun setTrackVolume(volume: Float) {
@@ -3742,7 +3789,11 @@ class PlayerViewModel @Inject constructor(
         return aiStateHolder.generateAiMetadata(song, fields)
     }
 
-    private fun updateSongInStates(updatedSong: Song, newLyrics: Lyrics? = null) {
+    private fun updateSongInStates(
+        updatedSong: Song,
+        newLyrics: Lyrics? = null,
+        isLoadingLyrics: Boolean? = null
+    ) {
         // Update the queue first
         val currentQueue = _playerUiState.value.currentPlaybackQueue
         val songIndex = currentQueue.indexOfFirst { it.id == updatedSong.id }
@@ -3759,7 +3810,8 @@ class PlayerViewModel @Inject constructor(
             val finalLyrics = newLyrics ?: state.lyrics
             state.copy(
                 currentSong = updatedSong,
-                lyrics = if (state.currentSong?.id == updatedSong.id) finalLyrics else state.lyrics
+                lyrics = if (state.currentSong?.id == updatedSong.id) finalLyrics else state.lyrics,
+                isLoadingLyrics = isLoadingLyrics ?: state.isLoadingLyrics
             )
         }
     }
@@ -3950,5 +4002,30 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             userPreferencesRepository.addCustomGenre(genre, iconResId)
         }
+    }
+}
+
+internal fun Song.withRepositoryHydration(repositorySong: Song): Song {
+    if (id != repositorySong.id) return this
+
+    return repositorySong.copy(
+        contentUriString = repositorySong.contentUriString.ifBlank { contentUriString },
+        albumArtUriString = repositorySong.albumArtUriString ?: albumArtUriString,
+        duration = repositorySong.duration.takeIf { it > 0L } ?: duration,
+        lyrics = repositorySong.lyrics ?: lyrics
+    )
+}
+
+internal fun Song.improvesLyricsLookupComparedTo(previousSong: Song): Boolean {
+    return (previousSong.lyrics.isNullOrBlank() && !lyrics.isNullOrBlank()) ||
+        (previousSong.path.isBlank() && path.isNotBlank()) ||
+        (previousSong.contentUriString.isBlank() && contentUriString.isNotBlank())
+}
+
+internal fun parsePersistedLyrics(rawLyrics: String?): Lyrics? {
+    val normalizedLyrics = rawLyrics?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    val parsedLyrics = LyricsUtils.parseLyrics(normalizedLyrics)
+    return parsedLyrics.takeIf {
+        !it.synced.isNullOrEmpty() || !it.plain.isNullOrEmpty()
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImplTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImplTest.kt
@@ -1,0 +1,48 @@
+package com.theveloper.pixelplay.data.repository
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.database.LyricsDao
+import com.theveloper.pixelplay.data.model.LyricsSourcePreference
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.network.lyrics.LrcLibApiService
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import org.junit.Test
+
+class LyricsRepositoryImplTest {
+
+    @Test
+    fun getLyrics_returnsSongLyricsBeforeNeedingStorageRead() = runTest {
+        val repository = LyricsRepositoryImpl(
+            context = mockk<Context>(relaxed = true),
+            lrcLibApiService = mockk<LrcLibApiService>(relaxed = true),
+            lyricsDao = mockk<LyricsDao>(relaxed = true),
+            okHttpClient = mockk<OkHttpClient>(relaxed = true)
+        )
+        val song = Song(
+            id = "12",
+            title = "Track",
+            artist = "Artist",
+            artistId = 5L,
+            album = "Album",
+            albumId = 8L,
+            path = "",
+            contentUriString = "",
+            albumArtUriString = null,
+            duration = 180_000L,
+            lyrics = "[00:01.00]Hello again",
+            mimeType = "audio/mpeg",
+            bitrate = 320_000,
+            sampleRate = 44_100
+        )
+
+        val lyrics = repository.getLyrics(song, LyricsSourcePreference.EMBEDDED_FIRST)
+
+        assertThat(lyrics).isNotNull()
+        assertThat(lyrics!!.areFromRemote).isFalse()
+        assertThat(lyrics.synced).isNotEmpty()
+        assertThat(lyrics.synced!!.first().line).isEqualTo("Hello again")
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelHydrationTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelHydrationTest.kt
@@ -1,0 +1,72 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.Song
+import org.junit.Test
+
+class PlayerViewModelHydrationTest {
+
+    @Test
+    fun withRepositoryHydration_fillsMissingLookupFieldsAndLyrics() {
+        val currentSong = testSong(
+            path = "",
+            contentUriString = "content://media/external/audio/media/42",
+            albumArtUriString = "content://art/current",
+            lyrics = null
+        )
+        val repositorySong = testSong(
+            path = "/music/track.mp3",
+            contentUriString = "content://media/external/audio/media/42",
+            albumArtUriString = null,
+            lyrics = "[00:01.00]Hello world"
+        )
+
+        val hydratedSong = currentSong.withRepositoryHydration(repositorySong)
+
+        assertThat(hydratedSong.path).isEqualTo("/music/track.mp3")
+        assertThat(hydratedSong.lyrics).isEqualTo("[00:01.00]Hello world")
+        assertThat(hydratedSong.albumArtUriString).isEqualTo("content://art/current")
+    }
+
+    @Test
+    fun improvesLyricsLookupComparedTo_returnsTrueWhenHydrationAddsLyricsOrPath() {
+        val partialSong = testSong(path = "", lyrics = null)
+        val hydratedSong = testSong(path = "/music/track.mp3", lyrics = "Stored lyrics")
+
+        assertThat(hydratedSong.improvesLyricsLookupComparedTo(partialSong)).isTrue()
+        assertThat(partialSong.improvesLyricsLookupComparedTo(hydratedSong)).isFalse()
+    }
+
+    @Test
+    fun parsePersistedLyrics_returnsParsedLyricsForNonBlankContent() {
+        val parsedLyrics = parsePersistedLyrics("[00:01.00]Line one")
+
+        assertThat(parsedLyrics).isNotNull()
+        assertThat(parsedLyrics!!.synced).isNotEmpty()
+        assertThat(parsedLyrics.synced!!.first().line).isEqualTo("Line one")
+    }
+
+    private fun testSong(
+        path: String = "/music/original.mp3",
+        contentUriString: String = "content://media/external/audio/media/42",
+        albumArtUriString: String? = "content://art/original",
+        lyrics: String? = null
+    ): Song {
+        return Song(
+            id = "42",
+            title = "Track",
+            artist = "Artist",
+            artistId = 7L,
+            album = "Album",
+            albumId = 11L,
+            path = path,
+            contentUriString = contentUriString,
+            albumArtUriString = albumArtUriString,
+            duration = 215_000L,
+            lyrics = lyrics,
+            mimeType = "audio/mpeg",
+            bitrate = 320_000,
+            sampleRate = 44_100
+        )
+    }
+}


### PR DESCRIPTION
- **PlayerViewModel**:
    - Implement a hydration mechanism to update the current `Song` with data from `musicRepository` (e.g., file paths, lyrics, and durations).
    - Introduce `withRepositoryHydration` and `improvesLyricsLookupComparedTo` to safely merge repository data into the active playback state.
    - Automate lyrics reloading or application of persisted lyrics when a song is "hydrated" with new metadata.
    - Update `updateSongInStates` to support optional `isLoadingLyrics` state overrides.
- **LyricsRepositoryImpl**:
    - Optimize `loadLyricsFromStorage` to check for lyrics directly on the `Song` object before querying the database.
- **MediaMapper**:
    - Enhance `toSong` mapping to extract file paths from `MediaItem` extras or URI schemes.
- **Unit Tests**:
    - Add `LyricsRepositoryImplTest` to verify prioritized loading of embedded lyrics.
    - Add `PlayerViewModelHydrationTest` to validate song hydration logic, lookup improvements, and lyrics parsing.