### PR TITLE
Implement a stable URI scheme for local album art to improve caching …

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/PixelPlayApplication.kt
@@ -47,6 +47,9 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
     @Inject
     lateinit var navidromeCoilFetcherFactory: dagger.Lazy<com.theveloper.pixelplay.data.image.NavidromeCoilFetcher.Factory>
 
+    @Inject
+    lateinit var localArtworkCoilFetcherFactory: dagger.Lazy<com.theveloper.pixelplay.data.image.LocalArtworkCoilFetcher.Factory>
+
     // AÑADE EL COMPANION OBJECT
     companion object {
         const val NOTIFICATION_CHANNEL_ID = "pixelplay_music_channel"
@@ -109,6 +112,7 @@ class PixelPlayApplication : Application(), ImageLoaderFactory, Configuration.Pr
     override fun newImageLoader(): ImageLoader {
         return imageLoader.get().newBuilder()
             .components {
+                add(localArtworkCoilFetcherFactory.get())
                 add(telegramCoilFetcherFactory.get())
                 add(navidromeCoilFetcherFactory.get())
             }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.theveloper.pixelplay.data.model.Album
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 
 @Entity(
@@ -25,14 +26,19 @@ data class AlbumEntity(
     @ColumnInfo(name = "year") val year: Int
 )
 
+private fun mediaStoreAlbumArtUri(albumId: Long): String {
+    return android.content.ContentUris.withAppendedId(
+        android.net.Uri.parse("content://media/external/audio/albumart"),
+        albumId
+    ).toString()
+}
+
 fun AlbumEntity.toAlbum(): Album {
-    // If stored art URI is null/blank, fall back to the standard content URI
-    // that MediaStore reliably resolves (same as MediaStoreSongRepository uses)
-    val effectiveAlbumArtUri = this.albumArtUriString?.takeIf { it.isNotBlank() }
-        ?: android.content.ContentUris.withAppendedId(
-            android.net.Uri.parse("content://media/external/audio/albumart"),
-            this.id
-        ).toString()
+    val effectiveAlbumArtUri = when {
+        this.albumArtUriString.isNullOrBlank() -> mediaStoreAlbumArtUri(this.id)
+        LocalArtworkUri.looksLikeVolatileArtworkUri(this.albumArtUriString) -> mediaStoreAlbumArtUri(this.id)
+        else -> this.albumArtUriString
+    }
 
     return Album(
         id = this.id,

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/SongEntity.kt
@@ -7,6 +7,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.theveloper.pixelplay.data.model.ArtistRef
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.utils.normalizeMetadataText
 import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 
@@ -78,7 +79,11 @@ private fun SongEntity.toSongInternal(artists: List<ArtistRef>): Song {
         albumArtist = this.albumArtist?.normalizeMetadataText(),
         path = this.filePath, // Map the file path
         contentUriString = this.contentUriString,
-        albumArtUriString = this.albumArtUriString,
+        albumArtUriString = LocalArtworkUri.resolveSongArtworkUri(
+            storedUri = this.albumArtUriString,
+            songId = this.id,
+            contentUriString = this.contentUriString
+        ),
         duration = this.duration,
         genre = this.genre.normalizeMetadataText(),
         lyrics = this.lyrics?.normalizeMetadataText(),

--- a/app/src/main/java/com/theveloper/pixelplay/data/image/LocalArtworkCoilFetcher.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/image/LocalArtworkCoilFetcher.kt
@@ -1,0 +1,45 @@
+package com.theveloper.pixelplay.data.image
+
+import android.net.Uri
+import coil.ImageLoader
+import coil.fetch.FetchResult
+import coil.fetch.Fetcher
+import coil.fetch.SourceResult
+import coil.request.Options
+import com.theveloper.pixelplay.utils.AlbumArtUtils
+import com.theveloper.pixelplay.utils.LocalArtworkUri
+import okio.Path.Companion.toPath
+import javax.inject.Inject
+
+class LocalArtworkCoilFetcher(
+    private val uri: Uri,
+    private val options: Options
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult? {
+        val songId = LocalArtworkUri.parseSongId(uri.toString()) ?: return null
+        val cachedFile = AlbumArtUtils.ensureAlbumArtCachedFile(
+            appContext = options.context,
+            songId = songId
+        ) ?: return null
+
+        return SourceResult(
+            source = coil.decode.ImageSource(
+                file = cachedFile.absolutePath.toPath(),
+                fileSystem = okio.FileSystem.SYSTEM
+            ),
+            mimeType = null,
+            dataSource = coil.decode.DataSource.DISK
+        )
+    }
+
+    class Factory @Inject constructor() : Fetcher.Factory<Uri> {
+        override fun create(data: Uri, options: Options, imageLoader: ImageLoader): Fetcher? {
+            return if (data.scheme == LocalArtworkUri.SCHEME) {
+                LocalArtworkCoilFetcher(data, options)
+            } else {
+                null
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -13,6 +13,7 @@ import com.kyant.taglib.TagLib
 import com.theveloper.pixelplay.data.database.MusicDao
 import com.theveloper.pixelplay.data.database.TelegramDao // Added
 import com.theveloper.pixelplay.data.database.TelegramSongEntity // Added
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import kotlinx.coroutines.flow.first // Added
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
@@ -246,8 +247,8 @@ class SongMetadataEditor(
                     newTrackNumber
                 )
 
-                coverArtUpdate?.let { update ->
-                    storedCoverArtUri = saveCoverArtPreview(songId, update)
+                coverArtUpdate?.let {
+                    storedCoverArtUri = LocalArtworkUri.buildSongUri(songId)
                     storedCoverArtUri?.let { coverUri ->
                         musicDao.updateSongAlbumArt(songId, coverUri)
                     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/paging/MediaStorePagingSource.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/paging/MediaStorePagingSource.kt
@@ -129,7 +129,12 @@ class MediaStorePagingSource(
                 val id = cursor.getLong(idCol)
                 val albumId = cursor.getLong(albumIdCol)
                 val path = cursor.getString(pathCol)
-                val albumArtUriString = AlbumArtUtils.getCachedAlbumArtUri(context, id)?.toString()
+                val albumArtUriString = AlbumArtUtils.getAlbumArtUri(
+                    appContext = context,
+                    path = path,
+                    songId = id,
+                    forceRefresh = false
+                )
 
                 val song = Song(
                     id = id.toString(),

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/FolderTreeBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/FolderTreeBuilder.kt
@@ -7,6 +7,7 @@ import com.theveloper.pixelplay.data.model.FolderSource
 import com.theveloper.pixelplay.data.model.MusicFolder
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.utils.DirectoryRuleResolver
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.utils.StorageType
 import com.theveloper.pixelplay.utils.StorageUtils
 import kotlinx.collections.immutable.toImmutableList
@@ -146,6 +147,12 @@ class FolderTreeBuilder @Inject constructor() {
     private fun FolderSongRow.toFolderStubSong(): Song {
         val parentPath = normalizePath(parentDirectoryPath)
         val syntheticPath = if (parentPath.isBlank()) title else "$parentPath/$title"
+        val resolvedAlbumArtUri = when {
+            LocalArtworkUri.isLocalArtworkUri(albumArtUriString) -> albumArtUriString
+            id > 0L && LocalArtworkUri.looksLikeVolatileArtworkUri(albumArtUriString) ->
+                LocalArtworkUri.buildSongUri(id)
+            else -> albumArtUriString
+        }
         return Song(
             id = id.toString(),
             title = title,
@@ -155,7 +162,7 @@ class FolderTreeBuilder @Inject constructor() {
             albumId = -1L,
             path = syntheticPath,
             contentUriString = "",
-            albumArtUriString = albumArtUriString,
+            albumArtUriString = resolvedAlbumArtUri,
             duration = 0L,
             trackNumber = 0,
             year = 0,

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
@@ -178,9 +178,12 @@ class MediaStoreSongRepository @Inject constructor(
                     val albumId = cursor.getLong(albumIdCol)
 
                     // Album art (individual / cached per song)
-                    val albumArtUriString = AlbumArtUtils
-                        .getCachedAlbumArtUri(context, id)
-                        ?.toString()
+                    val albumArtUriString = AlbumArtUtils.getAlbumArtUri(
+                        appContext = context,
+                        path = path,
+                        songId = id,
+                        forceRefresh = false
+                    )
 
                     // Artists parsing (supports multiple artists separated by user delimiters)
                     val rawArtist = cursor.getString(artistCol).normalizeMetadataTextOrEmpty()

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -57,6 +57,7 @@ import com.theveloper.pixelplay.ui.glancewidget.ControlWidget4x2
 import com.theveloper.pixelplay.ui.glancewidget.PixelPlayGlanceWidget
 import com.theveloper.pixelplay.ui.glancewidget.PlayerActions
 import com.theveloper.pixelplay.ui.glancewidget.PlayerInfoStateDefinition
+import com.theveloper.pixelplay.utils.AlbumArtUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1886,9 +1887,9 @@ class MusicService : MediaLibraryService() {
     private fun loadArtworkBytesForWidget(uri: Uri): ByteArray? {
         val scheme = uri.scheme?.lowercase()
         return when (scheme) {
-            "content", "file", "android.resource" -> {
+            "content", "file", "android.resource", com.theveloper.pixelplay.utils.LocalArtworkUri.SCHEME -> {
                 runCatching {
-                    applicationContext.contentResolver.openInputStream(uri)?.use { input ->
+                    AlbumArtUtils.openArtworkInputStream(applicationContext, uri)?.use { input ->
                         readBytesCapped(input, MAX_WIDGET_ARTWORK_BYTES)
                     }
                 }.getOrElse { error ->

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/http/MediaFileHttpServerService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/http/MediaFileHttpServerService.kt
@@ -828,8 +828,14 @@ class MediaFileHttpServerService : Service() {
 
                 val songIdLong = cursor.getLong(idCol)
                 val albumId = cursor.getLong(albumIdCol)
+                val path = cursor.getString(dataCol).orEmpty()
                 val contentUri = ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songIdLong)
-                val albumArtUri = AlbumArtUtils.getCachedAlbumArtUri(this, songIdLong)?.toString()
+                val albumArtUri = AlbumArtUtils.getAlbumArtUri(
+                    appContext = this,
+                    path = path,
+                    songId = songIdLong,
+                    forceRefresh = false
+                )
 
                 Song(
                     id = songIdLong.toString(),
@@ -839,7 +845,7 @@ class MediaFileHttpServerService : Service() {
                     album = cursor.getString(albumCol).orEmpty(),
                     albumId = albumId,
                     albumArtist = if (albumArtistCol >= 0) cursor.getString(albumArtistCol) else null,
-                    path = cursor.getString(dataCol).orEmpty(),
+                    path = path,
                     contentUriString = contentUri.toString(),
                     albumArtUriString = albumArtUri,
                     duration = cursor.getLong(durationCol),

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearStatePublisher.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearStatePublisher.kt
@@ -15,6 +15,7 @@ import com.theveloper.pixelplay.data.model.PlayerInfo
 import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearPlayerState
 import com.theveloper.pixelplay.shared.WearThemePalette
+import com.theveloper.pixelplay.utils.AlbumArtUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -141,7 +142,7 @@ class WearStatePublisher @Inject constructor(
     private fun readBytesFromUriCapped(uriString: String, maxBytes: Int): ByteArray? {
         return try {
             val uri = Uri.parse(uriString)
-            contentResolver.openInputStream(uri)?.use { input ->
+            AlbumArtUtils.openArtworkInputStream(application, uri)?.use { input ->
                 val buffer = ByteArray(16 * 1024)
                 val output = ByteArrayOutputStream()
                 var total = 0
@@ -261,7 +262,7 @@ class WearStatePublisher @Inject constructor(
 
     private fun decodeBoundedBitmapFromUri(uri: Uri, maxDimension: Int): Bitmap? {
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        contentResolver.openInputStream(uri)?.use { stream ->
+        AlbumArtUtils.openArtworkInputStream(application, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, bounds)
         } ?: return null
 
@@ -284,7 +285,7 @@ class WearStatePublisher @Inject constructor(
             inPreferredConfig = Bitmap.Config.ARGB_8888
         }
 
-        val decoded = contentResolver.openInputStream(uri)?.use { stream ->
+        val decoded = AlbumArtUtils.openArtworkInputStream(application, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, decodeOptions)
         } ?: return null
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -29,6 +29,7 @@ import com.theveloper.pixelplay.utils.AlbumArtCacheManager
 import com.theveloper.pixelplay.utils.AlbumArtUtils
 import com.theveloper.pixelplay.utils.AudioMetaUtils.getAudioMetadata
 import com.theveloper.pixelplay.utils.DirectoryRuleResolver
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 import com.theveloper.pixelplay.utils.splitArtistsByDelimiters
 import dagger.assisted.Assisted
@@ -644,15 +645,6 @@ constructor(
 
     private fun isSongUnchanged(raw: RawSongData, existing: SongEntity?): Boolean {
         if (existing == null) return false
-        existing.albumArtUriString?.let { albumArtUriString ->
-            if (!albumArtUriString.contains("song_art_${existing.id}")) {
-                return false
-            }
-
-            if (!AlbumArtUtils.hasCachedAlbumArt(applicationContext, existing.id)) {
-                return false
-            }
-        }
 
         val parentDir = File(raw.filePath).parent ?: ""
         val existingDateModifiedSeconds = TimeUnit.MILLISECONDS.toSeconds(existing.dateAdded)
@@ -976,13 +968,7 @@ constructor(
                         if (meta.year != null) year = meta.year
 
                         meta.artwork?.let { art ->
-                            val uri =
-                                    AlbumArtUtils.saveAlbumArtToCache(
-                                            applicationContext,
-                                            art.bytes,
-                                            raw.id
-                                    )
-                            albumArtUriString = uri.toString()
+                            albumArtUriString = LocalArtworkUri.buildSongUri(raw.id)
                         }
                     }
                 } catch (e: Exception) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.presentation.components
 
 import android.graphics.Bitmap
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -27,6 +28,7 @@ import coil.request.CachePolicy
 import coil.request.ImageRequest
 import coil.size.Size
 import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 
 @OptIn(ExperimentalCoilApi::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -38,6 +40,18 @@ fun OptimizedAlbumArt(
     placeholderModel: Any? = null
 ) {
     val context = LocalContext.current
+    val isStableLocalArtwork = remember(uri) {
+        when (uri) {
+            is String -> LocalArtworkUri.isLocalArtworkUri(uri)
+            is Uri -> uri.scheme == LocalArtworkUri.SCHEME
+            is ImageRequest -> {
+                val data = uri.data
+                (data as? String)?.let(LocalArtworkUri::isLocalArtworkUri) == true ||
+                    (data as? Uri)?.scheme == LocalArtworkUri.SCHEME
+            }
+            else -> false
+        }
+    }
 
     if (renderDirectAlbumArt(
             model = uri,
@@ -58,7 +72,7 @@ fun OptimizedAlbumArt(
                 .error(R.drawable.ic_music_placeholder)
                 .size(targetSize)
                 .memoryCachePolicy(CachePolicy.ENABLED)
-                .diskCachePolicy(CachePolicy.ENABLED)
+                .diskCachePolicy(if (isStableLocalArtwork) CachePolicy.DISABLED else CachePolicy.ENABLED)
                 .build()
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PrefetchAlbumNeighbors.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PrefetchAlbumNeighbors.kt
@@ -12,6 +12,7 @@ import coil.request.CachePolicy
 import coil.request.ImageRequest
 import coil.size.Size
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -31,10 +32,12 @@ fun PrefetchAlbumNeighborsImg(
         for (i in bounds) {
             if (i == index) continue
             queue[i].albumArtUriString?.let { data ->
+                val diskPolicy = if (LocalArtworkUri.isLocalArtworkUri(data)) CachePolicy.DISABLED else CachePolicy.ENABLED
                 val req = coil.request.ImageRequest.Builder(context)
                     .data(data)
                     .memoryCacheKey("album:$data")
-                    .diskCacheKey("album:$data")
+                    .diskCacheKey(if (diskPolicy == CachePolicy.DISABLED) null else "album:$data")
+                    .diskCachePolicy(diskPolicy)
                     .size(coil.size.Size.ORIGINAL)
                     .build()
                 loader.enqueue(req)
@@ -64,11 +67,12 @@ fun PrefetchAlbumNeighbors(
                     .filter { it in queue.indices && it != page }
                 indices.forEach { idx ->
                     queue[idx].albumArtUriString?.let { uri ->
+                        val diskPolicy = if (LocalArtworkUri.isLocalArtworkUri(uri)) coil.request.CachePolicy.DISABLED else coil.request.CachePolicy.ENABLED
                         val req = coil.request.ImageRequest.Builder(context)
                             .data(uri)
                             .size(targetSize)
                             .memoryCachePolicy(coil.request.CachePolicy.ENABLED)
-                            .diskCachePolicy(coil.request.CachePolicy.ENABLED)
+                            .diskCachePolicy(diskPolicy)
                             .networkCachePolicy(coil.request.CachePolicy.ENABLED)
                             .allowHardware(true)
                             .build()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
@@ -18,6 +18,7 @@ import com.theveloper.pixelplay.data.database.AlbumArtThemeDao
 import com.theveloper.pixelplay.data.database.AlbumArtThemeEntity
 import com.theveloper.pixelplay.data.database.StoredColorSchemeValues
 import com.theveloper.pixelplay.data.database.toComposeColor
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.ui.theme.clearExtractedColorCache
 import com.theveloper.pixelplay.ui.theme.extractSeedColor
 import com.theveloper.pixelplay.ui.theme.generateColorSchemeFromSeed
@@ -166,6 +167,7 @@ class ColorSchemeProcessor @Inject constructor(
     private suspend fun loadBitmapForColorExtraction(uri: String, skipCache: Boolean): Bitmap? {
         return try {
             val cachePolicy = if (skipCache) CachePolicy.DISABLED else CachePolicy.ENABLED
+            val diskCachePolicy = if (LocalArtworkUri.isLocalArtworkUri(uri)) CachePolicy.DISABLED else cachePolicy
             
             val request = ImageRequest.Builder(context)
                 .data(uri)
@@ -173,7 +175,7 @@ class ColorSchemeProcessor @Inject constructor(
                 .size(Size(128, 128)) // Small size for fast processing
                 .bitmapConfig(Bitmap.Config.ARGB_8888)
                 .memoryCachePolicy(cachePolicy)
-                .diskCachePolicy(cachePolicy)
+                .diskCachePolicy(diskCachePolicy)
                 .build()
             
             val drawable = context.imageLoader.execute(request).drawable ?: return null

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
@@ -3,6 +3,7 @@ package com.theveloper.pixelplay.utils
 import android.content.ContentUris
 import android.content.Context
 import android.net.Uri
+import android.provider.MediaStore
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +12,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileInputStream
+import java.io.InputStream
 
 object AlbumArtUtils {
 
@@ -27,13 +29,19 @@ object AlbumArtUtils {
         path: String,
         songId: Long,
         forceRefresh: Boolean
-    ): String? = getEmbeddedAlbumArtUri(appContext, path, songId, forceRefresh)?.toString()
+    ): String? {
+        return if (hasLocalAlbumArt(appContext, path, songId, forceRefresh)) {
+            LocalArtworkUri.buildSongUri(songId)
+        } else {
+            null
+        }
+    }
 
     fun getCachedAlbumArtUri(
         appContext: Context,
         songId: Long
     ): Uri? {
-        val cachedFile = albumArtCacheFile(appContext, songId)
+        val cachedFile = getCachedAlbumArtFile(appContext, songId)
         if (!cachedFile.exists()) return null
 
         cachedFile.setLastModified(System.currentTimeMillis())
@@ -44,11 +52,11 @@ object AlbumArtUtils {
         appContext: Context,
         songId: Long
     ): Boolean {
-        return albumArtCacheFile(appContext, songId).exists()
+        return getCachedAlbumArtFile(appContext, songId).exists()
     }
 
     /**
-     * Enhanced embedded art extraction with better error handling
+     * Enhanced album art detection without eagerly persisting the whole library to cache.
      */
     fun getEmbeddedAlbumArtUri(
         appContext: Context,
@@ -56,12 +64,96 @@ object AlbumArtUtils {
         songId: Long,
         deepScan: Boolean
     ): Uri? {
-        val audioFile = File(filePath)
-        if (!audioFile.exists() || !audioFile.canRead()) {
+        ensureAlbumArtCachedFile(appContext, songId, filePath, deepScan)?.let { cachedFile ->
+            return shareableCacheUri(appContext, cachedFile)
+        }
+        return null
+    }
+
+    fun ensureAlbumArtCachedFile(
+        appContext: Context,
+        songId: Long,
+        filePath: String? = null,
+        forceRefresh: Boolean = false
+    ): File? {
+        val cachedFile = getCachedAlbumArtFile(appContext, songId)
+        val noArtFile = noArtMarkerFile(appContext, songId)
+
+        if (!forceRefresh) {
+            if (cachedFile.exists() && cachedFile.length() > 0) {
+                cachedFile.setLastModified(System.currentTimeMillis())
+                return cachedFile
+            }
+            if (noArtFile.exists()) {
+                return null
+            }
+        } else {
+            cachedFile.delete()
+            noArtFile.delete()
+        }
+
+        val resolvedPath = filePath ?: resolveSongMediaStoreInfo(appContext, songId)?.path ?: return null
+        if (!File(resolvedPath).exists()) {
             return null
         }
 
-        val cachedFile = albumArtCacheFile(appContext, songId)
+        getExternalAlbumArtUri(resolvedPath)?.let { externalUri ->
+            if (copyUriToCache(appContext, externalUri, cachedFile) != null) {
+                noArtFile.delete()
+                return cachedFile
+            }
+        }
+
+        extractEmbeddedAlbumArtBytes(resolvedPath)?.let { bytes ->
+            cacheAlbumArtBytes(appContext, bytes, songId)
+            return cachedFile.takeIf { it.exists() && it.length() > 0 }
+        }
+
+        resolveSongMediaStoreInfo(appContext, songId)?.albumId?.let { albumId ->
+            getMediaStoreAlbumArtUri(appContext, albumId)?.let { mediaStoreUri ->
+                if (copyUriToCache(appContext, mediaStoreUri, cachedFile) != null) {
+                    noArtFile.delete()
+                    return cachedFile
+                }
+            }
+        }
+
+        cachedFile.delete()
+        noArtFile.createNewFile()
+        return null
+    }
+
+    fun openArtworkInputStream(
+        appContext: Context,
+        uri: Uri
+    ): InputStream? {
+        return when {
+            uri.scheme.equals(LocalArtworkUri.SCHEME, ignoreCase = true) -> {
+                val songId = LocalArtworkUri.parseSongId(uri.toString()) ?: return null
+                val resolvedPath = resolveSongMediaStoreInfo(appContext, songId)?.path
+                ensureAlbumArtCachedFile(
+                    appContext = appContext,
+                    songId = songId,
+                    filePath = resolvedPath
+                )?.inputStream()
+            }
+            uri.scheme.isNullOrBlank() && uri.toString().startsWith("/") -> File(uri.toString()).inputStream()
+            else -> appContext.contentResolver.openInputStream(uri)
+        }
+    }
+
+    private fun hasLocalAlbumArt(
+        appContext: Context,
+        filePath: String,
+        songId: Long,
+        deepScan: Boolean
+    ): Boolean {
+        val audioFile = File(filePath)
+        if (!audioFile.exists() || !audioFile.canRead()) {
+            return false
+        }
+
+        val cachedFile = getCachedAlbumArtFile(appContext, songId)
         val noArtFile = noArtMarkerFile(appContext, songId)
 
         if (!deepScan) {
@@ -69,38 +161,36 @@ object AlbumArtUtils {
                 if (cachedFile.exists()) {
                     cachedFile.delete()
                 }
-                return null
+                return false
             }
 
-            getCachedAlbumArtUri(appContext, songId)?.let { return it }
+            if (cachedFile.exists() && cachedFile.length() > 0) {
+                return true
+            }
         } else {
             noArtFile.delete()
         }
 
-        // Try to extract embedded art using pooled MediaMetadataRetriever.
-        return MediaMetadataRetrieverPool.withRetriever { retriever ->
-            try {
-                retriever.setDataSource(filePath)
-            } catch (e: IllegalArgumentException) {
-                // FileDescriptor fallback
-                try {
-                    FileInputStream(filePath).use { fis ->
-                        retriever.setDataSource(fis.fd)
-                    }
-                } catch (e2: Exception) {
-                    return@withRetriever null
-                }
-            }
-
-            val bytes = retriever.embeddedPicture
-            if (bytes != null && bytes.isNotEmpty()) {
-                saveAlbumArtToCache(appContext, bytes, songId)
-            } else {
-                cachedFile.delete()
-                noArtFile.createNewFile()
-                null
-            }
+        if (getExternalAlbumArtUri(filePath) != null) {
+            noArtFile.delete()
+            return true
         }
+
+        val hasEmbeddedArt = extractEmbeddedAlbumArtBytes(filePath)?.isNotEmpty() == true
+        if (hasEmbeddedArt) {
+            noArtFile.delete()
+            return true
+        }
+
+        val albumId = resolveSongMediaStoreInfo(appContext, songId)?.albumId
+        if (albumId != null && getMediaStoreAlbumArtUri(appContext, albumId) != null) {
+            noArtFile.delete()
+            return true
+        }
+
+        cachedFile.delete()
+        noArtFile.createNewFile()
+        return false
     }
 
     /**
@@ -181,7 +271,16 @@ object AlbumArtUtils {
      * Save embedded art to cache with unique naming
      */
     fun saveAlbumArtToCache(appContext: Context, bytes: ByteArray, songId: Long): Uri {
-        val file = albumArtCacheFile(appContext, songId)
+        val file = cacheAlbumArtBytes(appContext, bytes, songId)
+        return shareableCacheUri(appContext, file)
+    }
+
+    fun getCachedAlbumArtFile(appContext: Context, songId: Long): File {
+        return File(appContext.cacheDir, "song_art_${songId}.jpg")
+    }
+
+    private fun cacheAlbumArtBytes(appContext: Context, bytes: ByteArray, songId: Long): File {
+        val file = getCachedAlbumArtFile(appContext, songId)
 
         file.outputStream().use { outputStream ->
             outputStream.write(bytes)
@@ -193,15 +292,82 @@ object AlbumArtUtils {
             AlbumArtCacheManager.cleanCacheIfNeeded(appContext)
         }
 
-        return shareableCacheUri(appContext, file)
-    }
-
-    private fun albumArtCacheFile(appContext: Context, songId: Long): File {
-        return File(appContext.cacheDir, "song_art_${songId}.jpg")
+        return file
     }
 
     private fun noArtMarkerFile(appContext: Context, songId: Long): File {
         return File(appContext.cacheDir, "song_art_${songId}_no.jpg")
+    }
+
+    private data class MediaStoreSongInfo(
+        val path: String,
+        val albumId: Long?
+    )
+
+    private fun resolveSongMediaStoreInfo(
+        appContext: Context,
+        songId: Long
+    ): MediaStoreSongInfo? {
+        val selection = "${MediaStore.Audio.Media._ID} = ?"
+        val selectionArgs = arrayOf(songId.toString())
+        val projection = arrayOf(
+            MediaStore.Audio.Media.DATA,
+            MediaStore.Audio.Media.ALBUM_ID
+        )
+
+        return runCatching {
+            appContext.contentResolver.query(
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                projection,
+                selection,
+                selectionArgs,
+                null
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use null
+                val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA))
+                val albumId = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID))
+                MediaStoreSongInfo(
+                    path = path,
+                    albumId = albumId.takeIf { it > 0L }
+                )
+            }
+        }.getOrNull()
+    }
+
+    private fun extractEmbeddedAlbumArtBytes(filePath: String): ByteArray? {
+        return MediaMetadataRetrieverPool.withRetriever { retriever ->
+            try {
+                retriever.setDataSource(filePath)
+            } catch (e: IllegalArgumentException) {
+                try {
+                    FileInputStream(filePath).use { fis ->
+                        retriever.setDataSource(fis.fd)
+                    }
+                } catch (e2: Exception) {
+                    return@withRetriever null
+                }
+            }
+
+            retriever.embeddedPicture?.takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun copyUriToCache(
+        appContext: Context,
+        sourceUri: Uri,
+        targetFile: File
+    ): File? {
+        return runCatching {
+            openArtworkInputStream(appContext, sourceUri)?.use { input ->
+                targetFile.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
+
+            appScope.launch {
+                AlbumArtCacheManager.cleanCacheIfNeeded(appContext)
+            }
+
+            targetFile
+        }.getOrNull()
     }
 
     private fun shareableCacheUri(appContext: Context, file: File): Uri {

--- a/app/src/main/java/com/theveloper/pixelplay/utils/LocalArtworkUri.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/LocalArtworkUri.kt
@@ -1,0 +1,58 @@
+package com.theveloper.pixelplay.utils
+
+object LocalArtworkUri {
+    const val SCHEME = "pixelplay_local_art"
+    private const val HOST_SONG = "song"
+
+    fun buildSongUri(songId: Long): String = "$SCHEME://$HOST_SONG/$songId"
+
+    fun isLocalArtworkUri(uriString: String?): Boolean {
+        return uriString?.startsWith("$SCHEME://") == true
+    }
+
+    fun parseSongId(uriString: String): Long? {
+        if (!isLocalArtworkUri(uriString)) return null
+        val prefix = "$SCHEME://$HOST_SONG/"
+        return uriString.removePrefix(prefix)
+            .substringBefore('?')
+            .toLongOrNull()
+    }
+
+    fun looksLikeVolatileArtworkUri(uriString: String?): Boolean {
+        if (uriString.isNullOrBlank()) return false
+        val normalized = uriString.lowercase()
+        return normalized.contains("song_art_") &&
+            (
+                normalized.startsWith("content://") ||
+                    normalized.startsWith("file://") ||
+                    normalized.startsWith("/") ||
+                    normalized.contains(".provider/")
+                )
+    }
+
+    fun isLikelyLocalMedia(contentUriString: String): Boolean {
+        val normalized = contentUriString.lowercase()
+        return !normalized.startsWith("telegram://") &&
+            !normalized.startsWith("netease://") &&
+            !normalized.startsWith("qqmusic://") &&
+            !normalized.startsWith("navidrome://") &&
+            !normalized.startsWith("gdrive://")
+    }
+
+    fun resolveSongArtworkUri(
+        storedUri: String?,
+        songId: Long,
+        contentUriString: String
+    ): String? {
+        val normalizedStoredUri = storedUri?.takeIf { it.isNotBlank() } ?: return null
+        if (!isLikelyLocalMedia(contentUriString)) {
+            return normalizedStoredUri
+        }
+
+        return if (isLocalArtworkUri(normalizedStoredUri) || looksLikeVolatileArtworkUri(normalizedStoredUri)) {
+            buildSongUri(songId)
+        } else {
+            normalizedStoredUri
+        }
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/utils/LocalArtworkUriTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/LocalArtworkUriTest.kt
@@ -1,0 +1,47 @@
+package com.theveloper.pixelplay.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LocalArtworkUriTest {
+
+    @Test
+    fun resolveSongArtworkUri_convertsLegacyLocalCacheUriToStableUri() {
+        val resolved = LocalArtworkUri.resolveSongArtworkUri(
+            storedUri = "content://com.theveloper.pixelplay.provider/cache/song_art_42.jpg",
+            songId = 42L,
+            contentUriString = "content://media/external/audio/media/42"
+        )
+
+        assertThat(resolved).isEqualTo(LocalArtworkUri.buildSongUri(42L))
+    }
+
+    @Test
+    fun resolveSongArtworkUri_keepsRemoteArtworkUriUntouched() {
+        val resolved = LocalArtworkUri.resolveSongArtworkUri(
+            storedUri = "https://example.com/cover.jpg",
+            songId = 42L,
+            contentUriString = "content://media/external/audio/media/42"
+        )
+
+        assertThat(resolved).isEqualTo("https://example.com/cover.jpg")
+    }
+
+    @Test
+    fun resolveSongArtworkUri_keepsCloudSourceArtworkUntouched() {
+        val resolved = LocalArtworkUri.resolveSongArtworkUri(
+            storedUri = "telegram_art://123/456",
+            songId = 42L,
+            contentUriString = "telegram://123/456"
+        )
+
+        assertThat(resolved).isEqualTo("telegram_art://123/456")
+    }
+
+    @Test
+    fun parseSongId_readsStableSongUri() {
+        val songId = LocalArtworkUri.parseSongId(LocalArtworkUri.buildSongUri(99L))
+
+        assertThat(songId).isEqualTo(99L)
+    }
+}


### PR DESCRIPTION
…efficiency and performance.

- **New Core Components**:
    - Introduce `LocalArtworkUri` utility to manage a custom `pixelplay_local_art://` scheme, providing stable identifiers for song artwork.
    - Implement `LocalArtworkCoilFetcher` and its factory to handle asynchronous loading of local artwork through the Coil image library.
- **AlbumArtUtils**:
    - Refactor artwork extraction to be lazy; avoid eagerly persisting all library art to cache during sync.
    - Add `ensureAlbumArtCachedFile` to resolve artwork on-demand from external files, embedded tags, or MediaStore.
    - Introduce `openArtworkInputStream` to provide a unified way to read artwork from various URI schemes.
- **Data & Synchronization**:
    - Update `SongEntity` and `AlbumEntity` to resolve volatile or legacy cache URIs into stable `LocalArtworkUri` strings.
    - Modify `SyncWorker` and `SongMetadataEditor` to use the new URI scheme when discovering or updating artwork.
    - Optimize `isSongUnchanged` logic in `SyncWorker` by removing redundant cache existence checks.
- **UI & Performance**:
    - **OptimizedAlbumArt**: Disable Coil's disk cache for `LocalArtworkUri` sources since the files are already managed locally in the app's cache directory.
    - **Wear & Widgets**: Update `WearStatePublisher` and `MusicService` to use the new unified input stream resolver for artwork.
    - **Prefetching**: Update `PrefetchAlbumNeighbors` and `ColorSchemeProcessor` to respect disk cache policies based on the URI scheme.
- **Unit Tests**:
    - Add `LocalArtworkUriTest` to verify URI resolution, parsing, and legacy conversion logic.