### PR TITLE
fix: embedded lyrics empty in EditSongSheet

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.media3.common.Player
+import com.theveloper.pixelplay.data.media.AudioMetadataReader
 import com.theveloper.pixelplay.data.media.CoverArtUpdate
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import java.io.ByteArrayOutputStream
@@ -162,6 +163,24 @@ private fun EditSongContent(
         trackNumber = song.trackNumber.toString()
         coverArtPreview = null
         editedCoverArt = null
+
+        // Try to read embedded lyrics if they were not cached in the database
+        if (lyrics.isBlank() && song.path.isNotBlank()) {
+            withContext(Dispatchers.IO) {
+                try {
+                    val file = java.io.File(song.path)
+                    if (file.exists()) {
+                        AudioMetadataReader.read(file)?.lyrics?.let { embeddedLyrics ->
+                            if (embeddedLyrics.isNotBlank()) {
+                                lyrics = embeddedLyrics
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e, "Failed to read embedded lyrics for EditSongSheet")
+                }
+            }
+        }
     }
 
     if (isGenerating) {


### PR DESCRIPTION
### Description
Fixes an issue where embedded lyrics show up as completely empty when trying to edit a song's metadata, even though they display perfectly fine in `LyricsSheet`.

### Why is this happen
When a song is initially synced into the user's library, the app intentionally skips deep-scanning the file for embedded lyrics to make the library scanning process extremely fast. As a result, the database initially saves the lyrics for most songs as null.

Unlike the `LyricsSheet` (which dynamically extracts the embedded lyrics from the actual file on-the-fly), the `EditSongSheet` originally relied only on the database value, which is can be empty as explained before. This caused existing embedded lyrics to never appear in the text field.

### Fix
This PR simply updates the `EditSongSheet` to mimic the `LyricsSheet` (stablePlayerState): if the database returns empty lyrics, it will asynchronously read the actual audio file for embedded tags when the sheet is opened.

This correctly populates the text field without slowing down the initial library sync performance.