### PR TITLE
Refactor album grouping and artist resolution logic during media sync…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtils.kt
@@ -1,0 +1,142 @@
+package com.theveloper.pixelplay.data.worker
+
+import com.theveloper.pixelplay.data.database.AlbumEntity
+import com.theveloper.pixelplay.data.database.SongEntity
+import com.theveloper.pixelplay.utils.normalizeMetadataText
+import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
+import com.theveloper.pixelplay.utils.splitArtistsByDelimiters
+
+internal data class AlbumGroupingKey(
+    val normalizedTitle: String,
+    val identity: String
+)
+
+internal fun resolveAlbumArtist(
+    rawAlbumArtist: String?,
+    metadataAlbumArtist: String?
+): String? {
+    return sequenceOf(metadataAlbumArtist, rawAlbumArtist)
+        .mapNotNull { candidate ->
+            candidate.normalizeMetadataText()
+                ?.takeIf { it.isNotBlank() && !it.equals("<unknown>", ignoreCase = true) }
+        }
+        .firstOrNull()
+}
+
+internal fun buildAlbumGroupingKey(song: SongEntity): AlbumGroupingKey {
+    return buildAlbumGroupingKey(
+        albumName = song.albumName,
+        albumArtist = song.albumArtist,
+        albumArtUriString = song.albumArtUriString,
+        parentDirectoryPath = song.parentDirectoryPath,
+        fallbackAlbumId = song.albumId
+    )
+}
+
+internal fun buildAlbumGroupingKeys(album: AlbumEntity): List<AlbumGroupingKey> {
+    val albumKeys = mutableListOf<AlbumGroupingKey>()
+
+    albumKeys += buildAlbumGroupingKey(
+        albumName = album.title,
+        albumArtist = album.artistName,
+        albumArtUriString = album.albumArtUriString,
+        parentDirectoryPath = null,
+        fallbackAlbumId = album.id
+    )
+
+    if (!album.albumArtUriString.isNullOrBlank()) {
+        albumKeys += AlbumGroupingKey(
+            normalizedTitle = album.title.normalizeMetadataTextOrEmpty()
+                .ifBlank { "Unknown Album" }
+                .lowercase(),
+            identity = "art:${album.albumArtUriString.trim()}"
+        )
+    }
+
+    return albumKeys.distinct()
+}
+
+internal fun chooseAlbumDisplayArtist(
+    songs: List<SongEntity>,
+    preferAlbumArtist: Boolean
+): String {
+    if (songs.isEmpty()) return "Unknown Artist"
+
+    val albumArtist = mostCommonValue(
+        songs.mapNotNull { song ->
+            song.albumArtist.normalizeMetadataText()?.takeIf { it.isNotBlank() }
+        }
+    )
+    val trackArtist = mostCommonValue(
+        songs.map { song ->
+            song.artistName.normalizeMetadataTextOrEmpty()
+        }
+    )
+
+    return when {
+        preferAlbumArtist && albumArtist != null -> albumArtist
+        trackArtist != null -> trackArtist
+        albumArtist != null -> albumArtist
+        else -> "Unknown Artist"
+    }
+}
+
+internal fun resolveAlbumDisplayArtistId(
+    displayArtist: String,
+    songs: List<SongEntity>,
+    artistNameToId: Map<String, Long>,
+    artistDelimiters: List<String>
+): Long {
+    artistNameToId[displayArtist.trim()]?.let { return it }
+
+    val primaryArtistName = displayArtist
+        .splitArtistsByDelimiters(artistDelimiters)
+        .firstOrNull()
+        ?.trim()
+    if (!primaryArtistName.isNullOrEmpty()) {
+        artistNameToId[primaryArtistName]?.let { return it }
+    }
+
+    return songs.firstOrNull()?.artistId ?: 0L
+}
+
+private fun mostCommonValue(values: List<String>): String? {
+    return values
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .groupingBy { it }
+        .eachCount()
+        .maxWithOrNull(compareBy<Map.Entry<String, Int>> { it.value }.thenByDescending { it.key.length })
+        ?.key
+}
+
+private fun buildAlbumGroupingKey(
+    albumName: String,
+    albumArtist: String?,
+    albumArtUriString: String?,
+    parentDirectoryPath: String?,
+    fallbackAlbumId: Long
+): AlbumGroupingKey {
+    val normalizedTitle = albumName.normalizeMetadataTextOrEmpty()
+        .ifBlank { "Unknown Album" }
+        .lowercase()
+    val identity = when {
+        !albumArtist.isNullOrBlank() -> {
+            "artist:${albumArtist.normalizeMetadataTextOrEmpty().lowercase()}"
+        }
+        !albumArtUriString.isNullOrBlank() -> {
+            "art:${albumArtUriString.trim()}"
+        }
+        !parentDirectoryPath.isNullOrBlank() -> {
+            "dir:${parentDirectoryPath.trim().lowercase()}"
+        }
+        else -> {
+            "media:$fallbackAlbumId"
+        }
+    }
+
+    return AlbumGroupingKey(
+        normalizedTitle = normalizedTitle,
+        identity = identity
+    )
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -215,6 +215,12 @@ constructor(
                                 } else {
                                     musicDao.getAllArtistsListRaw()
                                 }
+                        val allExistingAlbums =
+                                if (syncMode == SyncMode.REBUILD) {
+                                    emptyList()
+                                } else {
+                                    musicDao.getAllAlbumsList(emptyList(), false)
+                                }
 
                         val existingArtistImageUrls =
                                 allExistingArtists.associate { it.id to it.imageUrl }
@@ -232,6 +238,7 @@ constructor(
                                         artistDelimiters = artistDelimiters,
                                         groupByAlbumArtist = groupByAlbumArtist,
                                         existingArtistImageUrls = existingArtistImageUrls,
+                                        existingAlbums = allExistingAlbums,
                                         existingArtistIdMap = existingArtistIdMap,
                                         initialMaxArtistId = maxArtistId
                                 )
@@ -394,6 +401,7 @@ constructor(
             artistDelimiters: List<String>,
             groupByAlbumArtist: Boolean,
             existingArtistImageUrls: Map<Long, String?>,
+            existingAlbums: List<AlbumEntity>,
             existingArtistIdMap: MutableMap<String, Long>,
             initialMaxArtistId: Long
     ): MultiArtistProcessResult {
@@ -403,9 +411,17 @@ constructor(
         
         val allCrossRefs = mutableListOf<SongArtistCrossRef>()
         val artistTrackCounts = mutableMapOf<Long, Int>()
-        val albumMap = mutableMapOf<Pair<String, String>, Long>()
+        val albumMap = mutableMapOf<AlbumGroupingKey, Long>()
         val artistSplitCache = mutableMapOf<String, List<String>>()
         val correctedSongs = ArrayList<SongEntity>(songs.size)
+
+        existingAlbums
+            .sortedBy { it.id }
+            .forEach { album ->
+                buildAlbumGroupingKeys(album).forEach { key ->
+                    albumMap.putIfAbsent(key, album.id)
+                }
+            }
 
         songs.forEach { song ->
             val rawArtistName = song.artistName
@@ -447,19 +463,8 @@ constructor(
             }
 
             // --- Album Logic ---
-            val rawAlbumName = song.albumName.trim()
-            val albumIdentityArtist = if (groupByAlbumArtist) {
-                song.albumArtist?.trim()?.takeIf { it.isNotEmpty() } ?: primaryArtistName
-            } else {
-                primaryArtistName
-            }
-            
-            val albumKey = rawAlbumName to albumIdentityArtist
-            
-            if (!albumMap.containsKey(albumKey)) {
-                albumMap[albumKey] = song.albumId 
-            }
-            val finalAlbumId = albumMap[albumKey] ?: song.albumId // fallback
+            val albumKey = buildAlbumGroupingKey(song)
+            val finalAlbumId = albumMap.getOrPut(albumKey) { song.albumId }
 
             correctedSongs.add(
                     song.copy(
@@ -486,12 +491,16 @@ constructor(
         val albumEntities = correctedSongs.groupBy { it.albumId }.map { (catAlbumId, songsInAlbum) ->
              val firstSong = songsInAlbum.first()
              val representativeAlbumArt = songsInAlbum.firstNotNullOfOrNull { it.albumArtUriString }
-             // Determine Album Artist Name
-             val determinedAlbumArtist = firstSong.albumArtist?.takeIf { it.isNotBlank() } 
-                 ?: firstSong.artistName
-                 
-             // Determine Album Artist ID (best effort lookup)
-             val determinedAlbumArtistId = artistNameToId[determinedAlbumArtist] ?: 0L
+             val determinedAlbumArtist = chooseAlbumDisplayArtist(
+                 songs = songsInAlbum,
+                 preferAlbumArtist = groupByAlbumArtist
+             )
+             val determinedAlbumArtistId = resolveAlbumDisplayArtistId(
+                 displayArtist = determinedAlbumArtist,
+                 songs = songsInAlbum,
+                 artistNameToId = artistNameToId,
+                 artistDelimiters = artistDelimiters
+             )
 
              AlbumEntity(
                  id = catAlbumId,
@@ -928,6 +937,10 @@ constructor(
         var title = raw.title
         var artist = raw.artist
         var album = raw.album
+        var albumArtist = resolveAlbumArtist(
+            rawAlbumArtist = raw.albumArtist,
+            metadataAlbumArtist = null
+        )
         var trackNumber = raw.trackNumber
         var year = raw.year
         var genre: String? = genreMap[raw.id] // Use mapped genre as default
@@ -954,6 +967,10 @@ constructor(
                         if (!meta.title.isNullOrBlank()) title = meta.title
                         if (!meta.artist.isNullOrBlank()) artist = meta.artist
                         if (!meta.album.isNullOrBlank()) album = meta.album
+                        albumArtist = resolveAlbumArtist(
+                            rawAlbumArtist = albumArtist,
+                            metadataAlbumArtist = meta.albumArtist
+                        )
                         if (!meta.genre.isNullOrBlank()) genre = meta.genre
                         if (meta.trackNumber != null) trackNumber = meta.trackNumber
                         if (meta.year != null) year = meta.year
@@ -979,7 +996,7 @@ constructor(
                 title = title,
                 artistName = artist,
                 artistId = raw.artistId,
-                albumArtist = raw.albumArtist,
+                albumArtist = albumArtist,
                 albumName = album,
                 albumId = raw.albumId,
                 contentUriString = contentUriString,

--- a/app/src/test/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtilsTest.kt
@@ -1,0 +1,110 @@
+package com.theveloper.pixelplay.data.worker
+
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.database.SongEntity
+import org.junit.Test
+
+class AlbumGroupingUtilsTest {
+
+    @Test
+    fun `resolveAlbumArtist prefers embedded album artist`() {
+        val resolved = resolveAlbumArtist(
+            rawAlbumArtist = null,
+            metadataAlbumArtist = "The Weeknd"
+        )
+
+        assertThat(resolved).isEqualTo("The Weeknd")
+    }
+
+    @Test
+    fun `buildAlbumGroupingKey ignores per-track artist when title and art match`() {
+        val soloTrack = testSong(
+            artistName = "The Weeknd",
+            albumArtist = null,
+            albumArtUriString = "content://art/hurry-up",
+            parentDirectoryPath = "/music/The Weeknd & Justice - Hurry Up Tomorrow"
+        )
+        val collabTrack = testSong(
+            artistName = "The Weeknd, Justice",
+            albumArtist = null,
+            albumArtUriString = "content://art/hurry-up",
+            parentDirectoryPath = "/music/The Weeknd & Justice - Hurry Up Tomorrow"
+        )
+
+        assertThat(buildAlbumGroupingKey(soloTrack)).isEqualTo(buildAlbumGroupingKey(collabTrack))
+    }
+
+    @Test
+    fun `buildAlbumGroupingKey keeps same-titled albums apart when directories differ`() {
+        val firstAlbum = testSong(
+            artistName = "Artist A",
+            albumArtist = null,
+            albumArtUriString = null,
+            parentDirectoryPath = "/music/Artist A/Greatest Hits"
+        )
+        val secondAlbum = testSong(
+            artistName = "Artist B",
+            albumArtist = null,
+            albumArtUriString = null,
+            parentDirectoryPath = "/music/Artist B/Greatest Hits"
+        )
+
+        assertThat(buildAlbumGroupingKey(firstAlbum)).isNotEqualTo(buildAlbumGroupingKey(secondAlbum))
+    }
+
+    @Test
+    fun `chooseAlbumDisplayArtist prefers dominant track artist when grouping is off`() {
+        val songs = listOf(
+            testSong(artistName = "The Weeknd", albumArtist = "The Weeknd & Justice"),
+            testSong(artistName = "The Weeknd", albumArtist = "The Weeknd & Justice"),
+            testSong(artistName = "The Weeknd, Justice", albumArtist = "The Weeknd & Justice")
+        )
+
+        val displayArtist = chooseAlbumDisplayArtist(
+            songs = songs,
+            preferAlbumArtist = false
+        )
+
+        assertThat(displayArtist).isEqualTo("The Weeknd")
+    }
+
+    @Test
+    fun `chooseAlbumDisplayArtist prefers album artist when grouping is on`() {
+        val songs = listOf(
+            testSong(artistName = "The Weeknd", albumArtist = "The Weeknd & Justice"),
+            testSong(artistName = "The Weeknd, Justice", albumArtist = "The Weeknd & Justice")
+        )
+
+        val displayArtist = chooseAlbumDisplayArtist(
+            songs = songs,
+            preferAlbumArtist = true
+        )
+
+        assertThat(displayArtist).isEqualTo("The Weeknd & Justice")
+    }
+
+    private fun testSong(
+        artistName: String,
+        albumArtist: String?,
+        albumArtUriString: String? = null,
+        parentDirectoryPath: String = "/music/default",
+        albumName: String = "Hurry Up Tomorrow",
+        albumId: Long = 42L
+    ): SongEntity {
+        return SongEntity(
+            id = albumId,
+            title = "Track",
+            artistName = artistName,
+            artistId = 1L,
+            albumArtist = albumArtist,
+            albumName = albumName,
+            albumId = albumId,
+            contentUriString = "content://media/$albumId",
+            albumArtUriString = albumArtUriString,
+            duration = 180_000L,
+            genre = null,
+            filePath = "$parentDirectoryPath/track.flac",
+            parentDirectoryPath = parentDirectoryPath
+        )
+    }
+}


### PR DESCRIPTION
…hronization

- **Album Grouping**:
    - Introduce `AlbumGroupingKey` to identify albums using a combination of normalized titles, artists, artwork, or directory paths.
    - Implement `AlbumGroupingUtils` to provide robust logic for building grouping keys and resolving album artists.
    - Ensure that albums with the same title but different metadata or storage locations are correctly separated or merged.
- **SyncWorker**:
    - Update `processMultiArtistSongs` to utilize the new grouping utility, improving album ID assignment consistency.
    - Improve display artist selection for albums by analyzing common values across all tracks in an album.
    - Enhance metadata extraction to better resolve `albumArtist` by prioritizing metadata tags over raw media provider values.
- **Testing**:
    - Add `AlbumGroupingUtilsTest` to verify artist resolution, directory-based separation, and dominant artist selection logic.