### PR TITLE
fix: lyrics source priority, foreground service flickering, and custom artist image syncing

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -812,11 +812,20 @@ class MusicService : MediaLibraryService() {
         }
     }
 
+    private fun isServiceAlreadyForeground(): Boolean {
+        val player = mediaSession?.player ?: return false
+        return player.playWhenReady &&
+            player.playbackState != Player.STATE_IDLE &&
+            player.playbackState != Player.STATE_ENDED
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val forcedForegroundStart =
             intent?.getBooleanExtra(EXTRA_FORCE_FOREGROUND_ON_START, false) == true
         val isMediaButtonIntent = intent?.action == Intent.ACTION_MEDIA_BUTTON
-        if (forcedForegroundStart || isMediaButtonIntent) {
+        val needsTemporaryForeground = forcedForegroundStart ||
+            (isMediaButtonIntent && !isServiceAlreadyForeground())
+        if (needsTemporaryForeground) {
             startTemporaryForegroundForCommand()
         }
 
@@ -881,7 +890,7 @@ class MusicService : MediaLibraryService() {
             }
         }
         val startCommandResult = super.onStartCommand(intent, flags, startId)
-        if (forcedForegroundStart || isMediaButtonIntent) {
+        if (needsTemporaryForeground) {
             val player = mediaSession?.player
             val isActivelyPlaying = player?.let {
                 it.playWhenReady &&

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -223,8 +223,8 @@ constructor(
                                     musicDao.getAllAlbumsList(emptyList(), false)
                                 }
 
-                        val existingArtistImageUrls =
-                                allExistingArtists.associate { it.id to it.imageUrl }
+                        val existingArtistMetadata =
+                                allExistingArtists.associate { it.id to (it.imageUrl to it.customImageUri) }
                         
                         // Load all existing artist IDs to ensure stability across incremental syncs
                         val existingArtistIdMap = allExistingArtists.associate { it.name to it.id }.toMutableMap()
@@ -238,7 +238,7 @@ constructor(
                                         songs = songsToInsert,
                                         artistDelimiters = artistDelimiters,
                                         groupByAlbumArtist = groupByAlbumArtist,
-                                        existingArtistImageUrls = existingArtistImageUrls,
+                                        existingArtistMetadata = existingArtistMetadata,
                                         existingAlbums = allExistingAlbums,
                                         existingArtistIdMap = existingArtistIdMap,
                                         initialMaxArtistId = maxArtistId
@@ -401,7 +401,7 @@ constructor(
             songs: List<SongEntity>,
             artistDelimiters: List<String>,
             groupByAlbumArtist: Boolean,
-            existingArtistImageUrls: Map<Long, String?>,
+            existingArtistMetadata: Map<Long, Pair<String?, String?>>,
             existingAlbums: List<AlbumEntity>,
             existingArtistIdMap: MutableMap<String, Long>,
             initialMaxArtistId: Long
@@ -479,11 +479,13 @@ constructor(
         // Build Entities
         val artistEntities = artistNameToId.map { (name, id) ->
             val count = artistTrackCounts[id] ?: 0
+            val metadata = existingArtistMetadata[id]
             ArtistEntity(
                 id = id,
                 name = name,
                 trackCount = count,
-                imageUrl = existingArtistImageUrls[id]
+                imageUrl = metadata?.first,
+                customImageUri = metadata?.second
             )
         }
         

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
@@ -165,36 +165,57 @@ class LyricsStateHolder @Inject constructor(
     }
 
     /**
-     * Fetch lyrics for the given song from the remote service.
+     * Fetch lyrics for the given song, respecting the user's source preference.
      */
     fun fetchLyricsForSong(
         song: Song,
         forcePickResults: Boolean,
+        sourcePreference: LyricsSourcePreference,
         contextHelper: (Int) -> String
     ) {
         loadingJob?.cancel()
         loadingJob = scope?.launch {
             _searchUiState.value = LyricsSearchUiState.Loading
 
-            // Embedded lyrics must be prioritized for manual fetch too.
-            val embeddedRaw = withContext(Dispatchers.IO) { readEmbeddedLyricsFromFile(song) }
-            if (!embeddedRaw.isNullOrBlank()) {
-                val embeddedParsed = LyricsUtils.parseLyrics(embeddedRaw)
-                if (hasValidLyrics(embeddedParsed)) {
-                    val parsed = embeddedParsed.copy(areFromRemote = false)
-                    _searchUiState.value = LyricsSearchUiState.Success(parsed)
+            // Build ordered list of local source checks based on user preference.
+            // API_FIRST: skip local sources, go straight to remote.
+            // EMBEDDED_FIRST: check embedded, then local .lrc, then remote.
+            // LOCAL_FIRST: check local .lrc, then embedded, then remote.
+            val localSourceChecks: List<suspend () -> Pair<String, Int>?> = when (sourcePreference) {
+                LyricsSourcePreference.API_FIRST -> emptyList()
+                LyricsSourcePreference.EMBEDDED_FIRST -> listOf(
+                    { readEmbeddedLyricsFromFile(song)?.let { it to R.string.lyrics_embedded_already_available } },
+                    { readLocalLrcFile(song)?.let { it to R.string.local_lrc_already_available } }
+                )
+                LyricsSourcePreference.LOCAL_FIRST -> listOf(
+                    { readLocalLrcFile(song)?.let { it to R.string.local_lrc_already_available } },
+                    { readEmbeddedLyricsFromFile(song)?.let { it to R.string.lyrics_embedded_already_available } }
+                )
+            }
 
-                    val songId = song.id.toLongOrNull()
-                    if (songId != null) {
-                        musicRepository.updateLyrics(songId, embeddedRaw)
+            // Try local sources in priority order.
+            for (sourceCheck in localSourceChecks) {
+                val result = withContext(Dispatchers.IO) { sourceCheck() }
+                if (result != null) {
+                    val (rawLyrics, messageResId) = result
+                    val parsed = LyricsUtils.parseLyrics(rawLyrics)
+                    if (hasValidLyrics(parsed)) {
+                        val lyrics = parsed.copy(areFromRemote = false)
+                        _searchUiState.value = LyricsSearchUiState.Success(lyrics)
+
+                        val songId = song.id.toLongOrNull()
+                        if (songId != null) {
+                            musicRepository.updateLyrics(songId, rawLyrics)
+                        }
+
+                        _songUpdates.emit(song.copy(lyrics = rawLyrics) to lyrics)
+                        _messageEvents.emit(contextHelper(messageResId))
+                        return@launch
                     }
-
-                    _songUpdates.emit(song.copy(lyrics = embeddedRaw) to parsed)
-                    _messageEvents.emit(contextHelper(R.string.lyrics_embedded_already_available))
-                    return@launch
                 }
             }
 
+            // Fall through to remote fetch.
             if (forcePickResults) {
                 musicRepository.searchRemoteLyrics(song)
                     .onSuccess { (query, results) ->
@@ -316,6 +337,17 @@ class LyricsStateHolder @Inject constructor(
                 ?.lyrics
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
+        }.getOrNull()
+    }
+
+    private fun readLocalLrcFile(song: Song): String? {
+        return runCatching {
+            val songFile = File(song.path)
+            val directory = songFile.parentFile ?: return@runCatching null
+            val lrcFile = File(directory, "${songFile.nameWithoutExtension}.lrc")
+            if (lrcFile.exists() && lrcFile.canRead()) {
+                lrcFile.readText().trim().takeIf { it.isNotBlank() }
+            } else null
         }.getOrNull()
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -458,7 +458,7 @@ class PlayerViewModel @Inject constructor(
     val lyricsSourcePreference: StateFlow<LyricsSourcePreference> = userPreferencesRepository.lyricsSourcePreferenceFlow
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
+            started = SharingStarted.Eagerly,
             initialValue = LyricsSourcePreference.EMBEDDED_FIRST
         )
 
@@ -3824,7 +3824,7 @@ class PlayerViewModel @Inject constructor(
      */
     fun fetchLyricsForCurrentSong(forcePickResults: Boolean = false) {
         val currentSong = stablePlayerState.value.currentSong ?: return
-        lyricsStateHolder.fetchLyricsForSong(currentSong, forcePickResults) { resId ->
+        lyricsStateHolder.fetchLyricsForSong(currentSong, forcePickResults, lyricsSourcePreference.value) { resId ->
             context.getString(resId)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="search">Search</string>
     <string name="searching_lyrics">Searching for lyrics…</string>
     <string name="lyrics_embedded_already_available">Embedded lyrics already found. Online fetch skipped.</string>
+    <string name="local_lrc_already_available">Local (.lrc) lyrics already found. Online fetch skipped.</string>
     <string name="fetch_lyrics_show_options_title">Show lyric options</string>
     <string name="fetch_lyrics_show_options_subtitle">Always open the picker instead of auto-applying the first match</string>
     <string name="error">Error</string>


### PR DESCRIPTION
### Description
- The Lyrics Source Priority setting (Embedded First / Online First / Local First) was not being applied when fetching lyrics. Embedded lyrics were always prioritized regardless of the selected preference.
- Function `startTemporaryForegroundForCommand()` flickering if service already in foreground.
- Custom artist image disappear after a while (periodic sync) because not being include in SyncWorker.

### Fix
- `LyricsStateHolder.fetchLyricsForSong()` now checks sources in the order defined by the user's preference.
- add `isServiceAlreadyForeground()` checker to only allow `startTemporaryForegroundForCommand()`  for media intent button if service is not in foreground.
- add `customImageUri` in `SyncWorker` to preserve custom artist image during periodic sync.
