### PR TITLE
Implement a close button for the notification player and refactor ser…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicNotificationProvider.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicNotificationProvider.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.data.service
 
 object MusicNotificationProvider {
+    const val CUSTOM_COMMAND_CLOSE_PLAYER = "com.theveloper.pixelplay.CLOSE_PLAYER"
     const val CUSTOM_COMMAND_TOGGLE_SHUFFLE = "com.theveloper.pixelplay.TOGGLE_SHUFFLE"
     const val CUSTOM_COMMAND_SHUFFLE_ON = "com.theveloper.pixelplay.SHUFFLE_ON"
     const val CUSTOM_COMMAND_SHUFFLE_OFF = "com.theveloper.pixelplay.SHUFFLE_OFF"

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -60,6 +60,7 @@ import com.theveloper.pixelplay.ui.glancewidget.PlayerInfoStateDefinition
 import com.theveloper.pixelplay.utils.AlbumArtUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -357,6 +358,7 @@ class MusicService : MediaLibraryService() {
 
                 val defaultResult = super.onConnect(session, controller)
                 val customCommands = listOf(
+                    MusicNotificationProvider.CUSTOM_COMMAND_CLOSE_PLAYER,
                     MusicNotificationProvider.CUSTOM_COMMAND_LIKE,
                     MusicNotificationProvider.CUSTOM_COMMAND_SET_FAVORITE_STATE,
                     MusicNotificationProvider.CUSTOM_COMMAND_TOGGLE_SHUFFLE,
@@ -398,6 +400,9 @@ class MusicService : MediaLibraryService() {
                 Timber.tag("MusicService")
                     .d("onCustomCommand received: ${customCommand.customAction}")
                 when (customCommand.customAction) {
+                    MusicNotificationProvider.CUSTOM_COMMAND_CLOSE_PLAYER -> {
+                        closeNotificationPlayer()
+                    }
                     MusicNotificationProvider.CUSTOM_COMMAND_COUNTED_PLAY -> {
                         val count = args.getInt("count", 1)
                         startCountedPlay(count)
@@ -1207,21 +1212,17 @@ class MusicService : MediaLibraryService() {
         val allowBackground = keepPlayingInBackground
 
         if (!allowBackground) {
-            player?.apply {
-                playWhenReady = false
-                stop()
-                clearMediaItems()
-            }
-            schedulePlaybackSnapshotPersist(immediate = true)
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
-            super.onTaskRemoved(rootIntent)
+            stopPlaybackAndUnload(
+                reason = "task_removed_background_disabled"
+            )
             return
         }
 
         if (player == null || !player.playWhenReady || player.mediaItemCount == 0 || player.playbackState == Player.STATE_ENDED) {
-            schedulePlaybackSnapshotPersist(immediate = true)
-            stopSelf()
+            stopPlaybackAndUnload(
+                reason = "task_removed_not_playing"
+            )
+            return
         }
         super.onTaskRemoved(rootIntent)
     }
@@ -2035,6 +2036,50 @@ class MusicService : MediaLibraryService() {
         session.setMediaButtonPreferences(buttons)
     }
 
+    private fun closeNotificationPlayer() {
+        stopPlaybackAndUnload(
+            reason = "notification_close_button"
+        )
+    }
+
+    private fun stopPlaybackAndUnload(
+        reason: String,
+    ) {
+        Timber.tag(TAG).d(
+            "Stopping playback and unloading service. reason=%s",
+            reason
+        )
+        followUpMediaSessionUiRefreshJob?.cancel()
+        followUpWidgetUpdateJob?.cancel()
+        debouncedWidgetUpdateJob?.cancel()
+        playbackSnapshotPersistJob?.cancel()
+
+        val sessionToRelease = mediaSession
+        val player = sessionToRelease?.player ?: engine.masterPlayer
+
+        clearHeadsetReconnectResume()
+        cancelDurationSleepTimerInternal()
+        endOfTrackTimerSongId = null
+
+        persistPlaybackSnapshotImmediately()
+
+        player.playWhenReady = false
+        player.stop()
+        player.clearMediaItems()
+
+        requestWidgetFullUpdate(force = true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
+
+        stopSelf()
+    }
+
+    private fun persistPlaybackSnapshotImmediately() {
+        playbackSnapshotPersistJob?.cancel()
+        playbackSnapshotPersistJob = serviceScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            persistPlaybackSnapshot()
+        }
+    }
+
     private fun refreshMediaSessionUiWithFollowUp(
         session: MediaSession,
         delayMs: Long = 250L
@@ -2276,12 +2321,19 @@ class MusicService : MediaLibraryService() {
             .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
+        val closeButton = CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+            .setCustomIconResId(R.drawable.rounded_close_24)
+            .setDisplayName(getString(R.string.close_notification_player))
+            .setSessionCommand(SessionCommand(MusicNotificationProvider.CUSTOM_COMMAND_CLOSE_PLAYER, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
+            .build()
+
         // Let Media3 provide the primary previous/play-next transport buttons from player
         // commands instead of advertising custom back/forward slots here. When custom
         // SLOT_BACK/SLOT_FORWARD buttons are present, Media3 strips the legacy
         // ACTION_SKIP_TO_PREVIOUS/NEXT flags from PlaybackStateCompat, which causes some
         // OEM compact system players (including ColorOS Control Center) to gray out skip.
-        return listOf(likeButton, shuffleButton, repeatButton)
+        return listOf(likeButton, closeButton, shuffleButton, repeatButton)
     }
 
     // ------------------------

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="external_playback_error">Unable to open that audio file.</string>
     <string name="open_full_player">Open full player</string>
     <string name="close_external_player">Close floating player</string>
+    <string name="close_notification_player">Close player</string>
     <string name="previous_track">Previous track</string>
     <string name="next_track">Next track</string>
     <string name="pause_playback">Pause playback</string>


### PR DESCRIPTION
…vice teardown

- **MusicService**:
    - Add `CUSTOM_COMMAND_CLOSE_PLAYER` to the supported custom session commands.
    - Implement `stopPlaybackAndUnload` to centralize playback termination, state persistence, and service cleanup.
    - Introduce `persistPlaybackSnapshotImmediately` to ensure the current playback state is saved synchronously before shutdown.
    - Add a "Close player" `CommandButton` to the notification overflow menu.
    - Refactor `onTaskRemoved` to use the new centralized cleanup logic.
- **Resources**:
    - Add `close_notification_player` string resource.
- **Constants**:
    - Define `CUSTOM_COMMAND_CLOSE_PLAYER` in `MusicNotificationProvider`.