### PR TITLE
Implement playback queue synchronization and remote control for Wear OS

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/model/PlayerInfo.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/PlayerInfo.kt
@@ -78,6 +78,7 @@ data class PlayerInfo(
     val isShuffleEnabled: Boolean = false,
     val repeatMode: Int = 0, // 0 = OFF, 1 = ONE, 2 = ALL
     val wearThemePalette: WearThemePalette? = null,
+    val wearQueueRevision: String = "",
 ) {
     // equals y hashCode para ByteArray, ya que el por defecto no es comparando contenido
     override fun equals(other: Any?): Boolean {
@@ -104,6 +105,7 @@ data class PlayerInfo(
         if (isShuffleEnabled != other.isShuffleEnabled) return false
         if (repeatMode != other.repeatMode) return false
         if (wearThemePalette != other.wearThemePalette) return false
+        if (wearQueueRevision != other.wearQueueRevision) return false
 
         return true
     }
@@ -124,6 +126,7 @@ data class PlayerInfo(
         result = 31 * result + isShuffleEnabled.hashCode()
         result = 31 * result + repeatMode
         result = 31 * result + (wearThemePalette?.hashCode() ?: 0)
+        result = 31 * result + wearQueueRevision.hashCode()
         return result
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -958,6 +958,7 @@ class MusicService : MediaLibraryService() {
         }
 
         override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+            requestWidgetFullUpdate(force = true)
             schedulePlaybackSnapshotPersist(immediate = timeline.isEmpty)
         }
 
@@ -1657,6 +1658,7 @@ class MusicService : MediaLibraryService() {
         if (old.isPlaying != new.isPlaying) return true
         if (old.albumArtUri != new.albumArtUri) return true
         if (old.isFavorite != new.isFavorite) return true
+        if (old.queue != new.queue) return true
         if (old.themeColors != new.themeColors) return true
         if (old.isShuffleEnabled != new.isShuffleEnabled) return true
         if (old.repeatMode != new.repeatMode) return true
@@ -1667,17 +1669,87 @@ class MusicService : MediaLibraryService() {
         return drift > 3000L
     }
 
+    private fun shouldPublishWearState(old: PlayerInfo, new: PlayerInfo): Boolean {
+        return shouldUpdateWidget(old, new) || old.wearQueueRevision != new.wearQueueRevision
+    }
+
     private suspend fun processWidgetUpdateInternal() {
         val playerInfo = buildPlayerInfo()
         val oldInfo = lastWidgetPlayerInfo
-        
-        if (oldInfo == null || shouldUpdateWidget(oldInfo, playerInfo)) {
+
+        val shouldUpdateWidgets = oldInfo == null || shouldUpdateWidget(oldInfo, playerInfo)
+        val shouldPublishWear = oldInfo == null || shouldPublishWearState(oldInfo, playerInfo)
+
+        if (shouldUpdateWidgets || shouldPublishWear) {
             lastWidgetPlayerInfo = playerInfo
-            val currentMediaId = resolveCurrentMediaIdForWear()
+        }
+
+        if (shouldUpdateWidgets) {
             updateGlanceWidgets(playerInfo)
+        }
+
+        if (shouldPublishWear) {
+            val currentMediaId = resolveCurrentMediaIdForWear()
             // Publish state to Wear OS watch
             wearStatePublisher.publishState(currentMediaId, playerInfo)
         }
+    }
+
+    private fun buildWearQueueRevision(
+        timeline: Timeline,
+        currentIndex: Int,
+        currentMediaId: String?,
+    ): String {
+        val remoteClient = observedCastSession?.remoteMediaClient
+            ?: castSessionManager?.currentCastSession?.remoteMediaClient
+        val remoteStatus = remoteClient?.mediaStatus
+        val remoteQueueItems = remoteStatus?.queueItems.orEmpty()
+        if (remoteQueueItems.isNotEmpty()) {
+            val remoteCurrentIndex = remoteQueueItems.indexOfFirst {
+                it.itemId == remoteStatus?.getCurrentItemId()
+            }.takeIf { it >= 0 } ?: 0
+            val remoteTokens = remoteQueueItems.map { item ->
+                item.customData
+                    ?.optString("songId")
+                    ?.takeIf { it.isNotBlank() }
+                    ?: item.media?.contentId
+                    ?: item.itemId.toString()
+            }
+            return encodeWearQueueRevision(remoteTokens, remoteCurrentIndex)
+        }
+
+        if (timeline.isEmpty) {
+            return currentMediaId.orEmpty()
+        }
+
+        val window = Timeline.Window()
+        val tokens = buildList(timeline.windowCount) {
+            for (index in 0 until timeline.windowCount) {
+                timeline.getWindow(index, window)
+                val mediaItem = window.mediaItem
+                add(
+                    mediaItem.mediaId.ifBlank {
+                        mediaItem.localConfiguration?.uri?.toString()
+                            ?: mediaItem.mediaMetadata.title?.toString()
+                            ?: index.toString()
+                    }
+                )
+            }
+        }
+        val safeCurrentIndex = currentIndex.coerceIn(0, (timeline.windowCount - 1).coerceAtLeast(0))
+        return encodeWearQueueRevision(tokens, safeCurrentIndex)
+    }
+
+    private fun encodeWearQueueRevision(queueTokens: List<String>, currentIndex: Int): String {
+        if (queueTokens.isEmpty()) return ""
+        return buildString {
+            append(currentIndex)
+            append('|')
+            queueTokens.forEachIndexed { index, token ->
+                if (index > 0) append(',')
+                append(token)
+            }
+        }.hashCode().toString()
     }
 
     private suspend fun buildPlayerInfo(): PlayerInfo {
@@ -1792,6 +1864,11 @@ class MusicService : MediaLibraryService() {
         val wearThemePalette = schemePair?.let { buildWearThemePalette(it.dark) }
 
         val isFavorite = isSongFavorite(mediaId)
+        val wearQueueRevision = buildWearQueueRevision(
+            timeline = snapshotTimeline,
+            currentIndex = snapshotWindowIndex,
+            currentMediaId = mediaId,
+        )
 
         val queueItems = mutableListOf<com.theveloper.pixelplay.data.model.QueueItem>()
         // Reuse snapshotTimeline / snapshotWindowIndex captured at the top — no extra main-thread hop
@@ -1833,6 +1910,7 @@ class MusicService : MediaLibraryService() {
             isShuffleEnabled = shuffleEnabled,
             repeatMode = repeatMode,
             wearThemePalette = wearThemePalette,
+            wearQueueRevision = wearQueueRevision,
         )
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -31,6 +31,7 @@ import com.theveloper.pixelplay.shared.WearTransferRequest
 import com.theveloper.pixelplay.shared.WearVolumeCommand
 import com.theveloper.pixelplay.utils.MediaItemBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -38,6 +39,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -121,6 +123,21 @@ class WearCommandReceiver : WearableListenerService() {
                         }
                         WearPlaybackCommand.NEXT -> controller.seekToNext()
                         WearPlaybackCommand.PREVIOUS -> controller.seekToPrevious()
+                        WearPlaybackCommand.PLAY_QUEUE_INDEX -> {
+                            val queueIndex = command.queueIndex
+                            if (queueIndex == null) {
+                                Timber.tag(TAG).w("PLAY_QUEUE_INDEX missing queueIndex")
+                            } else if (queueIndex !in 0 until controller.mediaItemCount) {
+                                Timber.tag(TAG).w(
+                                    "PLAY_QUEUE_INDEX out of bounds: %d (size=%d)",
+                                    queueIndex,
+                                    controller.mediaItemCount
+                                )
+                            } else {
+                                controller.seekToDefaultPosition(queueIndex)
+                                controller.play()
+                            }
+                        }
                         WearPlaybackCommand.TOGGLE_SHUFFLE -> {
                             controller.sendCustomCommand(
                                 SessionCommand(
@@ -373,6 +390,10 @@ class WearCommandReceiver : WearableListenerService() {
                     .map { song -> song.toWearLibraryItem() }
             }
 
+            WearBrowseRequest.QUEUE -> {
+                getCurrentQueueItems()
+            }
+
             else -> {
                 Timber.tag(TAG).w("Unknown browse type: $browseType")
                 emptyList()
@@ -387,6 +408,57 @@ class WearCommandReceiver : WearableListenerService() {
             subtitle = displayArtist,
             type = WearLibraryItem.TYPE_SONG,
         )
+    }
+
+    private suspend fun getCurrentQueueItems(): List<WearLibraryItem> {
+        val deferred = CompletableDeferred<List<WearLibraryItem>>()
+        getOrBuildMediaController { controller ->
+            runCatching {
+                buildCurrentQueueItems(controller)
+            }.onSuccess(deferred::complete)
+                .onFailure(deferred::completeExceptionally)
+        }
+        return withTimeout(5_000L) {
+            deferred.await()
+        }
+    }
+
+    private fun buildCurrentQueueItems(controller: MediaController): List<WearLibraryItem> {
+        val queueSize = controller.mediaItemCount
+        if (queueSize <= 0) return emptyList()
+
+        val currentIndex = controller.currentMediaItemIndex
+            .takeIf { it in 0 until queueSize }
+            ?: 0
+
+        val queueIndices = buildList(queueSize) {
+            for (index in currentIndex until queueSize) {
+                add(index)
+            }
+            for (index in 0 until currentIndex) {
+                add(index)
+            }
+        }
+
+        return queueIndices.map { actualIndex ->
+            val mediaItem = controller.getMediaItemAt(actualIndex)
+            val metadata = mediaItem.mediaMetadata
+            val title = metadata.title?.toString()?.takeIf { it.isNotBlank() }
+                ?: "Track ${actualIndex + 1}"
+            val artist = metadata.artist?.toString()?.takeIf { it.isNotBlank() }.orEmpty()
+            val isCurrentItem = actualIndex == currentIndex
+            WearLibraryItem(
+                id = actualIndex.toString(),
+                title = title,
+                subtitle = when {
+                    isCurrentItem && artist.isNotBlank() -> "Playing · $artist"
+                    isCurrentItem -> "Playing"
+                    artist.isNotBlank() -> artist
+                    else -> ""
+                },
+                type = WearLibraryItem.TYPE_SONG,
+            )
+        }
     }
 
     // ---- Volume handling ----

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearStatePublisher.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearStatePublisher.kt
@@ -108,6 +108,7 @@ class WearStatePublisher @Inject constructor(
             volumeLevel = volumeLevel,
             volumeMax = volumeMax,
             themePalette = buildWearThemePalette(playerInfo),
+            queueRevision = playerInfo.wearQueueRevision,
         )
 
         val stateJson = json.encodeToString(wearState)

--- a/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlayerState.kt
+++ b/shared/src/main/java/com/theveloper/pixelplay/shared/WearPlayerState.kt
@@ -31,6 +31,8 @@ data class WearPlayerState(
     val volumeMax: Int = 0,
     /** Palette snapshot generated on phone (optional). */
     val themePalette: WearThemePalette? = null,
+    /** Changes whenever the active phone queue or current queue position changes. */
+    val queueRevision: String = "",
 ) {
     val isEmpty: Boolean
         get() = songId.isEmpty()

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/MoreScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/MoreScreen.kt
@@ -85,6 +85,11 @@ fun MoreScreen(
             browseViewModel.loadItems(WearBrowseRequest.QUEUE)
         }
     }
+    LaunchedEffect(playerState.queueRevision, isPhoneConnected, isWatchOutputSelected) {
+        if (isPhoneConnected && !isWatchOutputSelected) {
+            browseViewModel.loadItems(WearBrowseRequest.QUEUE)
+        }
+    }
     LaunchedEffect(
         isWatchOutputSelected,
         isPhoneConnected,

--- a/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/QueueScreen.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/presentation/screens/QueueScreen.kt
@@ -98,7 +98,7 @@ fun QueueScreen(
             browseViewModel.loadItems(WearBrowseRequest.QUEUE)
         }
     }
-    LaunchedEffect(playerState.songId, remoteControlsEnabled) {
+    LaunchedEffect(playerState.queueRevision, remoteControlsEnabled) {
         if (remoteControlsEnabled) {
             browseViewModel.loadItems(WearBrowseRequest.QUEUE)
         }


### PR DESCRIPTION
- **MusicService**:
    - Introduce `wearQueueRevision` to track changes in the media timeline and current playback index.
    - Implement `buildWearQueueRevision` to generate a unique hash for the current queue state, supporting both local and Cast playback.
    - Update `onTimelineChanged` to trigger widget and Wear state updates.
    - Refactor `processWidgetUpdateInternal` to selectively publish state updates based on queue revision changes.
- **WearCommandReceiver**:
    - Add support for `WearBrowseRequest.QUEUE` to fetch and format the current playback queue for the watch.
    - Implement `WearPlaybackCommand.PLAY_QUEUE_INDEX` to allow jumping to specific items in the queue from the watch.
    - Centralize queue item building with logic to prioritize the currently playing item.
- **Wear OS Screens**:
    - **QueueScreen**: Use `playerState.queueRevision` to trigger queue refreshes instead of just `songId`, ensuring the list stays in sync with manual queue modifications.
    - **MoreScreen**: Add a `LaunchedEffect` to reload queue items when the revision changes while connected to a phone.
- **Data Models**:
    - Update `PlayerInfo` and `WearPlayerState` to include and propagate the `queueRevision` string.