### PR TITLE
fix: ensure shuffled playback starts at index 0

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -180,7 +180,7 @@ fun DailyMixScreen(
                 showSongInfoSheet = false
             },
             onAddToPlayList = {
-                    showPlaylistBottomSheet = true;
+                showPlaylistBottomSheet = true;
             },
             onDeleteFromDevice = playerViewModel::deleteFromDevice,
             onNavigateToAlbum = {
@@ -278,7 +278,8 @@ fun DailyMixScreen(
                                 if (dailyMixSongs.isNotEmpty()) {
                                     playerViewModel.playSongsShuffled(
                                         songsToPlay = dailyMixSongs,
-                                        queueName = "Daily Mix"
+                                        queueName = "Daily Mix",
+                                        startAtZero = true,
                                     )
                                 }
                             },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -260,7 +260,8 @@ fun HomeScreen(
                             if (yourMixSongs.isNotEmpty()) {
                                 playerViewModel.playSongsShuffled(
                                     songsToPlay = yourMixSongs,
-                                    queueName = "Your Mix"
+                                    queueName = "Your Mix",
+                                    startAtZero = true,
                                 )
                             }
                         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -363,7 +363,8 @@ fun PlaylistDetailScreen(
                                 playerViewModel.playSongsShuffled(
                                     songsToPlay = localReorderableSongs,
                                     queueName = currentPlaylist.name,
-                                    playlistId = currentPlaylist.id
+                                    playlistId = currentPlaylist.id,
+                                    startAtZero = true,
                                 )
                             }
                         },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
@@ -197,7 +197,8 @@ fun RecentlyPlayedScreen(
                             onShuffle = {
                                 playerViewModel.playSongsShuffled(
                                     songsToPlay = queueSongs,
-                                    queueName = "Recently Played"
+                                    queueName = "Recently Played",
+                                    startAtZero = true,
                                 )
                             },
                             modifier = Modifier.padding(horizontal = 16.dp)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -986,7 +986,7 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             val randomSongs = musicRepository.getRandomSongs(limit = 500)
             if (randomSongs.isNotEmpty()) {
-                playSongsShuffled(randomSongs, "All Songs (Shuffled)")
+                playSongsShuffled(randomSongs, "All Songs (Shuffled)", startAtZero = true)
             }
         }
     }
@@ -1023,7 +1023,7 @@ class PlayerViewModel @Inject constructor(
                     // Shuffle a random subset (up to 500) to avoid loading entire library
                     val subset = if (songs.size > 500) songs.shuffled().take(500) else songs.toList()
                     Timber.d("[TileDebug] Calling playSongsShuffled with ${subset.size} songs")
-                    playSongsShuffled(subset, "All Songs (Shuffled)")
+                    playSongsShuffled(subset, "All Songs (Shuffled)", startAtZero = true)
                 } else {
                     Timber.w("[TileDebug] No songs found even after sync - library may be empty")
                     sendToast("No songs found in library")
@@ -1044,7 +1044,7 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             val randomSongs = musicRepository.getRandomSongs(limit = 500)
             if (randomSongs.isNotEmpty()) {
-                playSongsShuffled(randomSongs, "All Songs (Shuffled)")
+                playSongsShuffled(randomSongs, "All Songs (Shuffled)", startAtZero = true)
             }
         }
     }
@@ -1056,7 +1056,7 @@ class PlayerViewModel @Inject constructor(
         viewModelScope.launch {
             val favSongs = musicRepository.getFavoriteSongsOnce(playerUiState.value.currentStorageFilter)
             if (favSongs.isNotEmpty()) {
-                playSongsShuffled(favSongs, "Liked Songs (Shuffled)")
+                playSongsShuffled(favSongs, "Liked Songs (Shuffled)", startAtZero = true)
             }
         }
     }
@@ -1068,7 +1068,7 @@ class PlayerViewModel @Inject constructor(
                 val randomAlbum = allAlbums.random()
                 val albumSongs = musicRepository.getSongsForAlbum(randomAlbum.id).first()
                 if (albumSongs.isNotEmpty()) {
-                    playSongsShuffled(albumSongs, randomAlbum.title)
+                    playSongsShuffled(albumSongs, randomAlbum.title, startAtZero = true)
                 }
             }
         }
@@ -1081,7 +1081,7 @@ class PlayerViewModel @Inject constructor(
                 val randomArtist = allArtists.random()
                 val artistSongs = musicRepository.getSongsForArtist(randomArtist.id).first()
                 if (artistSongs.isNotEmpty()) {
-                    playSongsShuffled(artistSongs, randomArtist.name)
+                    playSongsShuffled(artistSongs, randomArtist.name, startAtZero = true)
                 }
             }
         }


### PR DESCRIPTION
This PR makes shuffled playback consistently start from the first song in the shuffled queue across all entry points. It fixes an issue where songs could be missed when playback began at a later index.

The change adds startAtZero = true to all relevant playSongsShuffled calls.