### PR TITLE
feat: support cover art deletion, art cropping, and improve metadata editing reliability

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -3,6 +3,7 @@ package com.theveloper.pixelplay.data.media
 import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.media.MediaScannerConnection
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
@@ -20,6 +21,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import org.gagravarr.opus.OpusFile
 import org.gagravarr.opus.OpusTags
+import org.jaudiotagger.audio.AudioFileIO
+import org.jaudiotagger.tag.FieldKey
+import org.jaudiotagger.tag.images.AndroidArtwork
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
@@ -156,9 +160,16 @@ class SongMetadataEditor(
             // Get file extension to determine which library to use
             val finalFilePath = filePath ?: ""
             val extension = finalFilePath.substringAfterLast('.', "").lowercase(Locale.ROOT)
-            val useVorbisJava = extension in opusExtensions
+            
+            // Analyze FLAC properties
+            val flacAnalysis = isProblematicFlacFile(finalFilePath)
+            val isHighResFlac = flacAnalysis is FlacAnalysisResult.Problematic
+            
+            // Determine the primary editor based on format and quality
+            // JAudioTagger handles WAV, OGG (Vorbis), and High-Res FLAC much better than current TagLib logic.
+            val useJAudioTaggerPrimary = extension in setOf("wav", "ogg") || isHighResFlac
 
-            // 2. Update the actual file with ALL metadata (if it exists)
+            // Update the actual file with ALL metadata (if it exists)
             val fileExists = finalFilePath.isNotBlank() && File(finalFilePath).exists()
             
             val fileUpdateSuccess = if (!fileExists) {
@@ -169,13 +180,9 @@ class SongMetadataEditor(
                      Log.e(TAG, "METADATA_EDIT: File does not exist: $finalFilePath")
                      false
                 }
-            } else if (useVorbisJava) {
-                Log.e(TAG, "METADATA_EDIT: Opus/Ogg file detected - skipping file modification to prevent corruption")
-                Log.e(TAG, "METADATA_EDIT: Will update DBs only for: $finalFilePath")
-                true // Skip file modification, proceed to DB update
-            } else {
-                Log.e(TAG, "METADATA_EDIT: Using TagLib for $extension file: $finalFilePath")
-                updateFileMetadataWithTagLib(
+            } else if (useJAudioTaggerPrimary) {
+                Log.d(TAG, "METADATA_EDIT: Using JAudioTagger as primary for $extension file: $finalFilePath")
+                updateFileMetadataWithJAudioTagger(
                     filePath = finalFilePath,
                     newTitle = newTitle,
                     newArtist = newArtist,
@@ -186,6 +193,37 @@ class SongMetadataEditor(
                     newDiscNumber = newDiscNumber,
                     coverArtUpdate = coverArtUpdate
                 )
+            } else {
+                Log.d(TAG, "METADATA_EDIT: Using TagLib for $extension file: $finalFilePath")
+                val tagLibSuccess = updateFileMetadataWithTagLib(
+                    filePath = finalFilePath,
+                    newTitle = newTitle,
+                    newArtist = newArtist,
+                    newAlbum = newAlbum,
+                    newGenre = trimmedGenre,
+                    newLyrics = trimmedLyrics,
+                    newTrackNumber = newTrackNumber,
+                    newDiscNumber = newDiscNumber,
+                    coverArtUpdate = coverArtUpdate
+                )
+                
+                // Fallback to JAudioTagger if TagLib fails for standard formats
+                if (!tagLibSuccess) {
+                    Log.w(TAG, "METADATA_EDIT: TagLib failed for $extension, falling back to JAudioTagger")
+                    updateFileMetadataWithJAudioTagger(
+                        filePath = finalFilePath,
+                        newTitle = newTitle,
+                        newArtist = newArtist,
+                        newAlbum = newAlbum,
+                        newGenre = trimmedGenre,
+                        newLyrics = trimmedLyrics,
+                        newTrackNumber = newTrackNumber,
+                        newDiscNumber = newDiscNumber,
+                        coverArtUpdate = coverArtUpdate
+                    )
+                } else {
+                    true
+                }
             }
 
             if (!fileUpdateSuccess) {
@@ -481,6 +519,88 @@ class SongMetadataEditor(
 
         } catch (e: Exception) {
             Log.e(TAG, "TAGLIB ERROR: ${e.javaClass.simpleName}: ${e.message}")
+            e.printStackTrace()
+            false
+        }
+    }
+
+    private fun updateFileMetadataWithJAudioTagger(
+        filePath: String,
+        newTitle: String,
+        newArtist: String,
+        newAlbum: String,
+        newGenre: String,
+        newLyrics: String,
+        newTrackNumber: Int,
+        newDiscNumber: Int?,
+        coverArtUpdate: CoverArtUpdate? = null
+    ): Boolean {
+        val targetFile = File(filePath)
+        
+        return try {
+            // Suppress JAudioTagger's verbose logging
+            java.util.logging.Logger.getLogger("org.jaudiotagger").level = java.util.logging.Level.OFF
+            
+            val audioFile = AudioFileIO.read(targetFile)
+            val tag = audioFile.tag ?: audioFile.createDefaultTag()
+            
+            // Update text fields
+            tag.setField(FieldKey.TITLE, newTitle)
+            tag.setField(FieldKey.ARTIST, newArtist)
+            tag.setField(FieldKey.ALBUM, newAlbum)
+            tag.setField(FieldKey.ALBUM_ARTIST, newArtist)
+            
+            if (newGenre.isNotBlank()) {
+                tag.setField(FieldKey.GENRE, newGenre)
+            } else {
+                tag.deleteField(FieldKey.GENRE)
+            }
+            
+            if (newLyrics.isNotBlank()) {
+                tag.setField(FieldKey.LYRICS, newLyrics)
+            } else {
+                tag.deleteField(FieldKey.LYRICS)
+            }
+            
+            tag.setField(FieldKey.TRACK, newTrackNumber.toString())
+            if (newDiscNumber != null && newDiscNumber > 0) {
+                tag.setField(FieldKey.DISC_NO, newDiscNumber.toString())
+            } else {
+                tag.deleteField(FieldKey.DISC_NO)
+            }
+
+            // Update cover art if provided
+            coverArtUpdate?.let { update ->
+                if (update.isDeletion) {
+                    tag.deleteArtworkField()
+                    Log.d(TAG, "JAUDIOTAGGER: Removed cover art")
+                } else if (update.bytes != null) {
+                    try {
+                        tag.deleteArtworkField()
+                        val artwork = AndroidArtwork()
+                        artwork.binaryData = update.bytes
+                        artwork.mimeType = update.mimeType
+                        artwork.pictureType = 3 // Standard value for "Front Cover"
+                        
+                        // Extract dimensions using Android native BitmapFactory to avoid ImageIO crash
+                        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                        BitmapFactory.decodeByteArray(update.bytes, 0, update.bytes.size, options)
+                        artwork.width = options.outWidth
+                        artwork.height = options.outHeight
+                        
+                        tag.setField(artwork)
+                        Log.d(TAG, "JAUDIOTAGGER: Embedded new cover art (${update.mimeType}, ${options.outWidth}x${options.outHeight})")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "JAUDIOTAGGER: Failed to create artwork from bytes", e)
+                    }
+                }
+            }
+
+            audioFile.commit()
+            Log.d(TAG, "JAUDIOTAGGER: SUCCESS - Updated file metadata: $filePath")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "JAUDIOTAGGER ERROR: ${e.javaClass.simpleName}: ${e.message}")
             e.printStackTrace()
             false
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -254,10 +254,8 @@ class SongMetadataEditor(
 
                 coverArtUpdate?.let {
                     AlbumArtUtils.clearCacheForSong(context, songId)
-                    storedCoverArtUri = LocalArtworkUri.buildSongUriWithTimestamp(songId)
-                    storedCoverArtUri?.let { coverUri ->
-                        musicDao.updateSongAlbumArt(songId, coverUri)
-                    }
+                    storedCoverArtUri = if (it.isDeletion) null else LocalArtworkUri.buildSongUriWithTimestamp(songId)
+                    musicDao.updateSongAlbumArt(songId, storedCoverArtUri)
                 }
             }
 
@@ -442,18 +440,29 @@ class SongMetadataEditor(
 
                 // Update cover art if provided
                 coverArtUpdate?.let { update ->
-                    val picture = Picture(
-                        data = update.bytes,
-                        description = "Front Cover",
-                        pictureType = "Front Cover",
-                        mimeType = update.mimeType
-                    )
-                    val pictureFd = fd.dup()
-                    val coverSaved = TagLib.savePictures(pictureFd.detachFd(), arrayOf(picture))
-                    if (!coverSaved) {
-                        Log.w(TAG, "TAGLIB: Failed to save cover art, but metadata was saved")
+                    val pictures = if (update.isDeletion) {
+                        emptyArray<Picture>()
+                    } else if (update.bytes != null) {
+                        arrayOf(
+                            Picture(
+                                data = update.bytes,
+                                description = "Front Cover",
+                                pictureType = "Front Cover",
+                                mimeType = update.mimeType
+                            )
+                        )
                     } else {
-                        Log.d(TAG, "TAGLIB: Successfully embedded cover art")
+                        null
+                    }
+
+                    pictures?.let {
+                        val pictureFd = fd.dup()
+                        val coverSaved = TagLib.savePictures(pictureFd.detachFd(), it)
+                        if (!coverSaved) {
+                            Log.w(TAG, "TAGLIB: Failed to save cover art, but metadata was saved")
+                        } else {
+                            Log.d(TAG, "TAGLIB: Successfully ${if (update.isDeletion) "removed" else "embedded"} cover art")
+                        }
                     }
                 }
             }
@@ -732,8 +741,9 @@ data class SongMetadataEditResult(
 )
 
 data class CoverArtUpdate(
-    val bytes: ByteArray,
-    val mimeType: String = "image/jpeg"
+    val bytes: ByteArray? = null,
+    val mimeType: String = "image/jpeg",
+    val isDeletion: Boolean = false
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
@@ -51,6 +51,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.automirrored.rounded.Notes
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Repeat
 import androidx.compose.material.icons.rounded.RepeatOne
 import androidx.compose.ui.platform.LocalContext
@@ -140,6 +141,7 @@ private fun EditSongContent(
     var discNumber by remember { mutableStateOf(song.discNumber?.toString() ?: "") }
     var coverArtPreview by remember { mutableStateOf<ImageBitmap?>(null) }
     var editedCoverArt by remember { mutableStateOf<CoverArtUpdate?>(null) }
+    var isCoverArtDeleted by remember { mutableStateOf(false) }
     var showCoverArtCropper by remember { mutableStateOf(false) }
     var pendingCoverArtUri by remember { mutableStateOf<Uri?>(null) }
 
@@ -165,6 +167,7 @@ private fun EditSongContent(
         discNumber = song.discNumber?.toString() ?: ""
         coverArtPreview = null
         editedCoverArt = null
+        isCoverArtDeleted = false
 
         // Try to read embedded lyrics if they were not cached in the database
         if (lyrics.isBlank() && song.path.isNotBlank()) {
@@ -232,6 +235,7 @@ private fun EditSongContent(
             onConfirm = { result ->
                 coverArtPreview = result.preview
                 editedCoverArt = result.update
+                isCoverArtDeleted = false
                 showCoverArtCropper = false
                 pendingCoverArtUri = null
             }
@@ -358,14 +362,21 @@ private fun EditSongContent(
                     modifier = Modifier.fillMaxWidth(),
                     albumArtUri = song.albumArtUriString,
                     preview = coverArtPreview,
+                    isDeleted = isCoverArtDeleted,
                     onPickNewArt = {
                         pickCoverArtLauncher.launch(
                             PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                         )
                     },
+                    onDelete = {
+                        coverArtPreview = null
+                        isCoverArtDeleted = true
+                        editedCoverArt = CoverArtUpdate(isDeletion = true)
+                    },
                     onReset = {
                         coverArtPreview = null
                         editedCoverArt = null
+                        isCoverArtDeleted = false
                     }
                 )
             }
@@ -621,7 +632,9 @@ private fun CoverArtEditorCard(
     modifier: Modifier = Modifier,
     albumArtUri: String?,
     preview: ImageBitmap?,
+    isDeleted: Boolean,
     onPickNewArt: () -> Unit,
+    onDelete: () -> Unit,
     onReset: () -> Unit,
 ) {
     Surface(
@@ -665,6 +678,15 @@ private fun CoverArtEditorCard(
                     contentAlignment = Alignment.Center
                 ) {
                     when {
+                        isDeleted -> {
+                            Icon(
+                                painter = painterResource(id = R.drawable.rounded_album_24),
+                                contentDescription = null,
+                                modifier = Modifier.size(72.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
                         preview != null -> {
                             Image(
                                 bitmap = preview,
@@ -719,7 +741,7 @@ private fun CoverArtEditorCard(
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically)
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
             ) {
                 FilledTonalButton(onClick = onPickNewArt) {
                     Icon(Icons.Rounded.Image, contentDescription = null)
@@ -727,11 +749,23 @@ private fun CoverArtEditorCard(
                     Text("Change cover art")
                 }
 
-                if (preview != null) {
+                if (preview != null || isDeleted) {
                     TextButton(onClick = onReset) {
                         Icon(Icons.Rounded.Restore, contentDescription = null)
                         Spacer(modifier = Modifier.width(4.dp))
                         Text("Reset")
+                    }
+                } else if (albumArtUri != null) {
+                    FilledTonalButton(
+                        onClick = onDelete,
+                        colors = ButtonDefaults.filledTonalButtonColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    ) {
+                        Icon(Icons.Rounded.Delete, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Delete cover art")
                     }
                 }
             }
@@ -776,14 +810,18 @@ private fun CoverArtCropperDialog(
         offset = Offset.Zero
     }
 
-    LaunchedEffect(containerSize, scale) {
-        offset = clampOffset(offset, scale, containerSize)
+    LaunchedEffect(containerSize, scale, loadedBitmap) {
+        loadedBitmap?.let { bitmap ->
+            offset = clampOffset(offset, scale, containerSize, bitmap.width, bitmap.height)
+        }
     }
 
     val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
         val newScale = (scale * zoomChange).coerceIn(1f, 4f)
         scale = newScale
-        offset = clampOffset(offset + panChange, newScale, containerSize)
+        loadedBitmap?.let { bitmap ->
+            offset = clampOffset(offset + panChange, newScale, containerSize, bitmap.width, bitmap.height)
+        }
     }
 
     val gridColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.18f)
@@ -855,7 +893,12 @@ private fun CoverArtCropperDialog(
                                     )
                                 }
 
-                                loadedBitmap != null -> {
+                                 loadedBitmap != null -> {
+                                    val bitmap = loadedBitmap!!
+                                    val baseScale = maxOf(containerSize / bitmap.width, containerSize / bitmap.height)
+                                    val displayWidth = with(LocalDensity.current) { (bitmap.width * baseScale).toDp() }
+                                    val displayHeight = with(LocalDensity.current) { (bitmap.height * baseScale).toDp() }
+
                                     Box(
                                         modifier = Modifier
                                             .fillMaxSize()
@@ -866,17 +909,16 @@ private fun CoverArtCropperDialog(
                                             .transformable(transformableState)
                                     ) {
                                         Image(
-                                            bitmap = loadedBitmap!!,
+                                            bitmap = bitmap,
                                             contentDescription = null,
                                             modifier = Modifier
-                                                .fillMaxSize()
+                                                .requiredSize(displayWidth, displayHeight)
                                                 .graphicsLayer {
                                                     scaleX = scale
                                                     scaleY = scale
                                                     translationX = offset.x
                                                     translationY = offset.y
-                                                },
-                                            contentScale = ContentScale.Crop
+                                                }
                                         )
                                     }
 
@@ -969,13 +1011,30 @@ private fun CoverArtCropperDialog(
 
 private const val COVER_ART_MIME_TYPE = "image/jpeg"
 
-private fun clampOffset(offset: Offset, scale: Float, containerSize: Float): Offset {
-    if (containerSize <= 0f) return Offset.Zero
-    val maxTranslation = (containerSize * (scale - 1f)) / 2f
-    if (maxTranslation <= 0f) return Offset.Zero
+private fun clampOffset(
+    offset: Offset,
+    scale: Float,
+    containerSize: Float,
+    bitmapWidth: Int,
+    bitmapHeight: Int
+): Offset {
+    if (containerSize <= 0f || bitmapWidth <= 0 || bitmapHeight <= 0) return Offset.Zero
+
+    // When using ContentScale.Crop, the image is scaled to fill the container size.
+    // The base scale factor is the maximum of the width and height ratios.
+    val baseScale = maxOf(containerSize / bitmapWidth, containerSize / bitmapHeight)
+    val totalScale = baseScale * scale
+
+    val scaledWidth = bitmapWidth * totalScale
+    val scaledHeight = bitmapHeight * totalScale
+
+    // Calculate maximum translation bounds (half of the overflow).
+    val maxX = maxOf(0f, (scaledWidth - containerSize) / 2f)
+    val maxY = maxOf(0f, (scaledHeight - containerSize) / 2f)
+
     return Offset(
-        x = offset.x.coerceIn(-maxTranslation, maxTranslation),
-        y = offset.y.coerceIn(-maxTranslation, maxTranslation)
+        x = offset.x.coerceIn(-maxX, maxX),
+        y = offset.y.coerceIn(-maxY, maxY)
     )
 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
@@ -81,8 +81,18 @@ fun SmartImage(
         ) ?: model
     }
 
-    if (model is ImageVector || model is Painter || model is ImageBitmap || model is Bitmap) {
-        // Already rendered inside handleDirectModel.
+    if (model == null || model is ImageVector || model is Painter || model is ImageBitmap || model is Bitmap) {
+        if (model == null) {
+            Placeholder(
+                modifier = clippedModifier,
+                drawableResId = placeholderResId,
+                contentDescription = contentDescription,
+                containerColor = placeHolderBackgroundColor,
+                iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                alpha = alpha
+            )
+        }
+        // Already rendered or null.
         return
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MetadataEditStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MetadataEditStateHolder.kt
@@ -81,6 +81,9 @@ class MetadataEditStateHolder @Inject constructor(
             } else {
                 null
             }
+        } else if (coverArtUpdate.isDeletion) {
+            Log.d("MetadataEditStateHolder", "Artwork deletion requested, skipping preservation")
+            coverArtUpdate
         } else {
             coverArtUpdate
         }
@@ -116,7 +119,11 @@ class MetadataEditStateHolder @Inject constructor(
         Log.d("MetadataEditStateHolder", "Editor result: success=${result.success}, error=${result.error}")
 
         if (result.success) {
-            val refreshedAlbumArtUri = result.updatedAlbumArtUri ?: song.albumArtUriString
+            val refreshedAlbumArtUri = if (coverArtUpdate?.isDeletion == true) {
+                null
+            } else {
+                result.updatedAlbumArtUri ?: song.albumArtUriString
+            }
             
             // Update Repository (Lyrics)
             if (normalizedLyrics != null) {
@@ -140,20 +147,27 @@ class MetadataEditStateHolder @Inject constructor(
             // When metadata changes (especially album/artist), MediaStore might re-index the song
             // and assign it a NEW album ID, resulting in a NEW albumArtUri.
             // Using the 'updatedSong' copy above might retain a STALE albumArtUri.
-            val freshSong = try {
+            val freshSongFromRepo = try {
                 musicRepository.getSong(song.id).first() ?: updatedSong
             } catch (e: Exception) {
                 updatedSong
             }
 
+            // Ensure we use the refreshed artwork URI we just generated/cleared.
+            // The repository emission may be stale for a split second.
+            val freshSong = freshSongFromRepo.copy(
+                albumArtUriString = refreshedAlbumArtUri
+            )
+
             // Force cache invalidation if album art might have changed
-            if (refreshedAlbumArtUri != null) {
-                // Invalidate Coil/Glide caches
-                imageCacheManager.invalidateCoverArtCaches(refreshedAlbumArtUri)
-                
-                // Force regenerate palette
-                themeStateHolder.forceRegenerateColorScheme(refreshedAlbumArtUri)
+            val uriToInvalidate = if (coverArtUpdate?.isDeletion == true) song.albumArtUriString else refreshedAlbumArtUri
+            if (uriToInvalidate != null) {
+                // Invalidate Coil/Glide caches for the affected URI (old or new)
+                imageCacheManager.invalidateCoverArtCaches(uriToInvalidate)
             }
+            
+            // Force regenerate palette
+            themeStateHolder.forceRegenerateColorScheme(refreshedAlbumArtUri)
 
             MetadataEditResult(
                 success = true,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ThemeStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ThemeStateHolder.kt
@@ -160,9 +160,15 @@ class ThemeStateHolder @Inject constructor(
     }
 
     suspend fun forceRegenerateColorScheme(
-        uriString: String,
+        uriString: String?,
         regenerateAllStyles: Boolean = false
     ) {
+         if (uriString == null) {
+             _currentAlbumArtColorSchemePair.value = null
+             _currentAlbumArtUri.value = null
+             return
+         }
+
          android.util.Log.d("ThemeStateHolder", "forceRegenerateColorScheme called for: $uriString")
          android.util.Log.d("ThemeStateHolder", "Current tracked global URI: ${_currentAlbumArtUri.value}")
          


### PR DESCRIPTION
### Summary

**Art Deletion**
- Add support for deleting cover art by removing embedded artwork and clearing related database entries
- Improve metadata state handling to support null artwork and properly refresh UI after deletion
- Enhance cache invalidation to clear both old and updated artwork
- Add "Delete cover art" option in edit sheet with reset capability
- Update `SmartImage` to show placeholders when artwork is removed
- Update `forceRegenerateColorScheme` in `ThemeStateHolder.kt` to generate default theme for deleted artwork

**Art Cropping**
- Implement improved image cropper with better scaling and aspect ratio handling

**Metadata Editing**
- Integrate JAudioTagger for safer metadata editing on WAV, OGG, and high-res FLAC files
- Add fallback to JAudioTagger when TagLib fails to prevent corruption and improve compatibility