### PR TITLE
Enable Compose non-skipping group optimization and disable smooth cor…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,12 @@ composeCompiler {
     // haven't changed) in Debug builds as well, making dev-mode performance more
     // representative of Release and reducing unnecessary recompositions during development.
     enableStrongSkippingMode = true
+
+    // Reduces generated code for non-skippable composables, improving runtime
+    // performance by eliminating unnecessary group bookkeeping.
+    featureFlags = setOf(
+        org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag.OptimizeNonSkippingGroups
+    )
 }
 
 ksp {

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -1386,7 +1386,7 @@ constructor(
 
     val useSmoothCornersFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.USE_SMOOTH_CORNERS] ?: true
+            preferences[PreferencesKeys.USE_SMOOTH_CORNERS] ?: false
         }
 
     suspend fun setUseSmoothCorners(enabled: Boolean) {


### PR DESCRIPTION
…ners by default

- **Build Configuration**: Enable the `OptimizeNonSkippingGroups` feature flag in the Compose compiler to improve runtime performance by reducing generated code for non-skippable composables.
- **UserPreferencesRepository**: Update the default value for `useSmoothCornersFlow` from `true` to `false`.