### PR TITLE
fix: prevent text clipping for non-latin scripts in top bar and album grid

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
@@ -522,7 +522,7 @@ private fun SharedAlbumTopBarProbe(
             expandedTitleStartPadding = 24.dp,
             collapsedTitleEndPadding = 24.dp,
             expandedTitleEndPadding = 136.dp,
-            containerHeightRange = 92.dp to 56.dp,
+            containerHeightRange = 112.dp to 56.dp,
             titleStyle = MaterialTheme.typography.headlineMedium.copy(
                 fontFamily = GoogleSansRounded,
                 fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -773,7 +773,7 @@ private fun SharedArtistTopBarProbe(
             expandedTitleStartPadding = 24.dp,
             collapsedTitleEndPadding = 88.dp,
             expandedTitleEndPadding = 136.dp,
-            containerHeightRange = 92.dp to 56.dp,
+            containerHeightRange = 112.dp to 56.dp,
             titleStyle = MaterialTheme.typography.headlineMedium.copy(
                 fontFamily = GoogleSansRounded,
                 fontWeight = FontWeight.SemiBold,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -2929,7 +2929,9 @@ fun AlbumGridItemRedesigned(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(12.dp)
+                        .height(84.dp)
+                        .padding(12.dp),
+                    verticalArrangement = Arrangement.Center
                 ) {
                     ShimmerBox(
                         modifier = Modifier
@@ -3032,7 +3034,9 @@ fun AlbumGridItemRedesigned(
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(12.dp)
+                            .height(84.dp)
+                            .padding(12.dp),
+                        verticalArrangement = Arrangement.Center
                     ) {
                         Text(
                             album.title,


### PR DESCRIPTION
### Summary
- Fix text being cut off when using non-Latin scripts (e.g. Japanese, Korean, Chinese)
- Adjust top bar and album grid height to better accommodate varying font metrics