### PR TITLE
Update `WakeMode` and add `WAKE_LOCK` permission for reliable backgro…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -367,7 +367,10 @@ class DualPlayerEngine @Inject constructor(
                     .build()
             )
             setHandleAudioBecomingNoisy(true) // Force player to pause automatically when audio is rerouted from a headset to device speakers
-            setWakeMode(C.WAKE_MODE_LOCAL) // Use CPU lock only. WiFi lock unused as we proxy via localhost. Saves battery.
+            // Cloud sources are proxied through localhost, but the proxy still depends on
+            // upstream network access. Keep both CPU and network awake so background
+            // playback does not stall when the screen turns off or the app is backgrounded.
+            setWakeMode(C.WAKE_MODE_NETWORK)
             // Explicitly keep both players live so they can overlap without affecting each other
             playWhenReady = false
         }


### PR DESCRIPTION
…und playback

- **DualPlayerEngine**: Update `WakeMode` from `WAKE_MODE_LOCAL` to `WAKE_MODE_NETWORK`. While cloud sources are proxied via localhost, the proxy requires upstream network access; this change ensures the network stays active to prevent stalling during background playback.
- **AndroidManifest.xml**: Add the `android.permission.WAKE_LOCK` permission to support the updated wake mode.