### PR TITLE
Improve playback queue management and favorites handling

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -477,6 +477,50 @@ interface MusicDao {
         filterMode: Int
     ): List<Long>
 
+    @Query("""
+        SELECT songs.id FROM songs
+        INNER JOIN favorites ON songs.id = favorites.songId AND favorites.isFavorite = 1
+        WHERE (:applyDirectoryFilter = 0 OR songs.parent_directory_path IN (:allowedParentDirs))
+        AND (
+            :filterMode = 0
+            OR (
+                :filterMode = 1
+                AND songs.content_uri_string NOT LIKE 'telegram://%'
+                AND songs.content_uri_string NOT LIKE 'netease://%'
+                AND songs.content_uri_string NOT LIKE 'gdrive://%'
+                AND songs.content_uri_string NOT LIKE 'qqmusic://%'
+                AND songs.content_uri_string NOT LIKE 'navidrome://%'
+            )
+            OR (
+                :filterMode = 2
+                AND (
+                    songs.content_uri_string LIKE 'telegram://%'
+                    OR songs.content_uri_string LIKE 'netease://%'
+                    OR songs.content_uri_string LIKE 'gdrive://%'
+                    OR songs.content_uri_string LIKE 'qqmusic://%'
+                    OR songs.content_uri_string LIKE 'navidrome://%'
+                )
+            )
+        )
+        ORDER BY
+            CASE WHEN :sortOrder = 'liked_title_az' THEN songs.title END ASC,
+            CASE WHEN :sortOrder = 'liked_title_za' THEN songs.title END DESC,
+            CASE WHEN :sortOrder = 'liked_artist' THEN songs.artist_name END ASC,
+            CASE WHEN :sortOrder = 'liked_artist_desc' THEN songs.artist_name END DESC,
+            CASE WHEN :sortOrder = 'liked_album' THEN songs.album_name END ASC,
+            CASE WHEN :sortOrder = 'liked_album_desc' THEN songs.album_name END DESC,
+            CASE WHEN :sortOrder = 'liked_date_liked' THEN favorites.timestamp END DESC,
+            CASE WHEN :sortOrder = 'liked_date_liked_asc' THEN favorites.timestamp END ASC,
+            songs.title ASC,
+            songs.id ASC
+    """)
+    suspend fun getFavoriteSongIdsSorted(
+        allowedParentDirs: List<String>,
+        applyDirectoryFilter: Boolean,
+        sortOrder: String,
+        filterMode: Int
+    ): List<Long>
+
     // --- Paginated Queries for Large Libraries ---
     /**
      * Returns a PagingSource for songs, enabling efficient pagination for large libraries.

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
@@ -261,4 +261,9 @@ interface MusicRepository {
         sortOption: com.theveloper.pixelplay.data.model.SortOption,
         storageFilter: com.theveloper.pixelplay.data.model.StorageFilter
     ): List<Long>
+
+    suspend fun getFavoriteSongIdsSorted(
+        sortOption: com.theveloper.pixelplay.data.model.SortOption,
+        storageFilter: com.theveloper.pixelplay.data.model.StorageFilter
+    ): List<Long>
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -796,4 +796,22 @@ class MusicRepositoryImpl @Inject constructor(
             filterMode = filterMode
         )
     }
+
+    override suspend fun getFavoriteSongIdsSorted(
+        sortOption: SortOption,
+        storageFilter: com.theveloper.pixelplay.data.model.StorageFilter
+    ): List<Long> = withContext(Dispatchers.IO) {
+        val allowedDirsFlow = userPreferencesRepository.allowedDirectoriesFlow.first()
+        val blockedDirsFlow = userPreferencesRepository.blockedDirectoriesFlow.first()
+        val (allowedParentDirs, applyFilter) = computeAllowedDirs(allowedDirsFlow, blockedDirsFlow)
+
+        val filterMode = storageFilter.toFilterMode()
+
+        musicDao.getFavoriteSongIdsSorted(
+            allowedParentDirs = allowedParentDirs,
+            applyDirectoryFilter = applyFilter,
+            sortOrder = sortOption.storageKey,
+            filterMode = filterMode
+        )
+    }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
@@ -229,11 +229,7 @@ fun LibraryFavoritesTab(
                                         if (isSelectionMode) {
                                             onSongSelectionToggle(song)
                                         } else {
-                                            playerViewModel.showAndPlaySong(
-                                                song,
-                                                favoriteSongs.itemSnapshotList.items,
-                                                "Liked Songs"
-                                            )
+                                            playerViewModel.showAndPlaySongFromFavorites(song)
                                         }
                                     }
                                 )
@@ -413,7 +409,7 @@ fun LibrarySongsTabPaginated(
                                         { songFromListItem -> onMoreOptionsClick(songFromListItem) }
                                     }
                                     val rememberedOnClick: () -> Unit = remember(song) {
-                                        { playerViewModel.showAndPlaySong(song) }
+                                        { playerViewModel.showAndPlaySongFromLibrary(song) }
                                     }
 
                                     EnhancedSongListItem(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -319,8 +319,7 @@ fun LibrarySongsTab(
                                         if (isSelectionMode) {
                                             { onSongSelectionToggle(song) }
                                         } else {
-                                            // Use snapshot items for playback queue
-                                            { playerViewModel.showAndPlaySong(song, songs.itemSnapshotList.items, "Library") }
+                                            { playerViewModel.showAndPlaySongFromLibrary(song) }
                                         }
                                     }
                                     

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -3,6 +3,7 @@ package com.theveloper.pixelplay.presentation.viewmodel
 import androidx.media3.session.MediaController
 import androidx.media3.common.Player
 import androidx.media3.common.C
+import androidx.media3.common.MediaItem
 import com.theveloper.pixelplay.data.service.player.DualPlayerEngine
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import javax.inject.Inject
@@ -572,6 +573,16 @@ class PlaybackStateHolder @Inject constructor(
     /*                               Shuffle & Repeat                             */
     /* -------------------------------------------------------------------------- */
 
+    private data class PreparedQueueReplacement(
+        val mediaItems: List<MediaItem>,
+        val targetIndex: Int
+    )
+
+    private data class PreparedQueueSegments(
+        val beforeCurrent: List<MediaItem>,
+        val afterCurrent: List<MediaItem>
+    )
+
     private fun reorderQueueInPlace(player: Player, desiredQueue: List<Song>): Boolean {
         if (desiredQueue.isEmpty()) return false
 
@@ -630,19 +641,96 @@ class PlaybackStateHolder @Inject constructor(
      * preserving the currently playing song and its position. This is O(1) IPC calls
      * versus O(n) for reorderQueueInPlace, making it suitable for large queue shuffles.
      */
-    private fun replacePlayerQueue(player: Player, newQueue: List<Song>, currentSongId: String?, currentPosition: Long) {
-        val wasPlaying = player.isPlaying
-        val targetIndex = if (currentSongId != null) {
-            newQueue.indexOfFirst { it.id == currentSongId }.takeIf { it != -1 } ?: 0
-        } else 0
+    private suspend fun buildQueueReplacement(
+        newQueue: List<Song>,
+        targetIndex: Int,
+        currentMediaItem: MediaItem?
+    ): PreparedQueueReplacement = withContext(Dispatchers.Default) {
+        val safeTargetIndex = targetIndex.coerceIn(0, (newQueue.size - 1).coerceAtLeast(0))
 
-        dualPlayerEngine.masterPlayer.setMediaItems(
-            newQueue.map { MediaItemBuilder.build(it) },
-            targetIndex,
+        val mediaItems = List(newQueue.size) { index ->
+            currentMediaItem
+                ?.takeIf { index == safeTargetIndex && it.mediaId == newQueue[safeTargetIndex].id }
+                ?: MediaItemBuilder.build(newQueue[index])
+        }
+
+        PreparedQueueReplacement(
+            mediaItems = mediaItems,
+            targetIndex = safeTargetIndex
+        )
+    }
+
+    private suspend fun buildQueueSegments(
+        newQueue: List<Song>,
+        currentIndex: Int,
+        currentMediaItem: MediaItem?
+    ): PreparedQueueSegments? = withContext(Dispatchers.Default) {
+        val safeCurrentIndex = currentIndex.coerceIn(0, (newQueue.size - 1).coerceAtLeast(0))
+        val currentQueueSong = newQueue.getOrNull(safeCurrentIndex) ?: return@withContext null
+        if (currentMediaItem?.mediaId != currentQueueSong.id) {
+            return@withContext null
+        }
+
+        val beforeCurrent = List(safeCurrentIndex) { index ->
+            MediaItemBuilder.build(newQueue[index])
+        }
+
+        val afterStartIndex = safeCurrentIndex + 1
+        val afterCurrent = List((newQueue.size - afterStartIndex).coerceAtLeast(0)) { offset ->
+            MediaItemBuilder.build(newQueue[afterStartIndex + offset])
+        }
+
+        PreparedQueueSegments(
+            beforeCurrent = beforeCurrent,
+            afterCurrent = afterCurrent
+        )
+    }
+
+    private fun replacePlayerQueuePreservingCurrent(
+        currentIndex: Int,
+        preparedSegments: PreparedQueueSegments
+    ): Boolean {
+        val masterPlayer = dualPlayerEngine.masterPlayer
+        val mediaItemCount = masterPlayer.mediaItemCount
+        if (currentIndex !in 0 until mediaItemCount) {
+            return false
+        }
+
+        val afterStartIndex = currentIndex + 1
+        if (preparedSegments.beforeCurrent.size != currentIndex) {
+            return false
+        }
+        if (preparedSegments.afterCurrent.size != (mediaItemCount - afterStartIndex)) {
+            return false
+        }
+
+        if (currentIndex > 0) {
+            masterPlayer.replaceMediaItems(0, currentIndex, preparedSegments.beforeCurrent)
+        }
+        masterPlayer.replaceMediaItems(afterStartIndex, mediaItemCount, preparedSegments.afterCurrent)
+
+        return masterPlayer.currentMediaItemIndex == currentIndex
+    }
+
+    private fun replacePlayerQueue(
+        player: Player,
+        preparedQueue: PreparedQueueReplacement,
+        currentPosition: Long
+    ) {
+        val shouldResumePlayback = player.playWhenReady || player.isPlaying
+        val masterPlayer = dualPlayerEngine.masterPlayer
+
+        masterPlayer.setMediaItems(
+            preparedQueue.mediaItems,
+            preparedQueue.targetIndex,
             currentPosition
         )
-        if (wasPlaying && !player.isPlaying) {
-            player.play()
+
+        if (shouldResumePlayback) {
+            masterPlayer.playWhenReady = true
+            if (!masterPlayer.isPlaying) {
+                masterPlayer.play()
+            }
         }
     }
 
@@ -676,11 +764,19 @@ class PlaybackStateHolder @Inject constructor(
                     }
 
                     val currentMediaId = player.currentMediaItem?.mediaId ?: currentSong?.id
-                    val currentIndex = currentMediaId
-                        ?.let { mediaId -> currentSongs.indexOfFirst { it.id == mediaId }.takeIf { it >= 0 } }
-                        ?: player.currentMediaItemIndex.coerceIn(0, (currentSongs.size - 1).coerceAtLeast(0))
+                    val playerCurrentIndex = player.currentMediaItemIndex
+                        .takeIf { it in currentSongs.indices }
+                    val currentIndex = when {
+                        playerCurrentIndex != null && currentMediaId != null &&
+                            currentSongs.getOrNull(playerCurrentIndex)?.id == currentMediaId -> playerCurrentIndex
+                        playerCurrentIndex != null && currentMediaId == null -> playerCurrentIndex
+                        currentMediaId != null ->
+                            currentSongs.indexOfFirst { it.id == currentMediaId }.takeIf { it >= 0 }
+                        else -> null
+                    } ?: 0
                     val currentPosition = player.currentPosition
                     val wasPlaying = player.isPlaying
+                    val currentMediaItem = player.currentMediaItem
 
                     // Run heavy shuffle work off main to keep UI and playback responsive.
                     val shuffledQueue = withContext(Dispatchers.Default) {
@@ -690,11 +786,43 @@ class PlaybackStateHolder @Inject constructor(
                     // For large queues, use bulk replace (1 IPC call) instead of
                     // per-item moveMediaItem (n IPC calls) which freezes the UI.
                     if (currentSongs.size > BULK_REPLACE_THRESHOLD) {
-                        replacePlayerQueue(player, shuffledQueue, currentMediaId, currentPosition)
+                        val preservedReplacement = buildQueueSegments(
+                            newQueue = shuffledQueue,
+                            currentIndex = currentIndex,
+                            currentMediaItem = currentMediaItem
+                        )
+                        val replacedInPlace = preservedReplacement?.let { preparedSegments ->
+                            replacePlayerQueuePreservingCurrent(currentIndex, preparedSegments)
+                        } == true
+
+                        if (!replacedInPlace) {
+                            val preparedQueue = buildQueueReplacement(
+                                newQueue = shuffledQueue,
+                                targetIndex = currentIndex,
+                                currentMediaItem = currentMediaItem
+                            )
+                            replacePlayerQueue(player, preparedQueue, currentPosition)
+                        }
                     } else {
                         val reordered = reorderQueueInPlace(player, shuffledQueue)
                         if (!reordered) {
-                            replacePlayerQueue(player, shuffledQueue, currentMediaId, currentPosition)
+                            val preservedReplacement = buildQueueSegments(
+                                newQueue = shuffledQueue,
+                                currentIndex = currentIndex,
+                                currentMediaItem = currentMediaItem
+                            )
+                            val replacedInPlace = preservedReplacement?.let { preparedSegments ->
+                                replacePlayerQueuePreservingCurrent(currentIndex, preparedSegments)
+                            } == true
+
+                            if (!replacedInPlace) {
+                                val preparedQueue = buildQueueReplacement(
+                                    newQueue = shuffledQueue,
+                                    targetIndex = currentIndex,
+                                    currentMediaItem = currentMediaItem
+                                )
+                                replacePlayerQueue(player, preparedQueue, currentPosition)
+                            }
                         }
                     }
 
@@ -726,6 +854,7 @@ class PlaybackStateHolder @Inject constructor(
                     val wasPlaying = player.isPlaying
                     val currentPosition = player.currentPosition
                     val currentSongId = currentSong?.id ?: player.currentMediaItem?.mediaId
+                    val currentMediaItem = player.currentMediaItem
                     val originalIndex = originalQueue.indexOfFirst { it.id == currentSongId }.takeIf { it >= 0 }
 
                     if (originalIndex == null) {
@@ -735,11 +864,43 @@ class PlaybackStateHolder @Inject constructor(
 
                     // Use bulk replace for large queues to avoid UI freeze
                     if (originalQueue.size > BULK_REPLACE_THRESHOLD) {
-                        replacePlayerQueue(player, originalQueue, currentSongId, currentPosition)
+                        val preservedReplacement = buildQueueSegments(
+                            newQueue = originalQueue,
+                            currentIndex = originalIndex,
+                            currentMediaItem = currentMediaItem
+                        )
+                        val replacedInPlace = preservedReplacement?.let { preparedSegments ->
+                            replacePlayerQueuePreservingCurrent(originalIndex, preparedSegments)
+                        } == true
+
+                        if (!replacedInPlace) {
+                            val preparedQueue = buildQueueReplacement(
+                                newQueue = originalQueue,
+                                targetIndex = originalIndex,
+                                currentMediaItem = currentMediaItem
+                            )
+                            replacePlayerQueue(player, preparedQueue, currentPosition)
+                        }
                     } else {
                         val reordered = reorderQueueInPlace(player, originalQueue)
                         if (!reordered) {
-                            replacePlayerQueue(player, originalQueue, currentSongId, currentPosition)
+                            val preservedReplacement = buildQueueSegments(
+                                newQueue = originalQueue,
+                                currentIndex = originalIndex,
+                                currentMediaItem = currentMediaItem
+                            )
+                            val replacedInPlace = preservedReplacement?.let { preparedSegments ->
+                                replacePlayerQueuePreservingCurrent(originalIndex, preparedSegments)
+                            } == true
+
+                            if (!replacedInPlace) {
+                                val preparedQueue = buildQueueReplacement(
+                                    newQueue = originalQueue,
+                                    targetIndex = originalIndex,
+                                    currentMediaItem = currentMediaItem
+                                )
+                                replacePlayerQueue(player, preparedQueue, currentPosition)
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -558,6 +558,91 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
+    fun showAndPlaySongFromLibrary(
+        song: Song,
+        queueName: String = "Library",
+        isVoluntaryPlay: Boolean = true
+    ) {
+        viewModelScope.launch {
+            runCatching {
+                val sortOption = playerUiState.value.currentSongSortOption
+                val storageFilter = playerUiState.value.currentStorageFilter
+                val sortedIds = musicRepository.getSongIdsSorted(sortOption, storageFilter)
+                val fullQueue = resolvePlaybackQueueFromSortedIds(sortedIds)
+                showAndPlaySong(
+                    song = song,
+                    contextSongs = fullQueue.ifEmpty { listOf(song) },
+                    queueName = queueName,
+                    isVoluntaryPlay = isVoluntaryPlay
+                )
+            }.onFailure { error ->
+                Timber.e(error, "Failed to build full library queue for songId=%s", song.id)
+                showAndPlaySong(song, listOf(song), queueName, isVoluntaryPlay)
+            }
+        }
+    }
+
+    fun showAndPlaySongFromFavorites(
+        song: Song,
+        queueName: String = "Liked Songs",
+        isVoluntaryPlay: Boolean = true
+    ) {
+        viewModelScope.launch {
+            runCatching {
+                val sortOption = playerUiState.value.currentFavoriteSortOption
+                val storageFilter = playerUiState.value.currentStorageFilter
+                val sortedIds = musicRepository.getFavoriteSongIdsSorted(sortOption, storageFilter)
+                val fullQueue = resolvePlaybackQueueFromSortedIds(sortedIds)
+                showAndPlaySong(
+                    song = song,
+                    contextSongs = fullQueue.ifEmpty { listOf(song) },
+                    queueName = queueName,
+                    isVoluntaryPlay = isVoluntaryPlay
+                )
+            }.onFailure { error ->
+                Timber.e(error, "Failed to build favorites queue for songId=%s", song.id)
+                showAndPlaySong(song, listOf(song), queueName, isVoluntaryPlay)
+            }
+        }
+    }
+
+    private suspend fun resolvePlaybackQueueFromSortedIds(sortedIds: List<Long>): List<Song> {
+        if (sortedIds.isEmpty()) return emptyList()
+
+        val orderedIds = sortedIds.map(Long::toString)
+        val cachedSongsById = libraryStateHolder.allSongsById.value
+        val missingIds = ArrayList<String>()
+
+        val cachedQueue = withContext(Dispatchers.Default) {
+            buildList(orderedIds.size) {
+                orderedIds.forEach { songId ->
+                    val cachedSong = cachedSongsById[songId]
+                    if (cachedSong != null) {
+                        add(cachedSong)
+                    } else {
+                        missingIds.add(songId)
+                    }
+                }
+            }
+        }
+
+        if (missingIds.isEmpty()) {
+            return cachedQueue
+        }
+
+        val missingSongsById = musicRepository.getSongsByIds(missingIds).first().associateBy { it.id }
+        return withContext(Dispatchers.Default) {
+            buildList(orderedIds.size) {
+                orderedIds.forEach { songId ->
+                    val resolvedSong = cachedSongsById[songId] ?: missingSongsById[songId]
+                    if (resolvedSong != null) {
+                        add(resolvedSong)
+                    }
+                }
+            }
+        }
+    }
+
     val castRoutes: StateFlow<List<MediaRouter.RouteInfo>> = castStateHolder.castRoutes
     val selectedRoute: StateFlow<MediaRouter.RouteInfo?> = castStateHolder.selectedRoute
     /** Pre-mapped so UI composables don't create a new Flow on every recomposition. */


### PR DESCRIPTION
- **MusicDao / MusicRepository**:
    - Implement `getFavoriteSongIdsSorted` to fetch sorted favorite song IDs with support for directory and storage filtering.
- **PlayerViewModel**:
    - Add `showAndPlaySongFromLibrary` and `showAndPlaySongFromFavorites` to handle queue resolution using sorted IDs from the database.
    - Implement `resolvePlaybackQueueFromSortedIds` to efficiently build playback queues by combining cached library data and repository lookups.
- **PlaybackStateHolder**:
    - Refactor queue replacement logic to use `replaceMediaItems` for better performance and to preserve the currently playing item's state.
    - Introduce `PreparedQueueReplacement` and `PreparedQueueSegments` to handle asynchronous queue building off the main thread, reducing UI freezes during shuffle or sort operations.
- **Library Screens**:
    - Update `LibrarySongsAndFavoritesTabs` and `LibrarySongsTab` to use the new specialized playback methods in `PlayerViewModel`.