### PR TITLE
Improve album art extraction and Wear OS synchronization

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
@@ -103,9 +103,10 @@ object AudioMetadataReader {
                     null
                 }
 
-                // Fallback: if TagLib couldn't read title OR artist, try JAudioTagger.
-                // This handles files with non-standard ID3 frames (e.g. 48kHz MP3s from ffmpeg).
-                val fallback = if (title == null || artist == null) {
+                // Fallback: TagLib sometimes parses core tags but misses APIC/other ID3 frames
+                // on some MP3s. If essential fields or requested artwork are missing, try
+                // JAudioTagger before giving up so we preserve full metadata when possible.
+                val fallback = if (title == null || artist == null || (readArtwork && artwork == null)) {
                     Log.w(TAG, "TagLib incomplete for ${file.name}, trying JAudioTagger fallback...")
                     readWithJAudioTagger(file)
                 } else null
@@ -134,7 +135,7 @@ object AudioMetadataReader {
 
     /**
      * Fallback reader using JAudioTagger for files where TagLib can't map ID3 frames.
-     * Only called when TagLib fails to read both title and artist.
+     * Called when TagLib leaves key metadata or requested artwork unresolved.
      */
     private fun readWithJAudioTagger(file: File): AudioMetadata? {
         return try {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
@@ -19,6 +19,7 @@ import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearThemePalette
 import com.theveloper.pixelplay.shared.WearTransferMetadata
 import com.theveloper.pixelplay.shared.WearTransferProgress
+import com.theveloper.pixelplay.utils.AlbumArtUtils
 import javax.inject.Singleton
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -357,7 +358,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
     private fun decodeBoundedBitmapFromUri(uriString: String, maxDimension: Int): Bitmap? {
         val uri = uriString.toUri()
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        contentResolver.openInputStream(uri)?.use { stream ->
+        AlbumArtUtils.openArtworkInputStream(application, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, bounds)
         } ?: return null
 
@@ -379,7 +380,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
             inMutable = false
         }
 
-        return contentResolver.openInputStream(uri)?.use { stream ->
+        return AlbumArtUtils.openArtworkInputStream(application, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, decodeOptions)
         }
     }
@@ -418,7 +419,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
             ?.takeIf { it.isNotBlank() }
             ?.let { uriString ->
                 runCatching {
-                    contentResolver.openInputStream(uriString.toUri())?.use { input ->
+                    AlbumArtUtils.openArtworkInputStream(application, uriString.toUri())?.use { input ->
                         BitmapFactory.decodeStream(
                             input,
                             null,

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -56,6 +56,7 @@ import com.theveloper.pixelplay.shared.WearTransferProgress
 import com.theveloper.pixelplay.shared.WearTransferRequest
 import com.theveloper.pixelplay.shared.WearVolumeCommand
 import com.theveloper.pixelplay.shared.WearVolumeState
+import com.theveloper.pixelplay.utils.AlbumArtUtils
 import com.theveloper.pixelplay.utils.MediaItemBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -1657,7 +1658,7 @@ class WearCommandReceiver : WearableListenerService() {
     private fun decodeBoundedBitmapFromUri(uriString: String, maxDimension: Int): Bitmap? {
         val uri = uriString.toUri()
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        contentResolver.openInputStream(uri)?.use { stream ->
+        AlbumArtUtils.openArtworkInputStream(this, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, bounds)
         } ?: return null
 
@@ -1679,7 +1680,7 @@ class WearCommandReceiver : WearableListenerService() {
             inMutable = false
         }
 
-        return contentResolver.openInputStream(uri)?.use { stream ->
+        return AlbumArtUtils.openArtworkInputStream(this, uri)?.use { stream ->
             BitmapFactory.decodeStream(stream, null, decodeOptions)
         }
     }
@@ -1718,7 +1719,7 @@ class WearCommandReceiver : WearableListenerService() {
             ?.takeIf { it.isNotBlank() }
             ?.let { uriString ->
                 runCatching {
-                    contentResolver.openInputStream(uriString.toUri())?.use { input ->
+                    AlbumArtUtils.openArtworkInputStream(this, uriString.toUri())?.use { input ->
                         BitmapFactory.decodeStream(
                             input,
                             null,

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.provider.MediaStore
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import com.theveloper.pixelplay.data.media.AudioMetadataReader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -343,7 +344,7 @@ object AlbumArtUtils {
     }
 
     private fun extractEmbeddedAlbumArtBytes(filePath: String): ByteArray? {
-        return MediaMetadataRetrieverPool.withRetriever { retriever ->
+        val retrieverArtwork = MediaMetadataRetrieverPool.withRetriever { retriever ->
             try {
                 retriever.setDataSource(filePath)
             } catch (e: IllegalArgumentException) {
@@ -358,6 +359,14 @@ object AlbumArtUtils {
 
             retriever.embeddedPicture?.takeIf { it.isNotEmpty() }
         }
+
+        if (retrieverArtwork != null) {
+            return retrieverArtwork
+        }
+
+        return runCatching {
+            AudioMetadataReader.read(File(filePath))?.artwork?.bytes?.takeIf { it.isNotEmpty() }
+        }.getOrNull()
     }
 
     private fun copyUriToCache(


### PR DESCRIPTION
- **AlbumArtUtils**:
    - Enhance `extractEmbeddedAlbumArtBytes` to use `AudioMetadataReader` as a fallback when `MediaMetadataRetriever` fails to find embedded artwork.
- **AudioMetadataReader**:
    - Update fallback logic to trigger `JAudioTagger` if artwork is requested but not found by TagLib, ensuring more reliable metadata extraction for certain MP3 files.
- **Wear OS Integration**:
    - Refactor `WearCommandReceiver` and `PhoneDirectWatchTransferCoordinator` to use `AlbumArtUtils.openArtworkInputStream` instead of direct `ContentResolver` calls for more robust bitmap decoding during watch transfers.