### PR TITLE
Implement a foreground service for watch music transfers

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/> <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
@@ -220,6 +221,10 @@
         <service
             android:name=".data.service.http.MediaFileHttpServerService"
             android:foregroundServiceType="mediaPlayback"
+            android:exported="false" />
+        <service
+            android:name=".data.service.wear.WatchTransferForegroundService"
+            android:foregroundServiceType="dataSync"
             android:exported="false" />
         <meta-data
             android:name="preloaded_fonts"

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
@@ -66,6 +66,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
             requestId = requestId,
             songId = songId,
         )
+        WatchTransferForegroundService.start(application)
         scope.launch {
             performTransfer(
                 nodeId = nodeId,

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchTransferForegroundService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WatchTransferForegroundService.kt
@@ -1,0 +1,278 @@
+package com.theveloper.pixelplay.data.service.wear
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.theveloper.pixelplay.MainActivity
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.shared.WearTransferProgress
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+class WatchTransferForegroundService : Service() {
+
+    @Inject lateinit var transferStateStore: PhoneWatchTransferStateStore
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var transferObserverJob: Job? = null
+    private var hasStartedForeground = false
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+        observeTransfers()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = buildNotification(transferStateStore.transfers.value.values.toList())
+        if (!hasStartedForeground) {
+            startInForeground(notification)
+        } else {
+            notificationManager().notify(NOTIFICATION_ID, notification)
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        transferObserverJob?.cancel()
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun observeTransfers() {
+        transferObserverJob?.cancel()
+        transferObserverJob = serviceScope.launch {
+            transferStateStore.transfers.collect { transfers ->
+                val states = transfers.values.toList()
+                if (states.isEmpty()) {
+                    stopForegroundCompat()
+                    stopSelf()
+                    return@collect
+                }
+
+                val notification = buildNotification(states)
+                if (!hasStartedForeground) {
+                    startInForeground(notification)
+                } else {
+                    notificationManager().notify(NOTIFICATION_ID, notification)
+                }
+            }
+        }
+    }
+
+    private fun startInForeground(notification: Notification) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            hasStartedForeground = true
+        } catch (error: Exception) {
+            Timber.tag(TAG).e(error, "Failed to start watch transfer foreground service")
+            stopSelf()
+        }
+    }
+
+    private fun stopForegroundCompat() {
+        if (!hasStartedForeground) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        } else {
+            @Suppress("DEPRECATION")
+            stopForeground(true)
+        }
+        hasStartedForeground = false
+    }
+
+    private fun buildNotification(transfers: List<PhoneWatchTransferState>): Notification {
+        val activeTransfers = transfers.filter { it.status == WearTransferProgress.STATUS_TRANSFERRING }
+        val selectedTransfer = activeTransfers.maxByOrNull { it.updatedAtMillis }
+            ?: transfers.maxByOrNull { it.updatedAtMillis }
+
+        val title = when {
+            activeTransfers.size > 1 -> "Sending ${activeTransfers.size} songs to watch"
+            activeTransfers.size == 1 -> "Sending to watch"
+            selectedTransfer?.status == WearTransferProgress.STATUS_COMPLETED -> "Transfer complete"
+            selectedTransfer?.status == WearTransferProgress.STATUS_FAILED -> "Transfer failed"
+            selectedTransfer?.status == WearTransferProgress.STATUS_CANCELLED -> "Transfer cancelled"
+            else -> "Preparing watch transfer"
+        }
+
+        val contentText = buildContentText(selectedTransfer, activeTransfers.size)
+        val progressPercent = (selectedTransfer?.progress?.times(100f) ?: 0f).toInt().coerceIn(0, 100)
+        val isIndeterminate = selectedTransfer == null ||
+            (selectedTransfer.status == WearTransferProgress.STATUS_TRANSFERRING && selectedTransfer.totalBytes <= 0L)
+        val isOngoing = activeTransfers.isNotEmpty()
+
+        val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.monochrome_player)
+            .setContentTitle(title)
+            .setContentText(contentText)
+            .setContentIntent(createOpenAppPendingIntent())
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
+            .setSilent(true)
+            .setOngoing(isOngoing)
+            .setShowWhen(false)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+
+        if (isOngoing) {
+            builder.setProgress(100, progressPercent, isIndeterminate)
+        } else {
+            builder.setProgress(0, 0, false)
+        }
+
+        if (transfers.size > 1) {
+            val style = NotificationCompat.InboxStyle()
+                .setSummaryText("${transfers.size} transfers")
+            transfers
+                .sortedByDescending { it.updatedAtMillis }
+                .take(MAX_STYLE_LINES)
+                .forEach { transfer ->
+                    style.addLine(formatTransferLine(transfer))
+                }
+            builder.setStyle(style)
+        } else {
+            val detailText = buildDetailedText(selectedTransfer)
+            if (detailText.isNotBlank()) {
+                builder.setStyle(NotificationCompat.BigTextStyle().bigText(detailText))
+            }
+        }
+
+        return builder.build()
+    }
+
+    private fun buildContentText(
+        transfer: PhoneWatchTransferState?,
+        activeTransferCount: Int,
+    ): String {
+        if (transfer == null) return "Starting transfer..."
+
+        if (activeTransferCount > 1) {
+            return transfer.songTitle.ifBlank { "Multiple active transfers" }
+        }
+
+        val songTitle = transfer.songTitle.ifBlank { "Preparing transfer..." }
+        val bytesText = formatBytesText(transfer)
+        return if (bytesText != null) {
+            "$songTitle • $bytesText"
+        } else {
+            songTitle
+        }
+    }
+
+    private fun buildDetailedText(transfer: PhoneWatchTransferState?): String {
+        if (transfer == null) return "Starting transfer..."
+
+        val statusLine = when (transfer.status) {
+            WearTransferProgress.STATUS_TRANSFERRING -> "Transferring"
+            WearTransferProgress.STATUS_COMPLETED -> "Completed"
+            WearTransferProgress.STATUS_FAILED -> "Failed"
+            WearTransferProgress.STATUS_CANCELLED -> "Cancelled"
+            else -> "Preparing"
+        }
+        val bytesLine = formatBytesText(transfer)
+        val errorLine = transfer.error?.takeIf { it.isNotBlank() }
+
+        return listOfNotNull(
+            transfer.songTitle.ifBlank { null },
+            statusLine,
+            bytesLine,
+            errorLine,
+        ).joinToString(separator = "\n")
+    }
+
+    private fun formatTransferLine(transfer: PhoneWatchTransferState): String {
+        val title = transfer.songTitle.ifBlank { transfer.songId }
+        val status = when (transfer.status) {
+            WearTransferProgress.STATUS_TRANSFERRING -> {
+                val percent = (transfer.progress * 100f).toInt().coerceIn(0, 100)
+                if (transfer.totalBytes > 0L) "$percent%" else "Starting"
+            }
+            WearTransferProgress.STATUS_COMPLETED -> "Completed"
+            WearTransferProgress.STATUS_FAILED -> "Failed"
+            WearTransferProgress.STATUS_CANCELLED -> "Cancelled"
+            else -> "Preparing"
+        }
+        return "$title • $status"
+    }
+
+    private fun formatBytesText(transfer: PhoneWatchTransferState): String? {
+        if (transfer.totalBytes <= 0L) return null
+        val sent = Formatter.formatShortFileSize(this, transfer.bytesTransferred)
+        val total = Formatter.formatShortFileSize(this, transfer.totalBytes)
+        return "$sent / $total"
+    }
+
+    private fun createOpenAppPendingIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        return PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Watch Transfers",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply {
+            description = "Shows live progress for phone-to-watch music transfers"
+            setShowBadge(false)
+        }
+        notificationManager().createNotificationChannel(channel)
+    }
+
+    private fun notificationManager(): NotificationManager {
+        return getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    companion object {
+        private const val TAG = "WatchTransferFgSvc"
+        private const val NOTIFICATION_CHANNEL_ID = "pixelplay_watch_transfers"
+        private const val NOTIFICATION_ID = 1003
+        private const val MAX_STYLE_LINES = 5
+
+        fun start(context: Context) {
+            val intent = Intent(context, WatchTransferForegroundService::class.java)
+            runCatching {
+                ContextCompat.startForegroundService(context, intent)
+            }.onFailure { error ->
+                Timber.tag(TAG).w(error, "Failed to start watch transfer foreground service")
+            }
+        }
+    }
+}


### PR DESCRIPTION
- **WatchTransferForegroundService**: Create a new `ForegroundService` to handle and display the progress of music transfers from phone to watch. It includes logic for notification management, dynamic progress updates, and multi-transfer tracking using `InboxStyle`.
- **PhoneDirectWatchTransferCoordinator**: Integrate the new service by calling `WatchTransferForegroundService.start()` when a transfer is initiated.
- **AndroidManifest.xml**:
    - Declare `WatchTransferForegroundService` with the `dataSync` foreground service type.
    - Add the `FOREGROUND_SERVICE_DATA_SYNC` permission.