### PR TITLE
feat: add new sorting options for albums and artists

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumEntity.kt
@@ -23,6 +23,7 @@ data class AlbumEntity(
     @ColumnInfo(name = "artist_id") val artistId: Long, // ID del artista principal del álbum (si aplica)
     @ColumnInfo(name = "album_art_uri_string") val albumArtUriString: String?,
     @ColumnInfo(name = "song_count") val songCount: Int,
+    @ColumnInfo(name = "date_added") val dateAdded: Long,
     @ColumnInfo(name = "year") val year: Int
 )
 
@@ -46,6 +47,7 @@ fun AlbumEntity.toAlbum(): Album {
         artist = this.artistName.normalizeMetadataTextOrEmpty(),
         albumArtUriString = effectiveAlbumArtUri,
         songCount = this.songCount,
+        dateAdded = this.dateAdded,
         year = this.year
     )
 }
@@ -62,6 +64,7 @@ fun Album.toEntity(artistIdForAlbum: Long): AlbumEntity { // Necesitamos pasar e
         artistId = artistIdForAlbum, // Asignar el ID del artista
         albumArtUriString = this.albumArtUriString,
         songCount = this.songCount,
+        dateAdded = this.dateAdded,
         year = this.year
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -695,6 +695,7 @@ interface MusicDao {
             albums.artist_id AS artist_id,
             albums.album_art_uri_string AS album_art_uri_string,
             COUNT(songs.id) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
@@ -726,6 +727,7 @@ interface MusicDao {
             albums.artist_name,
             albums.artist_id,
             albums.album_art_uri_string,
+            albums.date_added,
             albums.year
         ORDER BY albums.title ASC
     """)
@@ -747,6 +749,7 @@ interface MusicDao {
                 FROM songs
                 WHERE songs.album_id = albums.id
             ) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         WHERE albums.id = :albumId
@@ -766,6 +769,7 @@ interface MusicDao {
                 FROM songs
                 WHERE songs.album_id = albums.id
             ) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         WHERE albums.title LIKE '%' || :query || '%'
@@ -785,6 +789,7 @@ interface MusicDao {
             albums.artist_id AS artist_id,
             albums.album_art_uri_string AS album_art_uri_string,
             COUNT(songs.id) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
@@ -795,6 +800,7 @@ interface MusicDao {
             albums.artist_name,
             albums.artist_id,
             albums.album_art_uri_string,
+            albums.date_added,
             albums.year
         ORDER BY albums.title ASC
     """)
@@ -811,6 +817,7 @@ interface MusicDao {
             albums.artist_id AS artist_id,
             albums.album_art_uri_string AS album_art_uri_string,
             COUNT(songs.id) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         LEFT JOIN songs ON albums.id = songs.album_id
@@ -821,6 +828,7 @@ interface MusicDao {
             albums.artist_name,
             albums.artist_id,
             albums.album_art_uri_string,
+            albums.date_added,
             albums.year
         ORDER BY albums.title ASC
     """)
@@ -834,6 +842,7 @@ interface MusicDao {
             albums.artist_id AS artist_id,
             albums.album_art_uri_string AS album_art_uri_string,
             COUNT(songs.id) AS song_count,
+            albums.date_added AS date_added,
             albums.year AS year
         FROM albums
         INNER JOIN songs ON albums.id = songs.album_id
@@ -845,6 +854,7 @@ interface MusicDao {
             albums.artist_name,
             albums.artist_id,
             albums.album_art_uri_string,
+            albums.date_added,
             albums.year
         ORDER BY albums.title ASC
     """)

--- a/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
@@ -410,6 +410,7 @@ class GDriveRepository @Inject constructor(
                     artistName = primaryArtistName,
                     artistId = primaryArtistId,
                     songCount = 0,
+                    dateAdded = gdriveSong.dateAdded,
                     year = 0,
                     albumArtUriString = gdriveSong.albumArtUrl
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/LibraryModels.kt
@@ -11,6 +11,7 @@ data class Album(
     val title: String,
     val artist: String,
     val year: Int,
+    val dateAdded: Long,
     val albumArtUriString: String?,
     val songCount: Int
 ) : Parcelable {
@@ -19,6 +20,7 @@ data class Album(
             id = -1,
             title = "",
             artist = "",
+            dateAdded = 0,
             year = 0,
             albumArtUriString = null,
             songCount = 0

--- a/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/model/SortOption.kt
@@ -19,13 +19,14 @@ sealed class SortOption(val storageKey: String, val displayName: String) {
     object AlbumTitleZA : SortOption("album_title_za", "Title (Z-A)")
     object AlbumArtist : SortOption("album_artist", "Artist")
     object AlbumReleaseYear : SortOption("album_release_year", "Release Year")
+    object AlbumDateAdded : SortOption("album_date_added", "Date Added")
     object AlbumSizeAsc : SortOption("album_size_asc", "Fewest Songs")
     object AlbumSizeDesc : SortOption("album_size_desc", "Most Songs")
 
     // Artist Sort Options
     object ArtistNameAZ : SortOption("artist_name_az", "Name (A-Z)")
     object ArtistNameZA : SortOption("artist_name_za", "Name (Z-A)")
-    // object ArtistNumSongs : SortOption("artist_num_songs", "Number of Songs") // Requires ViewModel change & data
+    object ArtistNumSongs : SortOption("artist_num_songs", "Number of Songs")
 
     // Playlist Sort Options
     object PlaylistNameAZ : SortOption("playlist_name_az", "Name (A-Z)")
@@ -67,6 +68,7 @@ sealed class SortOption(val storageKey: String, val displayName: String) {
                 AlbumTitleZA,
                 AlbumArtist,
                 AlbumReleaseYear,
+                AlbumDateAdded,
                 AlbumSizeAsc,
                 AlbumSizeDesc
             )
@@ -74,7 +76,8 @@ sealed class SortOption(val storageKey: String, val displayName: String) {
         val ARTISTS: List<SortOption> by lazy {
             listOf(
                 ArtistNameAZ,
-                ArtistNameZA
+                ArtistNameZA,
+                ArtistNumSongs
             )
         }
         val PLAYLISTS: List<SortOption> by lazy {

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -641,6 +641,7 @@ class NavidromeRepository @Inject constructor(
                     artistName = primaryArtistName,
                     artistId = primaryArtistId,
                     songCount = 0,
+                    dateAdded = navidromeSong.dateAdded,
                     year = navidromeSong.year,
                     albumArtUriString = getCoverArtUrl(navidromeSong.coverArtId)
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
@@ -689,6 +689,7 @@ class NeteaseRepository @Inject constructor(
                     artistName = primaryArtistName,
                     artistId = primaryArtistId,
                     songCount = 0,
+                    dateAdded = neteaseSong.dateAdded,
                     year = 0,
                     albumArtUriString = neteaseSong.albumArtUrl
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
@@ -657,6 +657,7 @@ class QqMusicRepository @Inject constructor(
                     artistName = primaryArtistName,
                     artistId = primaryArtistId,
                     songCount = 0,
+                    dateAdded = qqSong.dateAdded,
                     year = 0,
                     albumArtUriString = qqSong.albumArtUrl
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -511,7 +511,8 @@ constructor(
                  artistName = determinedAlbumArtist,
                  artistId = determinedAlbumArtistId,
                  albumArtUriString = representativeAlbumArt,
-                 songCount = songsInAlbum.size, 
+                 songCount = songsInAlbum.size,
+                 dateAdded = firstSong.dateAdded,
                  year = firstSong.year
              )
         }
@@ -1342,6 +1343,7 @@ constructor(
                 var realTitle = tSong.title
                 var realArtistName = tSong.artist
                 var realAlbumName = channelName
+                var realDateAdded = tSong.dateAdded
                 var realYear = 0
                 var realTrackNumber = 0
                 var realAlbumArtist = "Telegram"
@@ -1428,6 +1430,7 @@ constructor(
                         artistName = realAlbumArtist, 
                         artistId = primaryArtistId, // Link to primary song artist (or album artist if we resolved it properly)
                         songCount = 0,
+                        dateAdded = realDateAdded,
                         year = realYear,
                         albumArtUriString = tSong.albumArtUriString // Use Telegram thumb or embedded art
                     )
@@ -1540,6 +1543,7 @@ constructor(
                         artistName = primaryArtistName,
                         artistId = primaryArtistId,
                         songCount = 0,
+                        dateAdded = nSong.dateAdded,
                         year = 0,
                         albumArtUriString = nSong.albumArtUrl
                     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/library/LibraryTabId.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/library/LibraryTabId.kt
@@ -32,7 +32,8 @@ enum class LibraryTabId(
             SortOption.AlbumTitleAZ,
             SortOption.AlbumTitleZA,
             SortOption.AlbumArtist,
-            SortOption.AlbumReleaseYear
+            SortOption.AlbumReleaseYear,
+            SortOption.AlbumDateAdded
         )
     ),
     Artists(
@@ -40,7 +41,8 @@ enum class LibraryTabId(
         label = "ARTIST",
         sortOptions = listOf(
             SortOption.ArtistNameAZ,
-            SortOption.ArtistNameZA
+            SortOption.ArtistNameZA,
+            SortOption.ArtistNumSongs
         )
     ),
     Playlists(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryStateHolder.kt
@@ -324,6 +324,7 @@ class LibraryStateHolder @Inject constructor(
                 SortOption.AlbumTitleZA -> _albums.value.sortedByDescending { it.title.lowercase() }
                 SortOption.AlbumArtist -> _albums.value.sortedBy { it.artist.lowercase() }
                 SortOption.AlbumReleaseYear -> _albums.value.sortedByDescending { it.year }
+                SortOption.AlbumDateAdded -> _albums.value.sortedByDescending { it.dateAdded }
                 SortOption.AlbumSizeAsc -> _albums.value.sortedWith(compareBy<Album> { it.songCount }.thenBy { it.title.lowercase() })
                 SortOption.AlbumSizeDesc -> _albums.value.sortedWith(compareByDescending<Album> { it.songCount }.thenBy { it.title.lowercase() })
                 else -> _albums.value
@@ -342,6 +343,7 @@ class LibraryStateHolder @Inject constructor(
             val sorted = when (sortOption) {
                 SortOption.ArtistNameAZ -> _artists.value.sortedBy { it.name.lowercase() }
                 SortOption.ArtistNameZA -> _artists.value.sortedByDescending { it.name.lowercase() }
+                SortOption.ArtistNumSongs -> _artists.value.sortedByDescending { it.songCount }
                 else -> _artists.value
             }
             _artists.value = sorted.toImmutableList()


### PR DESCRIPTION
- I added "Date Added" sorting for albums, which sorts them based on the dateAdded value of the first song. It should also work for online libraries that have dateAdded for songs, but I haven't been able to test it.
- I added "Number of Songs" sorting for artists, which appeared to be partially implemented but was not fully functional.

<img width="270" height="606" alt="Screenshot_20260328-235020" src="https://github.com/user-attachments/assets/4ac321e9-5eeb-4bb9-852c-f0668caf77cf" />
<img width="270" height="606" alt="Screenshot_20260329-001518" src="https://github.com/user-attachments/assets/12f7db82-74c4-4352-9bdd-03ff4b09a62d" />
