### PR TITLE
feat: add support for Telegram topic display modes in playlists

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
@@ -39,6 +39,10 @@ class PlaylistPreferencesRepository @Inject constructor(
     val playlistsSortOptionFlow: Flow<String> = userPreferencesRepository.playlistsSortOptionFlow
     val showTelegramCloudPlaylistsFlow: Flow<Boolean> =
         userPreferencesRepository.showTelegramCloudPlaylistsFlow
+    val telegramTopicDisplayModeFlow: Flow<TelegramTopicDisplayMode> =
+        userPreferencesRepository.telegramTopicDisplayModeFlow
+    suspend fun setTelegramTopicDisplayMode(mode: TelegramTopicDisplayMode) =
+        userPreferencesRepository.setTelegramTopicDisplayMode(mode)
 
     suspend fun createPlaylist(
         name: String,

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/TelegramTopicDisplayMode.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/TelegramTopicDisplayMode.kt
@@ -1,0 +1,17 @@
+package com.theveloper.pixelplay.data.preferences
+
+enum class TelegramTopicDisplayMode(val storageKey: String) {
+    /** One combined playlist per channel; individual topic playlists are hidden. */
+    CHANNELS_ONLY("channels_only"),
+
+    /** For forum channels: show only per-topic playlists; hide the combined channel playlist. */
+    TOPICS_ONLY("topics_only"),
+
+    /** For forum channels: show both the combined channel playlist and each topic playlist. */
+    CHANNELS_AND_TOPICS("channels_and_topics");
+
+    companion object {
+        fun fromStorageKey(key: String?): TelegramTopicDisplayMode =
+            entries.firstOrNull { it.storageKey == key } ?: CHANNELS_AND_TOPICS
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -118,6 +118,7 @@ constructor(
         val IS_FOLDER_FILTER_ACTIVE = booleanPreferencesKey("is_folder_filter_active")
         val IS_FOLDERS_PLAYLIST_VIEW = booleanPreferencesKey("is_folders_playlist_view")
         val SHOW_TELEGRAM_CLOUD_PLAYLISTS = booleanPreferencesKey("show_telegram_cloud_playlists")
+        val TELEGRAM_TOPIC_DISPLAY_MODE = stringPreferencesKey("telegram_topic_display_mode")
         val FOLDERS_SOURCE = stringPreferencesKey("folders_source")
         val FOLDER_BACK_GESTURE_NAVIGATION = booleanPreferencesKey("folder_back_gesture_navigation")
         val USE_SMOOTH_CORNERS = booleanPreferencesKey("use_smooth_corners")
@@ -1391,6 +1392,11 @@ constructor(
             preferences[PreferencesKeys.SHOW_TELEGRAM_CLOUD_PLAYLISTS] ?: true
         }
 
+    val telegramTopicDisplayModeFlow: Flow<TelegramTopicDisplayMode> = dataStore.data
+        .map { preferences ->
+            TelegramTopicDisplayMode.fromStorageKey(preferences[PreferencesKeys.TELEGRAM_TOPIC_DISPLAY_MODE])
+        }
+
     val foldersSourceFlow: Flow<FolderSource> = dataStore.data
         .map { preferences ->
             FolderSource.fromStorageKey(preferences[PreferencesKeys.FOLDERS_SOURCE])
@@ -1421,6 +1427,12 @@ constructor(
     suspend fun setShowTelegramCloudPlaylists(show: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.SHOW_TELEGRAM_CLOUD_PLAYLISTS] = show
+        }
+    }
+
+    suspend fun setTelegramTopicDisplayMode(mode: TelegramTopicDisplayMode) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.TELEGRAM_TOPIC_DISPLAY_MODE] = mode.storageKey
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LibrarySortBottomSheet.kt
@@ -59,7 +59,8 @@ fun LibrarySortBottomSheet(
     viewToggleChecked: Boolean = false,
     onViewToggleChange: (Boolean) -> Unit = {},
     viewToggleContent: (@Composable () -> Unit)? = null,
-    sourceToggleContent: (@Composable () -> Unit)? = null
+    sourceToggleContent: (@Composable () -> Unit)? = null,
+    extraContent: (@Composable () -> Unit)? = null
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -198,6 +199,11 @@ fun LibrarySortBottomSheet(
                     modifier = Modifier.padding(start = 2.dp, top = 8.dp, bottom = 8.dp)
                 )
                 sourceToggleContent()
+            }
+
+            if (extraContent != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                extraContent()
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,10 +30,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
-import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.LibraryMusic
+import androidx.compose.material.icons.rounded.Topic
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -441,13 +442,22 @@ fun PlaylistItem(
                             modifier = Modifier.size(18.dp)
                         )
                     }
-                    if (playlist.source == "TELEGRAM") {
+                    if (playlist.source == "TELEGRAM" || playlist.source == "TELEGRAM_TOPIC") {
                         Spacer(modifier = Modifier.width(8.dp))
                         Icon(
                             painter = painterResource(R.drawable.telegram),
                             contentDescription = "Telegram",
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(18.dp)
+                        )
+                    }
+                    if (playlist.source == "TELEGRAM_TOPIC") {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = Icons.Rounded.Topic,
+                            contentDescription = "Topic",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
                         )
                     }
                     if (playlist.source == "QQMUSIC") {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -626,8 +626,8 @@ fun LibraryScreen(
     val canHandleFolderBack by remember {
         derivedStateOf {
             currentTabId == LibraryTabId.FOLDERS &&
-                canNavigateBackInFolders &&
-                !isSortSheetVisible
+                    canNavigateBackInFolders &&
+                    !isSortSheetVisible
         }
     }
 
@@ -769,7 +769,7 @@ fun LibraryScreen(
             Column(
                 modifier = Modifier.background(headerContainerColor)
             ) {
-            TopAppBar(
+                TopAppBar(
                     title = {
                         if (isCompactNavigation) {
                             LibraryNavigationPill(
@@ -986,12 +986,49 @@ fun LibraryScreen(
                         val playlistUiState by playlistViewModel.uiState.collectAsStateWithLifecycle()
                         val visiblePlaylists = remember(
                             playlistUiState.playlists,
-                            playlistUiState.showTelegramCloudPlaylists
+                            playlistUiState.showTelegramCloudPlaylists,
+                            playlistUiState.telegramTopicDisplayMode
                         ) {
-                            if (playlistUiState.showTelegramCloudPlaylists) {
-                                playlistUiState.playlists
-                            } else {
-                                playlistUiState.playlists.filterNot { it.source == "TELEGRAM" }
+                            val mode = playlistUiState.telegramTopicDisplayMode
+                            val allPlaylists = playlistUiState.playlists
+
+                            // When Telegram cloud is hidden, remove all Telegram playlists
+                            if (!playlistUiState.showTelegramCloudPlaylists) {
+                                return@remember allPlaylists.filterNot {
+                                    it.source == "TELEGRAM" || it.source == "TELEGRAM_TOPIC"
+                                }
+                            }
+
+                            allPlaylists.filter { playlist ->
+                                when (playlist.source) {
+                                    "TELEGRAM_TOPIC" -> when (mode) {
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_ONLY ->
+                                            false
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.TOPICS_ONLY,
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_AND_TOPICS ->
+                                            playlist.songIds.isNotEmpty()
+                                    }
+                                    "TELEGRAM" -> when (mode) {
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_ONLY ->
+                                            true
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.TOPICS_ONLY -> {
+                                            // Hide combined playlist only for forum channels
+                                            // (those that have at least one topic playlist)
+                                            val chatId = playlist.id
+                                                .removePrefix("telegram_channel:")
+                                                .toLongOrNull()
+                                            if (chatId != null) {
+                                                allPlaylists.none { p ->
+                                                    p.source == "TELEGRAM_TOPIC" &&
+                                                            p.id.startsWith("telegram_topic:${chatId}_")
+                                                }
+                                            } else true
+                                        }
+                                        com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_AND_TOPICS ->
+                                            true
+                                    }
+                                    else -> true
+                                }
                             }
                         }
                         val allSongsLazyPagingItems = libraryViewModel.songsPagingFlow.collectAsLazyPagingItems()
@@ -1015,7 +1052,7 @@ fun LibraryScreen(
                             if (playlistUiState.showTelegramCloudPlaylists) return@LaunchedEffect
 
                             selectedPlaylists
-                                .filter { it.source == "TELEGRAM" }
+                                .filter { it.source == "TELEGRAM" || it.source == "TELEGRAM_TOPIC" }
                                 .forEach { playlist ->
                                     playlistMultiSelectionState.removeFromSelection(playlist.id)
                                 }
@@ -1158,10 +1195,10 @@ fun LibraryScreen(
                                     onNavigateBack = { playerViewModel.navigateBackFolder() },
                                     isShuffleEnabled = isShuffleEnabled,
                                     showStorageFilterButton = currentTabId == LibraryTabId.SONGS ||
-                                        currentTabId == LibraryTabId.ALBUMS ||
-                                        currentTabId == LibraryTabId.ARTISTS ||
-                                        currentTabId == LibraryTabId.LIKED ||
-                                        (ENABLE_FOLDERS_STORAGE_FILTER && currentTabId == LibraryTabId.FOLDERS),
+                                            currentTabId == LibraryTabId.ALBUMS ||
+                                            currentTabId == LibraryTabId.ARTISTS ||
+                                            currentTabId == LibraryTabId.LIKED ||
+                                            (ENABLE_FOLDERS_STORAGE_FILTER && currentTabId == LibraryTabId.FOLDERS),
                                     currentStorageFilter = playerUiState.currentStorageFilter,
                                     onStorageFilterClick = { playerViewModel.toggleStorageFilter() }
                                 )
@@ -1296,6 +1333,41 @@ fun LibraryScreen(
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                                 modifier = Modifier.padding(top = 8.dp, start = 2.dp)
                                             )
+                                        }
+                                    }
+                                } else null,
+                                extraContent = if (isPlaylistsTab && playlistUiState.showTelegramCloudPlaylists) {
+                                    {
+                                        Text(
+                                            text = "Topics Display",
+                                            style = MaterialTheme.typography.headlineSmall,
+                                            fontFamily = com.theveloper.pixelplay.ui.theme.GoogleSansRounded,
+                                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                                            modifier = Modifier.padding(start = 2.dp, bottom = 8.dp)
+                                        )
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(48.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            listOf(
+                                                com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_ONLY to "Channels",
+                                                com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.TOPICS_ONLY to "Topics",
+                                                com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode.CHANNELS_AND_TOPICS to "Both"
+                                            ).forEach { (mode, label) ->
+                                                ToggleSegmentButton(
+                                                    modifier = Modifier.weight(1f),
+                                                    active = playlistUiState.telegramTopicDisplayMode == mode,
+                                                    activeColor = MaterialTheme.colorScheme.primary,
+                                                    inactiveColor = MaterialTheme.colorScheme.surfaceVariant,
+                                                    activeContentColor = MaterialTheme.colorScheme.onPrimary,
+                                                    inactiveContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    activeCornerRadius = 32.dp,
+                                                    onClick = { playlistViewModel.setTelegramTopicDisplayMode(mode) },
+                                                    text = label
+                                                )
+                                            }
                                         }
                                     }
                                 } else null
@@ -1540,9 +1612,9 @@ fun LibraryScreen(
                 } else if (
                     playerUiState.isSyncingLibrary ||
                     (
-                        (playerUiState.isLoadingInitialSongs || playerUiState.isLoadingLibraryCategories) &&
-                            isLibraryContentEmpty
-                        )
+                            (playerUiState.isLoadingInitialSongs || playerUiState.isLoadingLibraryCategories) &&
+                                    isLibraryContentEmpty
+                            )
                 ) {
                     // P1-1: LibrarySyncOverlay reads syncProgress internally so that sync progress
                     // ticks don't trigger recomposition of the entire LibraryScreen.
@@ -1868,9 +1940,9 @@ fun LibraryScreen(
     // Merge Playlists Dialog
     if (showMergePlaylistDialog && pendingMergePlaylistIds.isNotEmpty()) {
         var mergePlaylistName by remember { mutableStateOf("") }
-        
+
         AlertDialog(
-            onDismissRequest = { 
+            onDismissRequest = {
                 showMergePlaylistDialog = false
                 pendingMergePlaylistIds = emptyList()
                 mergePlaylistName = ""
@@ -1914,7 +1986,7 @@ fun LibraryScreen(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { 
+                TextButton(onClick = {
                     showMergePlaylistDialog = false
                     pendingMergePlaylistIds = emptyList()
                     mergePlaylistName = ""
@@ -2049,8 +2121,8 @@ fun LibraryNavigationPill(
     )
     val targetArrowHorizontalPadding =
         LibraryNavigationPillArrowPaddingExpanded -
-            (LibraryNavigationPillArrowPaddingExpanded - LibraryNavigationPillArrowPaddingCompressed) *
-            compressionProgress
+                (LibraryNavigationPillArrowPaddingExpanded - LibraryNavigationPillArrowPaddingCompressed) *
+                compressionProgress
     val animatedArrowHorizontalPadding by animateDpAsState(
         targetValue = targetArrowHorizontalPadding,
         label = "LibraryPillArrowPadding"
@@ -2083,34 +2155,34 @@ fun LibraryNavigationPill(
         }
         val maxTitleWidth = (availableWidth - targetArrowWidth - pillGap - 40.dp).coerceAtLeast(0.dp)
         val idealTitleWidth = idealTextWidth +
-            titleHorizontalPadding * 2 +
-            (if (showIcon) (titleIconSize + titleIconSpacing) else 0.dp) +
-            4.dp // Tiny safety buffer
+                titleHorizontalPadding * 2 +
+                (if (showIcon) (titleIconSize + titleIconSpacing) else 0.dp) +
+                4.dp // Tiny safety buffer
         val naturalTitleWidth = minOf(idealTitleWidth, maxTitleWidth)
         val minCompressedTitleWidth = (
-            titleHorizontalPadding * 2 +
-                titleIconSize +
-                titleIconSpacing +
-                LibraryNavigationPillMinimumTextWidth
-            ).coerceAtMost(maxTitleWidth)
+                titleHorizontalPadding * 2 +
+                        titleIconSize +
+                        titleIconSpacing +
+                        LibraryNavigationPillMinimumTextWidth
+                ).coerceAtMost(maxTitleWidth)
         val forcedCompressionWidth = minOf(
             LibraryNavigationPillForcedCompressionWidth,
             (naturalTitleWidth - minCompressedTitleWidth).coerceAtLeast(0.dp),
         )
         val targetTitleWidth = (
-            naturalTitleWidth - (forcedCompressionWidth * compressionProgress)
-            ).coerceAtLeast(minCompressedTitleWidth)
+                naturalTitleWidth - (forcedCompressionWidth * compressionProgress)
+                ).coerceAtLeast(minCompressedTitleWidth)
         val widthCompressionRatio = if (idealTitleWidth.value > 0f) {
             (targetTitleWidth.value / idealTitleWidth.value).coerceIn(0f, 1f)
         } else {
             1f
         }
         val widthAxisBySpace = LibraryNavigationPillTitleWidthMin +
-            (LibraryNavigationPillTitleWidthMax - LibraryNavigationPillTitleWidthMin) *
-            widthCompressionRatio.coerceIn(0f, 1f)
+                (LibraryNavigationPillTitleWidthMax - LibraryNavigationPillTitleWidthMin) *
+                widthCompressionRatio.coerceIn(0f, 1f)
         val forcedWidthAxis = LibraryNavigationPillTitleWidthMax -
-            (LibraryNavigationPillTitleWidthMax - LibraryNavigationPillCompressedWidthAxis) *
-            compressionProgress
+                (LibraryNavigationPillTitleWidthMax - LibraryNavigationPillCompressedWidthAxis) *
+                compressionProgress
         val targetWidthAxis = minOf(widthAxisBySpace, forcedWidthAxis)
         val animatedTitleWidth by animateDpAsState(
             targetValue = targetTitleWidth,
@@ -2162,18 +2234,18 @@ fun LibraryNavigationPill(
                                 diff == 0 -> 0
                                 // If the absolute difference is very large, it's likely a wrap-around or a direct jump
                                 // We treat jumps as "forward" if positive, but we could also check a threshold
-                                abs(diff) > 1 -> diff.coerceIn(-1, 1) 
+                                abs(diff) > 1 -> diff.coerceIn(-1, 1)
                                 else -> diff
                             }
-                            
-                            val slideIn = slideInHorizontally { fullWidth -> 
-                                if (direction >= 0) fullWidth else -fullWidth 
+
+                            val slideIn = slideInHorizontally { fullWidth ->
+                                if (direction >= 0) fullWidth else -fullWidth
                             } + fadeIn(animationSpec = tween(220))
-                            
-                            val slideOut = slideOutHorizontally { fullWidth -> 
-                                if (direction >= 0) -fullWidth else fullWidth 
+
+                            val slideOut = slideOutHorizontally { fullWidth ->
+                                if (direction >= 0) -fullWidth else fullWidth
                             } + fadeOut(animationSpec = tween(220))
-                            
+
                             slideIn.togetherWith(slideOut)
                         },
                         label = "LibraryPillTitle"
@@ -2208,7 +2280,7 @@ fun LibraryNavigationPill(
                                     Spacer(modifier = Modifier.width(titleIconSpacing))
                                 }
                             }
-            Text(
+                            Text(
                                 modifier = Modifier
                                     .weight(1f, fill = false)
                                     .padding(end = 4.dp), // Add slight end padding for safety

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
@@ -220,7 +220,7 @@ fun TelegramDashboardScreen(
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .fillMaxSize()
-                        //.padding(top = currentTopBarHeightDp + 8.dp)
+                    //.padding(top = currentTopBarHeightDp + 8.dp)
                     ,
                     onAdd = onAddChannel
                 )
@@ -582,10 +582,16 @@ private fun TopicRow(topic: TelegramTopicEntity) {
                 .background(MaterialTheme.colorScheme.secondaryContainer),
             contentAlignment = Alignment.Center
         ) {
-            Text(
-                text = topic.iconEmoji?.let { "\uD83C\uDFB5" } ?: "🎵",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.primary,
+//            Text(
+//                text = topic.iconEmoji?.takeIf { it.isNotBlank() } ?: "🎵",
+//                style = MaterialTheme.typography.bodyMedium,
+//                color = MaterialTheme.colorScheme.primary,
+//            )
+            Icon(
+                imageVector = Icons.Rounded.Topic,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp)
             )
         }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -32,6 +32,8 @@ import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.os.Build
 import android.provider.MediaStore
+import com.theveloper.pixelplay.data.preferences.TelegramTopicDisplayMode
+import com.theveloper.pixelplay.data.ai.AiPlaylistGenerator
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import java.io.FileOutputStream
@@ -43,6 +45,7 @@ import javax.inject.Inject
 data class PlaylistUiState(
     val playlists: List<Playlist> = emptyList(),
     val showTelegramCloudPlaylists: Boolean = true,
+    val telegramTopicDisplayMode: TelegramTopicDisplayMode = TelegramTopicDisplayMode.CHANNELS_AND_TOPICS,
     val currentPlaylistSongs: List<Song> = emptyList(),
     val currentPlaylistDetails: Playlist? = null,
     val isLoading: Boolean = false,
@@ -59,7 +62,7 @@ data class PlaylistUiState(
     val currentPlaylistSongsSortOption: SortOption = SortOption.SongTitleAZ,
     val playlistSongsOrderMode: PlaylistSongsOrderMode = PlaylistSongsOrderMode.Sorted(SortOption.SongTitleAZ),
     val playlistOrderModes: Map<String, PlaylistSongsOrderMode> = emptyMap(),
-    
+
     // AI Generation State
     val isAiGenerating: Boolean = false,
     val aiGenerationError: String? = null
@@ -75,7 +78,7 @@ class PlaylistViewModel @Inject constructor(
     private val playlistPreferencesRepository: PlaylistPreferencesRepository,
     private val musicRepository: MusicRepository,
     private val dailyMixManager: DailyMixManager,
-    private val aiPlaylistGenerator: com.theveloper.pixelplay.data.ai.AiPlaylistGenerator,
+    private val aiPlaylistGenerator: AiPlaylistGenerator,
     private val m3uManager: M3uManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -109,6 +112,7 @@ class PlaylistViewModel @Inject constructor(
     init {
         loadPlaylistsAndInitialSortOption()
         observeTelegramCloudPlaylistVisibility()
+        observeTelegramTopicDisplayMode()
         loadMoreSongsForSelection(isInitialLoad = true)
         observePlaylistOrderModes()
     }
@@ -161,6 +165,21 @@ class PlaylistViewModel @Inject constructor(
             playlistPreferencesRepository.showTelegramCloudPlaylistsFlow.collect { show ->
                 _uiState.update { it.copy(showTelegramCloudPlaylists = show) }
             }
+        }
+    }
+
+    private fun observeTelegramTopicDisplayMode() {
+        viewModelScope.launch {
+            playlistPreferencesRepository.telegramTopicDisplayModeFlow.collect { mode ->
+                _uiState.update { it.copy(telegramTopicDisplayMode = mode) }
+            }
+        }
+    }
+
+    fun setTelegramTopicDisplayMode(mode: TelegramTopicDisplayMode) { // Simplified
+        _uiState.update { it.copy(telegramTopicDisplayMode = mode) }
+        viewModelScope.launch {
+            playlistPreferencesRepository.setTelegramTopicDisplayMode(mode)
         }
     }
 
@@ -293,8 +312,8 @@ class PlaylistViewModel @Inject constructor(
                     }
                 } else {
                     // Obtener la playlist de las preferencias del usuario
-                        val playlist = playlistPreferencesRepository.userPlaylistsFlow.first()
-                            .find { it.id == playlistId }
+                    val playlist = playlistPreferencesRepository.userPlaylistsFlow.first()
+                        .find { it.id == playlistId }
 
                     if (playlist != null) {
                         val orderMode = _uiState.value.playlistOrderModes[playlistId]
@@ -371,12 +390,12 @@ class PlaylistViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             var savedCoverPath: String? = null
-            
+
             if (coverImageUri != null) {
                 // Generate a unique ID for the image file since we don't have the playlist ID yet
                 val imageId = UUID.randomUUID().toString()
                 savedCoverPath = saveCoverImageToInternalStorage(
-                    Uri.parse(coverImageUri), 
+                    Uri.parse(coverImageUri),
                     imageId,
                     cropScale,
                     cropPanX,
@@ -491,7 +510,7 @@ class PlaylistViewModel @Inject constructor(
 
 
     suspend fun saveCoverImageToInternalStorage(
-        uri: Uri, 
+        uri: Uri,
         uniqueId: String,
         cropScale: Float,
         cropPanX: Float,
@@ -502,74 +521,74 @@ class PlaylistViewModel @Inject constructor(
                 // Load original bitmap
                 val originalBitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri)) { decoder, _, _ ->
-                         // Optimization: Mutable to support software rendering if needed
-                         decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE 
-                         // Use HARWARE if possible but need to copy for Canvas? 
-                         // Software is safer for manual Canvas drawing.
+                        // Optimization: Mutable to support software rendering if needed
+                        decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+                        // Use HARWARE if possible but need to copy for Canvas?
+                        // Software is safer for manual Canvas drawing.
                     }
                 } else {
                     @Suppress("DEPRECATION")
                     MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
                 }
-                
+
                 // Target dimensions (Square)
                 val targetSize = 1024
-                
+
                 // create target bitmap
                 val targetBitmap = Bitmap.createBitmap(targetSize, targetSize, Bitmap.Config.ARGB_8888)
                 val canvas = android.graphics.Canvas(targetBitmap)
-                
+
                 // Calculate base dimensions (fitting smallest dimension to target)
                 // Logic must match ImageCropView
                 val bitmapWidth = originalBitmap.width.toFloat()
                 val bitmapHeight = originalBitmap.height.toFloat()
                 val bitmapRatio = bitmapWidth / bitmapHeight
-                
+
                 val (baseWidth, baseHeight) = if (bitmapRatio > 1f) {
-                     // Wide: Height matches target
-                     targetSize * bitmapRatio to targetSize.toFloat()
+                    // Wide: Height matches target
+                    targetSize * bitmapRatio to targetSize.toFloat()
                 } else {
-                     // Tall: Width matches target
-                     targetSize.toFloat() to targetSize / bitmapRatio
+                    // Tall: Width matches target
+                    targetSize.toFloat() to targetSize / bitmapRatio
                 }
-                
+
                 // Calculate transformations
                 // Scaled Dimensions
                 val scaledWidth = baseWidth * cropScale
                 val scaledHeight = baseHeight * cropScale
-                
+
                 // Center + Pan
                 // Center of target is targetSize/2
                 // We want to center the Scaled Image at (Center + Pan)
                 // TopLeft = CenterX - ScaledW/2 + PanX
-                
+
                 // Pan is normalized relative to Viewport (TargetSize)
                 val panPxX = cropPanX * targetSize
                 val panPxY = cropPanY * targetSize
-                
+
                 val dx = (targetSize - scaledWidth) / 2f + panPxX
                 val dy = (targetSize - scaledHeight) / 2f + panPxY
-                
+
                 // Draw
                 // We draw the original bitmap scaled to (scaledWidth, scaledHeight) at (dx, dy)
                 val matrix = android.graphics.Matrix()
                 matrix.postScale(scaledWidth / bitmapWidth, scaledHeight / bitmapHeight)
                 matrix.postTranslate(dx, dy)
-                
+
                 canvas.drawBitmap(originalBitmap, matrix, null)
-                
+
                 // Save
                 val fileName = "playlist_cover_$uniqueId.jpg"
                 val file = File(context.filesDir, fileName)
                 FileOutputStream(file).use { out ->
                     targetBitmap.compress(Bitmap.CompressFormat.JPEG, 90, out)
                 }
-                
+
                 // Recycle
                 if (originalBitmap != targetBitmap) originalBitmap.recycle()
-                // Target bitmap is not recycled here, let GC handle? 
+                // Target bitmap is not recycled here, let GC handle?
                 // Or recycle explicitly if immediate memory pressure concern.
-                
+
                 file.absolutePath
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -660,20 +679,20 @@ class PlaylistViewModel @Inject constructor(
             // But if the user selected a new image, it will be a content content:// uri.
 
             if (coverImageUri != null && coverImageUri != currentPlaylist.coverImageUri) {
-                 // Check if it is a content URI or a file path that is NOT the existing saved path
-                 if (coverImageUri.startsWith("content://") || (coverImageUri.startsWith("/") && coverImageUri != currentPlaylist.coverImageUri)) {
-                     val imageId = UUID.randomUUID().toString()
-                     val newPath = saveCoverImageToInternalStorage(
-                         Uri.parse(coverImageUri),
-                         imageId,
-                         cropScale,
-                         cropPanX,
-                         cropPanY
-                     )
-                     if (newPath != null) {
-                         savedCoverPath = newPath
-                     }
-                 }
+                // Check if it is a content URI or a file path that is NOT the existing saved path
+                if (coverImageUri.startsWith("content://") || (coverImageUri.startsWith("/") && coverImageUri != currentPlaylist.coverImageUri)) {
+                    val imageId = UUID.randomUUID().toString()
+                    val newPath = saveCoverImageToInternalStorage(
+                        Uri.parse(coverImageUri),
+                        imageId,
+                        cropScale,
+                        cropPanX,
+                        cropPanY
+                    )
+                    if (newPath != null) {
+                        savedCoverPath = newPath
+                    }
+                }
             } else if (coverImageUri == null) {
                 // If passed null, it might mean remove cover? Or just no change?
                 // For this implementation let's assume if the user cleared it, the UI passes null.
@@ -682,7 +701,7 @@ class PlaylistViewModel @Inject constructor(
                 // Let's assume the UI sends the desired final state.
                 // NOTE: If the user didn't change the image, the UI might send the existing coverImageUri (which is a file path).
                 // Or if they removed it, they send null.
-                
+
                 // However, we also have crop parameters. If image is unchanged but crop changed, we should re-save (re-crop)
                 // if we have the original source. But we don't have the original source for the existing cover (we only have the cropped result).
                 // So, we can only re-crop if we have a source URI.
@@ -822,7 +841,7 @@ class PlaylistViewModel @Inject constructor(
 
     fun sortPlaylistSongs(sortOption: SortOption) {
         val playlistId = _uiState.value.currentPlaylistDetails?.id
-        
+
         // If SongDefaultOrder is selected, reload the playlist to get original order
         if (sortOption == SortOption.SongDefaultOrder) {
             if (playlistId != null) {
@@ -923,7 +942,7 @@ class PlaylistViewModel @Inject constructor(
     fun generateAiPlaylist(prompt: String, minLength: Int = 10, maxLength: Int = 50) {
         viewModelScope.launch {
             _uiState.update { it.copy(isAiGenerating = true, aiGenerationError = null) }
-            
+
             try {
                 // Fetch all library songs
                 val allSongs = withContext(Dispatchers.IO) {
@@ -937,18 +956,18 @@ class PlaylistViewModel @Inject constructor(
                     minLength = minLength,
                     maxLength = maxLength
                 )
-                
+
                 result.onSuccess { selectedSongs ->
                     // Create Playlist
-                    val playlistName = "AI: $prompt".take(50) 
-                    
+                    val playlistName = "AI: $prompt".take(50)
+
                     playlistPreferencesRepository.createPlaylist(
                         name = playlistName,
                         songIds = selectedSongs.map { it.id },
                         isAiGenerated = true,
                         source = "AI" // Mark as AI source
                     )
-                    
+
                     _uiState.update { it.copy(isAiGenerating = false) }
                     _playlistCreationEvent.emit(true)
                 }.onFailure { e ->
@@ -965,7 +984,7 @@ class PlaylistViewModel @Inject constructor(
             }
         }
     }
-    
+
     fun clearAiError() {
         _uiState.update { it.copy(aiGenerationError = null) }
     }
@@ -989,7 +1008,7 @@ class PlaylistViewModel @Inject constructor(
      */
     fun mergeSelectedPlaylists(playlistIds: List<String>, newPlaylistName: String) {
         if (newPlaylistName.isBlank()) return
-        
+
         viewModelScope.launch {
             try {
                 // Get all songs from selected playlists
@@ -1034,13 +1053,13 @@ class PlaylistViewModel @Inject constructor(
             Log.w("PlaylistViewModel", "Activity is null, cannot share")
             return
         }
-        
+
         viewModelScope.launch {
             try {
                 Log.d("PlaylistViewModel", "Starting share of ${playlistIds.size} playlists")
                 // Get all selected playlists with their songs
                 val playlistsWithSongs = getPlaylistsWithSongs(playlistIds)
-                
+
                 if (playlistsWithSongs.isEmpty()) {
                     Log.w("PlaylistViewModel", "No playlists found to share")
                     Toast.makeText(context, "No playlists to share", Toast.LENGTH_SHORT).show()
@@ -1050,7 +1069,7 @@ class PlaylistViewModel @Inject constructor(
                 val shareFile: File
                 val shareFileName: String
                 val shareMimeType: String
-                
+
                 if (playlistsWithSongs.size == 1) {
                     // Single playlist: share M3U file directly
                     val (playlist, songs) = playlistsWithSongs.first()
@@ -1065,7 +1084,7 @@ class PlaylistViewModel @Inject constructor(
                     val zipFileName = "Playlists_${playlistsWithSongs.first().first.name}_and_${playlistsWithSongs.size - 1}_more.zip"
                     shareFile = File(context.cacheDir, zipFileName)
                     val outputStream = FileOutputStream(shareFile)
-                    
+
                     java.util.zip.ZipOutputStream(outputStream).use { zipOut ->
                         playlistsWithSongs.forEach { (playlist, songs) ->
                             val m3uContent = m3uManager.generateM3u(playlist, songs)
@@ -1075,7 +1094,7 @@ class PlaylistViewModel @Inject constructor(
                             zipOut.closeEntry()
                         }
                     }
-                    
+
                     shareFileName = zipFileName
                     shareMimeType = "application/zip"
                     Log.d("PlaylistViewModel", "Created ZIP file: ${shareFile.absolutePath}, size: ${shareFile.length()} bytes")
@@ -1087,17 +1106,17 @@ class PlaylistViewModel @Inject constructor(
                     "${context.packageName}.provider",
                     shareFile
                 )
-                
+
                 val shareIntent = Intent(Intent.ACTION_SEND).apply {
                     type = shareMimeType
                     putExtra(Intent.EXTRA_STREAM, uri)
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-                
+
                 Log.d("PlaylistViewModel", "Launching share intent for: $shareFileName")
                 activity.startActivity(Intent.createChooser(shareIntent, "Share Playlists"))
                 Toast.makeText(context, "Sharing ${playlistsWithSongs.size} playlist(s)", Toast.LENGTH_SHORT).show()
-                
+
             } catch (e: Exception) {
                 Log.e("PlaylistViewModel", "Error sharing playlists", e)
                 Toast.makeText(context, "Share failed: ${e.message}", Toast.LENGTH_LONG).show()
@@ -1112,12 +1131,12 @@ class PlaylistViewModel @Inject constructor(
      */
     fun mergePlaylistsIntoOne(playlistIds: List<String>, newPlaylistName: String) {
         if (playlistIds.isEmpty() || newPlaylistName.isEmpty()) return
-        
+
         viewModelScope.launch {
             try {
                 // Get all playlists first
                 val currentPlaylists = _uiState.value.playlists
-                
+
                 // Get all songs from selected playlists
                 val allSongs = mutableSetOf<String>()
                 playlistIds.forEach { playlistId ->
@@ -1144,9 +1163,9 @@ class PlaylistViewModel @Inject constructor(
                     isAiGenerated = false,
                     isQueueGenerated = false
                 )
-                
+
                 Log.d("PlaylistViewModel", "Successfully merged ${playlistIds.size} playlists into '$newPlaylistName' with ${allSongs.size} total unique songs")
-                
+
             } catch (e: Exception) {
                 Log.e("PlaylistViewModel", "Error merging playlists", e)
             }
@@ -1158,7 +1177,7 @@ class PlaylistViewModel @Inject constructor(
      */
     fun exportPlaylistsAsM3u(playlistIds: List<String>) {
         if (playlistIds.isEmpty()) return
-        
+
         viewModelScope.launch {
             try {
                 Log.d("PlaylistViewModel", "Starting export of ${playlistIds.size} playlists")
@@ -1166,29 +1185,29 @@ class PlaylistViewModel @Inject constructor(
                 if (!musicDir.exists()) {
                     musicDir.mkdirs()
                 }
-                
+
                 val exportDir = File(musicDir, "PixelPlayer Exports")
                 if (!exportDir.exists()) {
                     exportDir.mkdirs()
                 }
-                
+
                 val playlistsWithSongs = getPlaylistsWithSongs(playlistIds)
                 if (playlistsWithSongs.isEmpty()) {
                     Log.w("PlaylistViewModel", "No playlists found to export")
                     Toast.makeText(context, "No playlists to export", Toast.LENGTH_SHORT).show()
                     return@launch
                 }
-                
+
                 playlistsWithSongs.forEach { (playlist, songs) ->
                     val m3uContent = m3uManager.generateM3u(playlist, songs)
                     val file = File(exportDir, "${playlist.name}.m3u")
                     file.writeText(m3uContent)
                     Log.d("PlaylistViewModel", "Exported playlist '${playlist.name}' to ${file.absolutePath}")
                 }
-                
+
                 Log.d("PlaylistViewModel", "Successfully exported ${playlistIds.size} playlists to $exportDir")
                 Toast.makeText(context, "Exported ${playlistsWithSongs.size} playlist(s) to Music/PixelPlayer Exports", Toast.LENGTH_SHORT).show()
-                
+
             } catch (e: Exception) {
                 Log.e("PlaylistViewModel", "Error exporting playlists", e)
                 Toast.makeText(context, "Export failed: ${e.message}", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
- Introduce TelegramTopicDisplayMode to control how Telegram channel and topic playlists are shown (Channels Only, Topics Only, or Both).

- Update UserPreferencesRepository and PlaylistPreferencesRepository to persist and expose the new display mode via DataStore.

- Implement dynamic playlist filtering in LibraryScreen based on the active TelegramTopicDisplayMode.

- Add a Topics Display segmented toggle to the LibrarySortBottomSheet.

- Standardize iconography for Telegram topics across PlaylistItem and TelegramDashboardScreen.

- Support TELEGRAM_TOPIC as a distinct playlist source with dedicated UI indicators.

- General UI refinements, including improved spacing and consistent icon usage.