### PR TITLE
Implement transient local playback on Wear OS via on-demand phone str…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
@@ -9,25 +9,34 @@ import android.os.Build
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.core.graphics.get
 import androidx.core.net.toUri
+import com.theveloper.pixelplay.data.gdrive.GDriveStreamProxy
 import com.google.android.gms.wearable.Wearable
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.navidrome.NavidromeStreamProxy
+import com.theveloper.pixelplay.data.netease.NeteaseStreamProxy
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
 import com.theveloper.pixelplay.data.preferences.ThemePreferencesRepository
 import com.theveloper.pixelplay.data.preferences.ThemePreference
+import com.theveloper.pixelplay.data.qqmusic.QqMusicStreamProxy
 import com.theveloper.pixelplay.data.repository.MusicRepository
+import com.theveloper.pixelplay.data.telegram.TelegramRepository
+import com.theveloper.pixelplay.data.telegram.TelegramStreamProxy
 import com.theveloper.pixelplay.presentation.viewmodel.ColorSchemeProcessor
 import com.theveloper.pixelplay.shared.WearDataPaths
 import com.theveloper.pixelplay.shared.WearThemePalette
 import com.theveloper.pixelplay.shared.WearTransferMetadata
 import com.theveloper.pixelplay.shared.WearTransferProgress
+import com.theveloper.pixelplay.shared.WearTransferRequest
 import com.theveloper.pixelplay.utils.AlbumArtUtils
 import javax.inject.Singleton
 import java.io.ByteArrayOutputStream
+import java.io.Closeable
 import java.io.File
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -38,6 +47,8 @@ import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import timber.log.Timber
 
 @Singleton
@@ -48,6 +59,13 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
     private val colorSchemeProcessor: ColorSchemeProcessor,
     private val transferStateStore: PhoneWatchTransferStateStore,
     private val transferCancellationStore: PhoneWatchTransferCancellationStore,
+    private val telegramRepository: TelegramRepository,
+    private val telegramStreamProxy: Lazy<TelegramStreamProxy>,
+    private val neteaseStreamProxy: NeteaseStreamProxy,
+    private val qqMusicStreamProxy: QqMusicStreamProxy,
+    private val navidromeStreamProxy: NavidromeStreamProxy,
+    private val gDriveStreamProxy: GDriveStreamProxy,
+    private val okHttpClient: OkHttpClient,
 ) {
     private val contentResolver by lazy { application.contentResolver }
     private val messageClient by lazy { Wearable.getMessageClient(application) }
@@ -57,10 +75,27 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
     private val albumPaletteSeedCache = ConcurrentHashMap<Long, Int>()
     private val albumArtworkTransferCache = ConcurrentHashMap<Long, ByteArray>()
 
+    private data class OpenedSongSource(
+        val inputStream: InputStream,
+        val fileSize: Long,
+        private val closeable: Closeable? = null,
+    ) : Closeable {
+        override fun close() {
+            if (closeable != null) {
+                closeable.close()
+            } else {
+                inputStream.close()
+            }
+        }
+    }
+
     fun startTransferToWatch(
         nodeId: String,
         requestId: String,
         songId: String,
+        transferMode: String = WearTransferRequest.MODE_SAVE_TO_LIBRARY,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = false,
     ) {
         transferStateStore.markRequested(
             requestId = requestId,
@@ -72,6 +107,9 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 nodeId = nodeId,
                 requestId = requestId,
                 songId = songId,
+                transferMode = transferMode,
+                startPositionMs = startPositionMs,
+                autoPlay = autoPlay,
             )
         }
     }
@@ -80,8 +118,11 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         nodeId: String,
         requestId: String,
         songId: String,
+        transferMode: String,
+        startPositionMs: Long,
+        autoPlay: Boolean,
     ) {
-        var openedInputStream: InputStream? = null
+        var openedSongSource: OpenedSongSource? = null
         try {
             val song = musicRepository.getSongsByIds(listOf(songId)).first().firstOrNull()
             if (song == null) {
@@ -94,7 +135,10 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 return
             }
 
-            if (!isSongTransferEligible(song)) {
+            if (
+                transferMode == WearTransferRequest.MODE_SAVE_TO_LIBRARY &&
+                !isSongTransferEligible(song)
+            ) {
                 sendTransferMetadataError(
                     nodeId = nodeId,
                     requestId = requestId,
@@ -104,19 +148,26 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 return
             }
 
-            val fileInputStream = openSongFile(song)
-            if (fileInputStream == null) {
+            val songSource = openSongSource(
+                song = song,
+                allowProxyStreaming = transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK,
+            )
+            if (songSource == null) {
                 sendTransferMetadataError(
                     nodeId = nodeId,
                     requestId = requestId,
                     songId = song.id,
-                    errorMessage = "Cannot read audio file",
+                    errorMessage = if (transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK) {
+                        "Cannot stream audio source to watch"
+                    } else {
+                        "Cannot read audio file"
+                    },
                 )
                 return
             }
-            openedInputStream = fileInputStream
+            openedSongSource = songSource
 
-            val fileSize = getSongFileSize(song)
+            val fileSize = songSource.fileSize
             val paletteSeedArgb = resolvePaletteSeedArgb(song)
             val transferThemePalette = resolveTransferThemePalette(song)
             val transferArtworkBytes = resolveTransferArtworkBytes(song)
@@ -136,6 +187,9 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 isFavorite = song.isFavorite,
                 paletteSeedArgb = paletteSeedArgb,
                 themePalette = transferThemePalette,
+                transferMode = transferMode,
+                startPositionMs = startPositionMs,
+                autoPlay = autoPlay,
             )
             transferStateStore.markMetadata(
                 requestId = requestId,
@@ -168,6 +222,8 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                     transfer.error == WearTransferProgress.ERROR_ALREADY_ON_WATCH
             } == true
             if (duplicateRejected) {
+                runCatching { openedSongSource?.close() }
+                openedSongSource = null
                 return
             }
 
@@ -193,6 +249,8 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                     totalBytes = fileSize,
                     status = WearTransferProgress.STATUS_CANCELLED,
                 )
+                runCatching { openedSongSource?.close() }
+                openedSongSource = null
                 return
             }
 
@@ -200,10 +258,11 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 nodeId = nodeId,
                 requestId = requestId,
                 songId = song.id,
-                inputStream = fileInputStream,
+                inputStream = songSource.inputStream,
                 fileSize = fileSize,
             )
-            openedInputStream = null
+            runCatching { songSource.close() }
+            openedSongSource = null
         } catch (error: Exception) {
             Timber.tag(TAG).e(error, "Direct transfer failed for songId=%s", songId)
             sendTransferProgress(
@@ -215,7 +274,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 status = WearTransferProgress.STATUS_FAILED,
                 error = error.message,
             )
-            runCatching { openedInputStream?.close() }
+            runCatching { openedSongSource?.close() }
         }
     }
 
@@ -253,31 +312,188 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
         }
     }
 
-    private fun openSongFile(song: Song): InputStream? {
-        return try {
-            val file = File(song.path)
-            if (file.exists() && file.canRead()) {
-                file.inputStream()
-            } else {
-                contentResolver.openInputStream(song.contentUriString.toUri())
+    private suspend fun openSongSource(
+        song: Song,
+        allowProxyStreaming: Boolean,
+    ): OpenedSongSource? {
+        openDirectSongSource(song)?.let { return it }
+        if (!allowProxyStreaming) return null
+
+        val streamUrl = resolveStreamUrl(song) ?: return null
+        return openHttpSongSource(streamUrl)
+    }
+
+    private fun openDirectSongSource(song: Song): OpenedSongSource? {
+        val directFile = song.path
+            .takeIf { it.isNotBlank() }
+            ?.let(::File)
+            ?.takeIf { it.isFile && it.canRead() && it.length() > 0L }
+        if (directFile != null) {
+            return runCatching {
+                OpenedSongSource(
+                    inputStream = directFile.inputStream(),
+                    fileSize = directFile.length(),
+                )
+            }.onFailure { error ->
+                Timber.tag(TAG).w(error, "Failed to open direct file for songId=%s", song.id)
+            }.getOrNull()
+        }
+
+        val rawUri = song.contentUriString
+        if (rawUri.isBlank()) return null
+        if (rawUri.startsWith("/")) {
+            val rawFile = File(rawUri)
+            if (rawFile.isFile && rawFile.canRead() && rawFile.length() > 0L) {
+                return runCatching {
+                    OpenedSongSource(
+                        inputStream = rawFile.inputStream(),
+                        fileSize = rawFile.length(),
+                    )
+                }.getOrNull()
             }
-        } catch (error: Exception) {
-            Timber.tag(TAG).w(error, "Failed to open song file: %s", song.path)
-            runCatching { contentResolver.openInputStream(song.contentUriString.toUri()) }.getOrNull()
+        }
+
+        val uri = runCatching { rawUri.toUri() }.getOrNull() ?: return null
+        return when (uri.scheme?.lowercase()) {
+            "file" -> {
+                val uriFile = uri.path?.let(::File)
+                    ?.takeIf { it.isFile && it.canRead() && it.length() > 0L }
+                    ?: return null
+                runCatching {
+                    OpenedSongSource(
+                        inputStream = uriFile.inputStream(),
+                        fileSize = uriFile.length(),
+                    )
+                }.getOrNull()
+            }
+
+            "content" -> {
+                runCatching {
+                    val inputStream = contentResolver.openInputStream(uri) ?: return@runCatching null
+                    val size = contentResolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
+                        afd.length.takeIf { it > 0L } ?: afd.declaredLength.takeIf { it > 0L }
+                    } ?: 0L
+                    OpenedSongSource(
+                        inputStream = inputStream,
+                        fileSize = size.coerceAtLeast(0L),
+                    )
+                }.onFailure { error ->
+                    Timber.tag(TAG).w(error, "Failed to open content source for songId=%s", song.id)
+                }.getOrNull()
+            }
+
+            else -> null
         }
     }
 
-    private fun getSongFileSize(song: Song): Long {
-        val file = File(song.path)
-        if (file.exists()) return file.length()
-
-        return try {
-            contentResolver.openAssetFileDescriptor(song.contentUriString.toUri(), "r")?.use {
-                it.length
-            } ?: 0L
-        } catch (_: Exception) {
-            0L
+    private suspend fun resolveStreamUrl(song: Song): String? {
+        val rawUri = song.contentUriString
+        val uri = runCatching { rawUri.toUri() }.getOrNull() ?: return null
+        return when (uri.scheme?.lowercase()) {
+            "http", "https" -> rawUri
+            "telegram" -> resolveTelegramStreamUrl(song, uri, rawUri)
+            "netease" -> {
+                ensureCloudProxyReady(neteaseStreamProxy) || return null
+                neteaseStreamProxy.resolveNeteaseUri(rawUri)
+            }
+            "qqmusic" -> {
+                ensureCloudProxyReady(qqMusicStreamProxy) || return null
+                qqMusicStreamProxy.warmUpStreamUrl(rawUri)
+                qqMusicStreamProxy.resolveQqMusicUri(rawUri)
+            }
+            "navidrome" -> {
+                ensureCloudProxyReady(navidromeStreamProxy) || return null
+                navidromeStreamProxy.warmUpStreamUrl(rawUri)
+                navidromeStreamProxy.resolveNavidromeUri(rawUri)
+            }
+            "gdrive" -> {
+                ensureGDriveProxyReady() || return null
+                gDriveStreamProxy.resolveGDriveUri(rawUri)
+            }
+            else -> null
         }
+    }
+
+    private suspend fun resolveTelegramStreamUrl(song: Song, uri: android.net.Uri, rawUri: String): String? {
+        if (!telegramRepository.isReady()) {
+            val ready = telegramRepository.awaitReady(10_000L)
+            if (!ready) {
+                Timber.tag(TAG).w("Telegram repository not ready for watch handoff")
+                return null
+            }
+        }
+
+        val resolved = telegramRepository.resolveTelegramUri(rawUri)
+        val fileId = resolved?.first
+            ?: song.telegramFileId
+            ?: uri.host?.toIntOrNull()
+            ?: uri.pathSegments.firstOrNull()?.toIntOrNull()
+            ?: return null
+        val knownSize = (resolved?.second ?: 0L).coerceAtLeast(0L)
+
+        val proxy = telegramStreamProxy.get()
+        if (!proxy.isReady()) {
+            proxy.start()
+            val ready = proxy.awaitReady(5_000L)
+            if (!ready) {
+                Timber.tag(TAG).w("Telegram stream proxy not ready for watch handoff")
+                return null
+            }
+        }
+        return proxy.getProxyUrl(fileId, knownSize)
+    }
+
+    private suspend fun ensureCloudProxyReady(proxy: Any): Boolean {
+        return when (proxy) {
+            is NeteaseStreamProxy -> {
+                if (!proxy.isReady()) proxy.start()
+                proxy.awaitReady(5_000L)
+            }
+            is QqMusicStreamProxy -> {
+                if (!proxy.isReady()) proxy.start()
+                proxy.awaitReady(5_000L)
+            }
+            is NavidromeStreamProxy -> {
+                if (!proxy.isReady()) proxy.start()
+                proxy.awaitReady(5_000L)
+            }
+            else -> false
+        }
+    }
+
+    private suspend fun ensureGDriveProxyReady(): Boolean {
+        if (gDriveStreamProxy.isReady()) return true
+        gDriveStreamProxy.start()
+        repeat(50) {
+            if (gDriveStreamProxy.isReady()) return true
+            delay(100L)
+        }
+        Timber.tag(TAG).w("GDrive stream proxy not ready for watch handoff")
+        return false
+    }
+
+    private suspend fun openHttpSongSource(url: String): OpenedSongSource? {
+        val response = withContext(Dispatchers.IO) {
+            okHttpClient.newCall(
+                Request.Builder()
+                    .url(url)
+                    .get()
+                    .build()
+            ).execute()
+        }
+        if (!response.isSuccessful) {
+            Timber.tag(TAG).w("Watch handoff stream request failed: code=%d url=%s", response.code, url)
+            response.close()
+            return null
+        }
+
+        val body = response.body
+
+        return OpenedSongSource(
+            inputStream = body.byteStream(),
+            fileSize = body.contentLength().coerceAtLeast(0L),
+            closeable = response,
+        )
     }
 
     private fun resolvePaletteSeedArgb(song: Song): Int? {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -442,6 +442,9 @@ class WearCommandReceiver : WearableListenerService() {
             nodeId = messageEvent.sourceNodeId,
             requestId = request.requestId,
             songId = request.songId,
+            transferMode = request.transferMode,
+            startPositionMs = request.startPositionMs,
+            autoPlay = request.autoPlay,
         )
     }
 

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferMetadata.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferMetadata.kt
@@ -26,5 +26,11 @@ data class WearTransferMetadata(
     val paletteSeedArgb: Int? = null,
     /** Full watch palette snapshot so local watch playback matches phone playback exactly. */
     val themePalette: WearThemePalette? = null,
+    /** Mirrors the request mode so the watch knows whether to persist the received audio. */
+    val transferMode: String = WearTransferRequest.MODE_SAVE_TO_LIBRARY,
+    /** Position to restore when local playback starts on watch. */
+    val startPositionMs: Long = 0L,
+    /** Whether playback should start automatically once the transfer finishes. */
+    val autoPlay: Boolean = false,
     val error: String? = null,
 )

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferRequest.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearTransferRequest.kt
@@ -10,4 +10,15 @@ import kotlinx.serialization.Serializable
 data class WearTransferRequest(
     val requestId: String,
     val songId: String,
-)
+    /** Whether the transfer should be persisted on watch or used only for transient playback. */
+    val transferMode: String = MODE_SAVE_TO_LIBRARY,
+    /** Position to restore when the watch starts playback. */
+    val startPositionMs: Long = 0L,
+    /** Whether playback should start automatically once the watch has the audio. */
+    val autoPlay: Boolean = false,
+) {
+    companion object {
+        const val MODE_SAVE_TO_LIBRARY = "save_to_library"
+        const val MODE_TEMPORARY_PLAYBACK = "temporary_playback"
+    }
+}

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearLocalPlayerRepository.kt
@@ -103,6 +103,8 @@ class WearLocalPlayerRepository @Inject constructor(
     private var currentQueueItemsById: Map<String, WearQueueSong> = emptyMap()
     private var lastPaletteSongId: String = ""
     private var lastArtworkSongId: String = ""
+    private var transientSongIds: Set<String> = emptySet()
+    private var transientCleanupPaths: Set<String> = emptySet()
 
     companion object {
         private const val TAG = "WearLocalPlayer"
@@ -173,7 +175,12 @@ class WearLocalPlayerRepository @Inject constructor(
     /**
      * Start local playback with the given songs, beginning at [startIndex].
      */
-    fun playLocalSongs(songs: List<LocalSongEntity>, startIndex: Int = 0) {
+    fun playLocalSongs(
+        songs: List<LocalSongEntity>,
+        startIndex: Int = 0,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = true,
+    ) {
         scope.launch {
             val playableSongs = songs.filter { song ->
                 val file = File(song.localPath)
@@ -197,6 +204,8 @@ class WearLocalPlayerRepository @Inject constructor(
                 queueSongs = queueSongs,
                 queueSongIdToLocal = playableSongs.associateBy { it.songId },
                 startIndex = startIndex,
+                startPositionMs = startPositionMs,
+                autoPlay = autoPlay,
             )
         }
     }
@@ -204,7 +213,12 @@ class WearLocalPlayerRepository @Inject constructor(
     /**
      * Start local playback from watch MediaStore songs.
      */
-    fun playUriSongs(songs: List<WearQueueSong>, startIndex: Int = 0) {
+    fun playUriSongs(
+        songs: List<WearQueueSong>,
+        startIndex: Int = 0,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = true,
+    ) {
         scope.launch {
             if (songs.isEmpty()) {
                 Timber.tag(TAG).w("No watch library songs available")
@@ -214,6 +228,43 @@ class WearLocalPlayerRepository @Inject constructor(
                 queueSongs = songs,
                 queueSongIdToLocal = emptyMap(),
                 startIndex = startIndex,
+                startPositionMs = startPositionMs,
+                autoPlay = autoPlay,
+            )
+        }
+    }
+
+    fun playTemporarySong(
+        song: LocalSongEntity,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = true,
+        cleanupPaths: Set<String> = emptySet(),
+    ) {
+        scope.launch {
+            val file = File(song.localPath)
+            if (!file.isFile || file.length() <= 0L) {
+                Timber.tag(TAG).w("Temporary playback file missing for songId=%s", song.songId)
+                return@launch
+            }
+
+            startPlayback(
+                queueSongs = listOf(
+                    WearQueueSong(
+                        songId = song.songId,
+                        title = song.title,
+                        artist = song.artist,
+                        album = song.album,
+                        uri = Uri.fromFile(file),
+                    )
+                ),
+                queueSongIdToLocal = mapOf(song.songId to song),
+                startIndex = 0,
+                startPositionMs = startPositionMs,
+                autoPlay = autoPlay,
+                transientSongIds = setOf(song.songId),
+                transientCleanupPaths = cleanupPaths +
+                    setOf(song.localPath) +
+                    listOfNotNull(song.artworkPath),
             )
         }
     }
@@ -222,9 +273,17 @@ class WearLocalPlayerRepository @Inject constructor(
         queueSongs: List<WearQueueSong>,
         queueSongIdToLocal: Map<String, LocalSongEntity>,
         startIndex: Int,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = true,
+        transientSongIds: Set<String> = emptySet(),
+        transientCleanupPaths: Set<String> = emptySet(),
     ) {
         withContext(Dispatchers.Main) {
             val player = getOrCreatePlayer()
+            if (this@WearLocalPlayerRepository.transientCleanupPaths.isNotEmpty()) {
+                player.stop()
+            }
+            clearTransientPlaybackArtifacts()
             currentQueueSongIds = queueSongs.map { it.songId }
             val latestSongsById = queueSongIdToLocal.keys.mapNotNull { songId ->
                 localSongDao.getSongById(songId)
@@ -233,6 +292,10 @@ class WearLocalPlayerRepository @Inject constructor(
                 latestSongsById[songId] ?: song
             }
             currentQueueItemsById = queueSongs.associateBy { it.songId }
+            this@WearLocalPlayerRepository.transientSongIds = transientSongIds
+            this@WearLocalPlayerRepository.transientCleanupPaths = transientCleanupPaths
+                .filter { it.isNotBlank() }
+                .toSet()
             lastPaletteSongId = ""
             lastArtworkSongId = ""
             _localThemePalette.value = null
@@ -253,16 +316,25 @@ class WearLocalPlayerRepository @Inject constructor(
                     .build()
             }
             val startIndexSafe = startIndex.coerceIn(0, mediaItems.lastIndex)
-            player.setMediaItems(mediaItems, startIndexSafe, 0L)
+            player.setMediaItems(mediaItems, startIndexSafe, startPositionMs.coerceAtLeast(0L))
             player.prepare()
-            player.play()
+            player.playWhenReady = autoPlay
+            if (autoPlay) {
+                player.play()
+            } else {
+                player.pause()
+            }
             _isLocalPlaybackActive.value = true
             updateQueueState(currentIndex = startIndexSafe)
             updateState()
             Timber.tag(TAG).d(
-                "Playing locally: ${queueSongs.getOrNull(startIndexSafe)?.title}, queue=${queueSongs.size}"
+                "Playing locally: ${queueSongs.getOrNull(startIndexSafe)?.title}, queue=${queueSongs.size}, autoPlay=$autoPlay"
             )
         }
+    }
+
+    fun play() {
+        exoPlayer?.play()
     }
 
     fun togglePlayPause() {
@@ -373,6 +445,7 @@ class WearLocalPlayerRepository @Inject constructor(
         mediaSession = null
         exoPlayer?.release()
         exoPlayer = null
+        clearTransientPlaybackArtifacts()
         _isLocalPlaybackActive.value = false
         _localPlayerState.value = WearLocalPlayerState()
         _localThemePalette.value = null
@@ -400,13 +473,24 @@ class WearLocalPlayerRepository @Inject constructor(
             currentPositionMs = player.currentPosition,
             totalDurationMs = player.duration.coerceAtLeast(0L),
             isFavorite = currentLocalSong?.isFavorite == true,
-            canToggleFavorite = currentLocalSong != null,
+            canToggleFavorite = currentLocalSong != null && currentItem?.mediaId !in transientSongIds,
             isShuffleEnabled = player.shuffleModeEnabled,
             repeatMode = player.repeatMode,
         )
         updateQueueState(currentIndex = player.currentMediaItemIndex)
         updatePaletteForSong(currentItem?.mediaId.orEmpty())
         updateArtworkForSong(currentItem?.mediaId.orEmpty())
+    }
+
+    private fun clearTransientPlaybackArtifacts() {
+        transientCleanupPaths.forEach { path ->
+            runCatching { File(path).delete() }
+                .onFailure { error ->
+                    Timber.tag(TAG).w(error, "Failed to delete transient playback artifact: %s", path)
+                }
+        }
+        transientCleanupPaths = emptySet()
+        transientSongIds = emptySet()
     }
 
     private fun startPositionUpdates() {

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackController.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackController.kt
@@ -53,6 +53,8 @@ class WearPlaybackController @Inject constructor(
     }
 
     // Convenience methods for common actions
+    fun play() = sendCommand(WearPlaybackCommand(WearPlaybackCommand.PLAY))
+    fun pause() = sendCommand(WearPlaybackCommand(WearPlaybackCommand.PAUSE))
     fun togglePlayPause() = sendCommand(WearPlaybackCommand(WearPlaybackCommand.TOGGLE_PLAY_PAUSE))
     fun next() = sendCommand(WearPlaybackCommand(WearPlaybackCommand.NEXT))
     fun previous() = sendCommand(WearPlaybackCommand(WearPlaybackCommand.PREVIOUS))

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
@@ -73,6 +73,9 @@ class WearTransferRepository @Inject constructor(
     private val channelClient: ChannelClient,
     private val messageClient: MessageClient,
     private val nodeClient: NodeClient,
+    private val localPlayerRepository: WearLocalPlayerRepository,
+    private val stateRepository: WearStateRepository,
+    private val playbackController: WearPlaybackController,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val json = Json { ignoreUnknownKeys = true }
@@ -112,6 +115,8 @@ class WearTransferRepository @Inject constructor(
 
     /** Artwork bytes received before/while audio transfer: requestId -> bytes */
     private val pendingArtworkByRequestId = ConcurrentHashMap<String, ByteArray>()
+    /** Temporary handoff requests waiting to become local watch playback. */
+    private val pendingTemporaryPlaybackRequests = ConcurrentHashMap<String, PendingTemporaryPlaybackRequest>()
 
     /** Failsafe timeout per transfer to avoid hanging states at 0%. */
     private val transferWatchdogs = ConcurrentHashMap<String, Job>()
@@ -131,6 +136,14 @@ class WearTransferRepository @Inject constructor(
         private const val CANCELLED_REQUEST_RETENTION_MS = 300_000L
     }
 
+    private data class PendingTemporaryPlaybackRequest(
+        val songId: String,
+        val startPositionMs: Long,
+        val autoPlay: Boolean,
+        val pausePhoneAfterStart: Boolean,
+        val requestedAtElapsedMs: Long,
+    )
+
     init {
         scope.launch {
             downloadedSongIds
@@ -149,6 +162,9 @@ class WearTransferRepository @Inject constructor(
         songId: String,
         requestId: String = UUID.randomUUID().toString(),
         targetNodeId: String? = null,
+        transferMode: String = WearTransferRequest.MODE_SAVE_TO_LIBRARY,
+        startPositionMs: Long = 0L,
+        autoPlay: Boolean = false,
     ) {
         // Don't request if already transferring this song
         if (songToRequestId.containsKey(songId)) {
@@ -170,6 +186,18 @@ class WearTransferRepository @Inject constructor(
 
             clearStaleTransfersForSong(songId)
             songToRequestId[songId] = requestId
+            if (
+                transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK &&
+                !pendingTemporaryPlaybackRequests.containsKey(requestId)
+            ) {
+                pendingTemporaryPlaybackRequests[requestId] = PendingTemporaryPlaybackRequest(
+                    songId = songId,
+                    startPositionMs = startPositionMs,
+                    autoPlay = autoPlay,
+                    pausePhoneAfterStart = false,
+                    requestedAtElapsedMs = SystemClock.elapsedRealtime(),
+                )
+            }
 
             _activeTransfers.update { map ->
                 map + (requestId to TransferState(
@@ -184,7 +212,13 @@ class WearTransferRepository @Inject constructor(
             armTransferWatchdog(requestId, songId)
 
             try {
-                val request = WearTransferRequest(requestId, songId)
+                val request = WearTransferRequest(
+                    requestId = requestId,
+                    songId = songId,
+                    transferMode = transferMode,
+                    startPositionMs = startPositionMs,
+                    autoPlay = autoPlay,
+                )
                 val requestBytes = json.encodeToString(request).toByteArray(Charsets.UTF_8)
 
                 if (targetNodeId != null) {
@@ -213,6 +247,33 @@ class WearTransferRepository @Inject constructor(
                 handleTransferError(requestId, songId, e.message ?: "Failed to send request")
             }
         }
+    }
+
+    fun requestTemporaryPlayback(
+        songId: String,
+        startPositionMs: Long,
+        autoPlay: Boolean,
+        pausePhoneAfterStart: Boolean,
+    ) {
+        if (songToRequestId.containsKey(songId)) {
+            Timber.tag(TAG).d("Temporary watch playback already requested for songId=%s", songId)
+            return
+        }
+        val requestId = UUID.randomUUID().toString()
+        pendingTemporaryPlaybackRequests[requestId] = PendingTemporaryPlaybackRequest(
+            songId = songId,
+            startPositionMs = startPositionMs,
+            autoPlay = autoPlay,
+            pausePhoneAfterStart = pausePhoneAfterStart,
+            requestedAtElapsedMs = SystemClock.elapsedRealtime(),
+        )
+        requestTransfer(
+            songId = songId,
+            requestId = requestId,
+            transferMode = WearTransferRequest.MODE_TEMPORARY_PLAYBACK,
+            startPositionMs = startPositionMs,
+            autoPlay = autoPlay,
+        )
     }
 
     private suspend fun notifyPhoneTransferFailure(
@@ -266,7 +327,10 @@ class WearTransferRepository @Inject constructor(
             return
         }
         val existingSong = localSongDao.getSongById(metadata.songId)
-        if (existingSong?.hasPlayableLocalFile() == true) {
+        if (
+            metadata.transferMode == WearTransferRequest.MODE_SAVE_TO_LIBRARY &&
+            existingSong?.hasPlayableLocalFile() == true
+        ) {
             notifyPhoneTransferFailure(
                 targetNodeId = sourceNodeId,
                 requestId = metadata.requestId,
@@ -551,6 +615,85 @@ class WearTransferRepository @Inject constructor(
 
             val extension = MimeTypeMap.getSingleton()
                 .getExtensionFromMimeType(resolvedMetadata.mimeType) ?: "mp3"
+            if (resolvedMetadata.transferMode == WearTransferRequest.MODE_TEMPORARY_PLAYBACK) {
+                val playbackDir = File(application.cacheDir, "temporary_playback")
+                if (!playbackDir.exists()) playbackDir.mkdirs()
+                val playbackFile = File(playbackDir, "$requestId.$extension")
+                if (playbackFile.exists() && !playbackFile.delete()) {
+                    tempFile.delete()
+                    handleTransferError(requestId, resolvedMetadata.songId, "Couldn't replace temporary playback file")
+                    return
+                }
+
+                if (playbackFile.absolutePath != tempFile.absolutePath) {
+                    val renamed = tempFile.renameTo(playbackFile)
+                    if (!renamed) {
+                        runCatching {
+                            tempFile.inputStream().use { input ->
+                                playbackFile.outputStream().use { output ->
+                                    input.copyTo(output)
+                                }
+                            }
+                        }.onFailure { error ->
+                            tempFile.delete()
+                            playbackFile.delete()
+                            throw error
+                        }
+                        if (!tempFile.delete()) {
+                            Timber.tag(TAG).w("Failed to delete temp playback staging file for requestId=%s", requestId)
+                        }
+                    }
+                }
+
+                val artworkPath = consumeAndPersistPendingArtwork(
+                    requestId = requestId,
+                    artworkKey = "temp_$requestId",
+                )
+                val pendingPlayback = pendingTemporaryPlaybackRequests.remove(requestId)
+                val resolvedStartPositionMs = resolveTemporaryPlaybackStartPosition(
+                    requestId = requestId,
+                    metadata = resolvedMetadata,
+                    pendingPlayback = pendingPlayback,
+                )
+                localPlayerRepository.playTemporarySong(
+                    song = LocalSongEntity(
+                        songId = resolvedMetadata.songId,
+                        title = resolvedMetadata.title,
+                        artist = resolvedMetadata.artist,
+                        album = resolvedMetadata.album,
+                        albumId = resolvedMetadata.albumId,
+                        duration = resolvedMetadata.duration,
+                        mimeType = resolvedMetadata.mimeType,
+                        fileSize = actualSize,
+                        bitrate = resolvedMetadata.bitrate,
+                        sampleRate = resolvedMetadata.sampleRate,
+                        isFavorite = resolvedMetadata.isFavorite,
+                        favoriteSyncPending = false,
+                        paletteSeedArgb = resolvedMetadata.paletteSeedArgb,
+                        themePaletteJson = resolvedMetadata.themePalette?.let { json.encodeToString(it) },
+                        artworkPath = artworkPath,
+                        localPath = playbackFile.absolutePath,
+                        transferredAt = System.currentTimeMillis(),
+                    ),
+                    startPositionMs = resolvedStartPositionMs,
+                    autoPlay = pendingPlayback?.autoPlay ?: resolvedMetadata.autoPlay,
+                )
+                stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+                if (pendingPlayback?.pausePhoneAfterStart == true) {
+                    playbackController.pause()
+                }
+                _activeTransfers.update { it - requestId }
+                songToRequestId.remove(resolvedMetadata.songId)
+                clearTransferWatchdog(requestId)
+                Timber.tag(TAG).d(
+                    "Temporary playback ready: %s (%d bytes) → %s",
+                    resolvedMetadata.title,
+                    actualSize,
+                    playbackFile.absolutePath,
+                )
+                return
+            }
+
             val localFile = File(musicDir, "${resolvedMetadata.songId}.$extension")
             val previousSong = localSongDao.getSongById(resolvedMetadata.songId)
 
@@ -582,7 +725,7 @@ class WearTransferRepository @Inject constructor(
 
             val artworkPath = consumeAndPersistPendingArtwork(
                 requestId = requestId,
-                songId = resolvedMetadata.songId,
+                artworkKey = resolvedMetadata.songId,
             )
 
             localSongDao.insert(
@@ -768,6 +911,7 @@ class WearTransferRepository @Inject constructor(
             map.filterValues { it.songId != songId }
         }
         staleRequestIds.forEach { staleRequestId ->
+            pendingTemporaryPlaybackRequests.remove(staleRequestId)
             pendingMetadata.remove(staleRequestId)
             pendingArtworkByRequestId.remove(staleRequestId)
             clearTransferWatchdog(staleRequestId)
@@ -792,6 +936,7 @@ class WearTransferRepository @Inject constructor(
         songId?.takeIf { it.isNotBlank() }?.let { safeSongId ->
             songToRequestId.remove(safeSongId)
         }
+        pendingTemporaryPlaybackRequests.remove(requestId)
         pendingMetadata.remove(requestId)
         pendingArtworkByRequestId.remove(requestId)
         clearTransferWatchdog(requestId)
@@ -812,10 +957,40 @@ class WearTransferRepository @Inject constructor(
             }
         }
         songToRequestId.remove(songId)
+        pendingTemporaryPlaybackRequests.remove(requestId)
         pendingMetadata.remove(requestId)
         pendingArtworkByRequestId.remove(requestId)
         clearTransferWatchdog(requestId)
         activeChannelRequestIds.remove(requestId)
+    }
+
+    private fun resolveTemporaryPlaybackStartPosition(
+        requestId: String,
+        metadata: WearTransferMetadata,
+        pendingPlayback: PendingTemporaryPlaybackRequest?,
+    ): Long {
+        val initialPositionMs = pendingPlayback?.startPositionMs ?: metadata.startPositionMs
+        if (!(pendingPlayback?.autoPlay ?: metadata.autoPlay)) {
+            return initialPositionMs.coerceAtLeast(0L)
+        }
+
+        val requestedAtElapsedMs = pendingPlayback?.requestedAtElapsedMs
+            ?: return initialPositionMs.coerceAtLeast(0L)
+        val elapsedMs = (SystemClock.elapsedRealtime() - requestedAtElapsedMs).coerceAtLeast(0L)
+        val adjustedPositionMs = initialPositionMs.coerceAtLeast(0L) + elapsedMs
+        val clampedPositionMs = if (metadata.duration > 0L) {
+            adjustedPositionMs.coerceAtMost(metadata.duration)
+        } else {
+            adjustedPositionMs
+        }
+        Timber.tag(TAG).d(
+            "Resolved temporary playback start for requestId=%s: base=%d elapsed=%d final=%d",
+            requestId,
+            initialPositionMs,
+            elapsedMs,
+            clampedPositionMs,
+        )
+        return clampedPositionMs
     }
 
     private fun LocalSongEntity.hasPlayableLocalFile(): Boolean {
@@ -823,9 +998,9 @@ class WearTransferRepository @Inject constructor(
         return file.isFile && file.length() > 0L
     }
 
-    private fun consumeAndPersistPendingArtwork(requestId: String, songId: String): String? {
+    private fun consumeAndPersistPendingArtwork(requestId: String, artworkKey: String): String? {
         val artworkBytes = pendingArtworkByRequestId.remove(requestId) ?: return null
-        return persistArtwork(songId, artworkBytes)
+        return persistArtwork(artworkKey, artworkBytes)
     }
 
     private fun persistArtwork(songId: String, artworkBytes: ByteArray): String? {

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/WearPlayerViewModel.kt
@@ -172,10 +172,14 @@ class WearPlayerViewModel @Inject constructor(
 
     val canCurrentSongPlayOnWatch: StateFlow<Boolean> = combine(
         isLocalPlaybackActive,
-        playerState,
+        isPhoneConnected,
+        stateRepository.playerState,
         localSongs,
-    ) { localActive, player, songs ->
-        localActive || (player.songId.isNotBlank() && songs.any { it.songId == player.songId })
+    ) { localActive, phoneConnected, remoteState, songs ->
+        localActive || (
+            remoteState.songId.isNotBlank() &&
+                (songs.any { it.songId == remoteState.songId } || phoneConnected)
+            )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     val canCurrentSongBeFavorited: StateFlow<Boolean> = combine(
@@ -257,19 +261,51 @@ class WearPlayerViewModel @Inject constructor(
     fun selectOutput(target: WearOutputTarget) {
         when (target) {
             WearOutputTarget.WATCH -> {
-                if (localPlayerRepository.isLocalPlaybackActive.value) {
+                val remoteState = stateRepository.playerState.value
+                val remoteSongId = remoteState.songId
+                val localState = localPlayerRepository.localPlayerState.value
+
+                if (
+                    localPlayerRepository.isLocalPlaybackActive.value &&
+                    (remoteSongId.isBlank() || localState.songId == remoteSongId)
+                ) {
+                    if (remoteSongId.isNotBlank() && localState.songId == remoteSongId) {
+                        localPlayerRepository.seekTo(remoteState.currentPositionMs)
+                        if (remoteState.isPlaying) {
+                            localPlayerRepository.play()
+                            playbackController.pause()
+                        } else {
+                            localPlayerRepository.pause()
+                        }
+                    }
                     stateRepository.setOutputTarget(WearOutputTarget.WATCH)
                     return
                 }
 
-                val remoteSongId = stateRepository.playerState.value.songId
                 if (remoteSongId.isBlank()) return
                 val songs = localSongs.value
                 val startIndex = songs.indexOfFirst { it.songId == remoteSongId }
-                if (startIndex == -1 || songs.isEmpty()) return
+                if (startIndex != -1 && songs.isNotEmpty()) {
+                    localPlayerRepository.playLocalSongs(
+                        songs = songs,
+                        startIndex = startIndex,
+                        startPositionMs = remoteState.currentPositionMs,
+                        autoPlay = remoteState.isPlaying,
+                    )
+                    stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+                    if (remoteState.isPlaying) {
+                        playbackController.pause()
+                    }
+                    return
+                }
 
-                localPlayerRepository.playLocalSongs(songs, startIndex)
-                stateRepository.setOutputTarget(WearOutputTarget.WATCH)
+                if (!isPhoneConnected.value) return
+                transferRepository.requestTemporaryPlayback(
+                    songId = remoteSongId,
+                    startPositionMs = remoteState.currentPositionMs,
+                    autoPlay = remoteState.isPlaying,
+                    pausePhoneAfterStart = remoteState.isPlaying,
+                )
             }
 
             WearOutputTarget.PHONE -> {


### PR DESCRIPTION
…eaming

- **WearTransferRepository**:
    - Add `requestTemporaryPlayback` to initiate transient audio transfers that are not persisted to the permanent library.
    - Implement `PendingTemporaryPlaybackRequest` to track handoff state, including playback position and auto-play status.
    - Update `handleTransferMetadata` and `handleTransferCompletion` to support `MODE_TEMPORARY_PLAYBACK`, using the cache directory for staging.
    - Introduce `resolveTemporaryPlaybackStartPosition` to adjust the start seek time based on transfer latency.
- **WearLocalPlayerRepository**:
    - Add `playTemporarySong` to handle playback of transient files with automatic cleanup of audio and artwork artifacts upon completion or replacement.
    - Update `playLocalSongs` and `playUriSongs` to support custom start positions and `autoPlay` flags.
- **PhoneDirectWatchTransferCoordinator**:
    - Implement `openSongSource` to support streaming from various providers (Telegram, Netease, QQ Music, Navidrome, GDrive) when a direct local file is unavailable.
    - Integrate `OkHttpClient` to stream remote content directly to the watch during handoff.
    - Update metadata resolution to include transfer modes and sync current playback position/state.
- **WearPlayerViewModel**:
    - Update `selectOutput` logic to automatically trigger a temporary transfer if the current phone song is not available in the watch's local library.
    - Ensure seamless handoff by syncing playback position and pausing the phone once the watch takes over.
- **Shared**:
    - Update `WearTransferRequest` and `WearTransferMetadata` with `transferMode`, `startPositionMs`, and `autoPlay` fields.