### PR TITLE
Decouple lyrics toggles, refine display behavior and optimize performance

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -134,6 +134,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.ui.text.style.TextGeometricTransform
 import androidx.compose.ui.text.style.TextOverflow
 import com.theveloper.pixelplay.presentation.components.subcomps.PlayingEqIcon
+import com.theveloper.pixelplay.utils.MultiLangRomanizer
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -188,8 +189,18 @@ fun LyricsSheet(
     val lyrics by remember { derivedStateOf { stablePlayerState.lyrics } }
     val isPlaying by remember { derivedStateOf { stablePlayerState.isPlaying } }
     val currentSong by remember { derivedStateOf { stablePlayerState.currentSong } }
-    val hasTranslatedSyncedLyrics = remember(lyrics) {
+
+    val hasTranslatedLyrics = remember(lyrics) {
+        // Translated lyrics read same timestamp on the lrc, not possible in plain type lyrics
         lyrics?.synced?.any { !it.translation.isNullOrBlank() } == true
+    }
+
+    val hasRomanizedLyrics = remember(lyrics) {
+        val hasSynced = lyrics?.synced?.any { !it.romanization.isNullOrBlank() } == true
+        val hasPlain = lyrics?.plain?.any { line ->
+            MultiLangRomanizer.isScriptThatNeedsRomanization(line)
+        } == true
+        hasSynced || hasPlain
     }
 
     val context = LocalContext.current
@@ -199,10 +210,18 @@ fun LyricsSheet(
         context.dataStore.data.map { it[stringPreferencesKey("lyrics_alignment")] ?: "left" }
     }
     val lyricsAlignment by lyricsAlignmentFlow.collectAsStateWithLifecycle(initialValue = "left")
+
+    // Read lyrics translation preference internally from DataStore
     val showLyricsTranslationFlow = remember(context) {
         context.dataStore.data.map { it[booleanPreferencesKey("show_lyrics_translation")] ?: true }
     }
     val showLyricsTranslation by showLyricsTranslationFlow.collectAsStateWithLifecycle(initialValue = true)
+
+    // Read lyrics romanization preference internally from DataStore
+    val showLyricsRomanizationFlow = remember(context) {
+        context.dataStore.data.map { it[booleanPreferencesKey("show_lyrics_romanization")] ?: true }
+    }
+    val showLyricsRomanization by showLyricsRomanizationFlow.collectAsStateWithLifecycle(initialValue = true)
 
     // Read animated lyrics preference internally from DataStore
     val useAnimatedLyricsFlow = remember(context) {
@@ -239,8 +258,8 @@ fun LyricsSheet(
     var showSyncedLyrics by remember(lyrics) {
         mutableStateOf(
             when {
-                lyrics?.synced != null -> true
-                lyrics?.plain != null -> false
+                !lyrics?.synced.isNullOrEmpty() -> true
+                !lyrics?.plain.isNullOrEmpty() -> false
                 else -> null
             }
         )
@@ -577,6 +596,7 @@ fun LyricsSheet(
                                 immersiveMode = immersiveMode,
                                 lyricsAlignment = lyricsAlignment,
                                 showTranslation = showLyricsTranslation,
+                                showRomanization = showLyricsRomanization,
                                 footer = {
                                     if (lyrics?.areFromRemote == true) {
                                         item(key = "provider_text") {
@@ -616,6 +636,8 @@ fun LyricsSheet(
                                         line = line,
                                         style = lyricsTextStyle,
                                         lyricsAlignment = lyricsAlignment,
+                                        showTranslation = if (hasTranslatedLyrics) showLyricsTranslation else true,
+                                        showRomanization = if (hasRomanizedLyrics) showLyricsRomanization else true,
                                         modifier = Modifier.fillMaxWidth()
                                     )
                                     Spacer(modifier = Modifier.height(16.dp))
@@ -777,7 +799,7 @@ fun LyricsSheet(
                     backgroundColor = backgroundColor,
                     onBackgroundColor = onBackgroundColor,
                     accentColor = accentColor,
-                    onAccentColor = onAccentColor
+                    onAccentColor = onAccentColor,
                 )
              }
             }
@@ -817,8 +839,10 @@ fun LyricsSheet(
                             }
                         }
                     },
-                    hasTranslatedLyrics = hasTranslatedSyncedLyrics,
+                    hasTranslatedLyrics = hasTranslatedLyrics,
+                    hasRomanizedLyrics = hasRomanizedLyrics,
                     showTranslation = showLyricsTranslation,
+                    showRomanization = showLyricsRomanization,
                     onShowTranslationChange = { enabled ->
                         resetImmersiveTimer()
                         coroutineScope.launch {
@@ -827,6 +851,15 @@ fun LyricsSheet(
                             }
                         }
                     },
+                    onShowRomanizationChange = { enabled ->
+                        resetImmersiveTimer()
+                        coroutineScope.launch {
+                            context.dataStore.edit { preferences ->
+                                preferences[booleanPreferencesKey("show_lyrics_romanization")] = enabled
+                            }
+                        }
+                    },
+                    immersiveLyricsEnabled = immersiveLyricsEnabled,
                     isShuffleEnabled = isShuffleEnabled,
                     repeatMode = repeatMode,
                     isFavoriteProvider = isFavoriteProvider,
@@ -935,6 +968,7 @@ fun SyncedLyricsList(
     immersiveMode: Boolean = false,
     lyricsAlignment: String = "left",
     showTranslation: Boolean = true,
+    showRomanization: Boolean = true,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     footer: LazyListScope.() -> Unit = {}
@@ -1038,6 +1072,7 @@ fun SyncedLyricsList(
                             immersiveMode = immersiveMode,
                             lyricsAlignment = lyricsAlignment,
                             showTranslation = showTranslation,
+                            showRomanization = showRomanization,
                             accentColor = accentColor,
                             style = textStyle,
                             modifier = parallaxModifier
@@ -1377,13 +1412,36 @@ fun PlainLyricsLine(
     style: TextStyle,
     lyricsAlignment: String = "left",
     showTranslation: Boolean = true,
+    showRomanization: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val sanitizedLines = remember(line) { line.split("\n") }
     val primaryText = remember(sanitizedLines) { if (sanitizedLines.isNotEmpty()) sanitizeLyricLineText(sanitizedLines[0]) else "" }
 
-    val translationText = remember(sanitizedLines) {
-        if (sanitizedLines.size > 1) sanitizedLines.drop(1).joinToString("\n") { sanitizeLyricLineText(it) } else ""
+    val isRomanizedScript = remember(primaryText) {
+        MultiLangRomanizer.isScriptThatNeedsRomanization(primaryText)
+    }
+
+    val translationText = remember(sanitizedLines, primaryText, isRomanizedScript) {
+        if (sanitizedLines.size > 1) {
+            val firstExtra = sanitizedLines[1]
+            val rest = if (sanitizedLines.size > 2) sanitizedLines.drop(2).joinToString("\n") { sanitizeLyricLineText(it) } else ""
+            
+            val isLatin = firstExtra.any { it.code in 32..126 } 
+            val isFirstRomanization = isRomanizedScript && isLatin
+
+            if (isFirstRomanization) rest else sanitizedLines.drop(1).joinToString("\n") { sanitizeLyricLineText(it) }
+        } else ""
+    }
+
+    val romanizationText = remember(sanitizedLines, primaryText, isRomanizedScript) {
+         if (sanitizedLines.size > 1) {
+            val firstExtra = sanitizedLines[1]
+            val isLatin = firstExtra.any { it.code in 32..126 } 
+            val isFirstRomanization = isRomanizedScript && isLatin
+            
+            if (isFirstRomanization) sanitizeLyricLineText(firstExtra) else ""
+        } else ""
     }
 
     val textAlign = when (lyricsAlignment) { "center" -> TextAlign.Center; "right" -> TextAlign.Right; else -> TextAlign.Left }
@@ -1401,13 +1459,23 @@ fun PlainLyricsLine(
         if (primaryText.isNotBlank()) {
             Text(text = primaryText, style = style, color = LocalContentColor.current.copy(alpha = 0.7f), textAlign = textAlign)
 
+            if (showRomanization && romanizationText.isNotBlank()) {
+                Text(
+                    text = romanizationText,
+                    style = translationStyle,
+                    color = translationColor,
+                    textAlign = textAlign,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+
             if (showTranslation && translationText.isNotBlank()) {
                 Text(
                     text = translationText,
                     style = translationStyle,
                     color = translationColor,
                     textAlign = textAlign,
-                    modifier = Modifier.padding(top = 4.dp)
+                    modifier = Modifier.padding(top = if (showRomanization && romanizationText.isNotBlank()) 2.dp else 4.dp)
                 )
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.FormatAlignLeft
 import androidx.compose.material.icons.automirrored.rounded.FormatAlignRight
+import androidx.compose.material.icons.rounded.Abc
 import androidx.compose.material.icons.rounded.FormatAlignCenter
 import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Translate
@@ -67,8 +68,12 @@ fun LyricsMoreBottomSheet(
     lyricsAlignment: String,
     onLyricsAlignmentChange: (String) -> Unit,
     hasTranslatedLyrics: Boolean,
+    hasRomanizedLyrics: Boolean,
     showTranslation: Boolean,
+    showRomanization: Boolean,
     onShowTranslationChange: (Boolean) -> Unit,
+    onShowRomanizationChange: (Boolean) -> Unit,
+    immersiveLyricsEnabled: Boolean,
     // BottomToggleRow params
     isShuffleEnabled: Boolean,
     repeatMode: Int,
@@ -253,43 +258,107 @@ fun LyricsMoreBottomSheet(
                 )
             }
 
-            // Sync Settings Group
-            if (showSyncedLyrics) {
-                 Column(
+            // Control Settings Group
+            val isSyncVisible = showSyncedLyrics
+            val isRomanizationVisible = hasRomanizedLyrics
+            val isTranslationVisible = hasTranslatedLyrics
+            val isImmersiveVisible = showSyncedLyrics && immersiveLyricsEnabled
+
+            if (isSyncVisible || isRomanizationVisible || isTranslationVisible) {
+                // Determine first and last items for rounding
+                val isRomanizationFirst = isRomanizationVisible && !isSyncVisible
+                val isTranslationFirst = isTranslationVisible && !isSyncVisible && !isRomanizationVisible
+
+                val isSyncLast = isSyncVisible && !isRomanizationVisible && !isTranslationVisible && !isImmersiveVisible
+                val isRomanizationLast = isRomanizationVisible && !isTranslationVisible && !isImmersiveVisible
+                val isTranslationLast = isTranslationVisible && !isImmersiveVisible
+
+                Column(
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                     Text(
-                         modifier = Modifier
-                             .padding(start = 6.dp, bottom = 6.dp),
-                         text = "Controls",
-                         color = accentColor,
-                         style = MaterialTheme.typography.bodyLargeEmphasized
-                     )
-                    ListItem(
-                        headlineContent = { Text(if (isSyncControlsVisible) "Hide Sync Controls" else "Adjust Sync") },
-                        leadingContent = {
-                            Icon(
-                                imageVector = Icons.Rounded.Tune,
-                                contentDescription = null
-                            )
-                        },
+                    Text(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(topStart = 18.dp, topEnd = 18.dp, bottomStart = 8.dp, bottomEnd = 8.dp))
-                            .background(itemBackgroundColor)
-                            .clickable {
-                                onDismissRequest()
-                                onToggleSyncControls()
-                            },
-                        colors = ListItemDefaults.colors(
-                            containerColor = Color.Transparent,
-                            headlineColor = contentColor,
-                            leadingIconColor = contentColor
-                        )
+                            .padding(start = 6.dp, bottom = 6.dp),
+                        text = "Controls",
+                        color = accentColor,
+                        style = MaterialTheme.typography.bodyLargeEmphasized
                     )
 
-                    if (hasTranslatedLyrics) {
+                    if (isSyncVisible) {
+                        ListItem(
+                            headlineContent = { Text(if (isSyncControlsVisible) "Hide Sync Controls" else "Adjust Sync") },
+                            leadingContent = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Tune,
+                                    contentDescription = null
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = 18.dp,
+                                        topEnd = 18.dp,
+                                        bottomStart = if (isSyncLast) 24.dp else 8.dp,
+                                        bottomEnd = if (isSyncLast) 24.dp else 8.dp
+                                    )
+                                )
+                                .background(itemBackgroundColor)
+                                .clickable {
+                                    onDismissRequest()
+                                    onToggleSyncControls()
+                                },
+                            colors = ListItemDefaults.colors(
+                                containerColor = Color.Transparent,
+                                headlineColor = contentColor,
+                                leadingIconColor = contentColor
+                            )
+                        )
+                    }
+
+                    if (isRomanizationVisible) {
+                        ListItem(
+                            headlineContent = { Text("Show Romanization") },
+                            leadingContent = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Abc,
+                                    contentDescription = null
+                                )
+                            },
+                            trailingContent = {
+                                Switch(
+                                    checked = showRomanization,
+                                    onCheckedChange = onShowRomanizationChange,
+                                    colors = SwitchDefaults.colors(
+                                        checkedThumbColor = onAccentColor,
+                                        checkedTrackColor = accentColor,
+                                        uncheckedThumbColor = contentColor,
+                                        uncheckedTrackColor = contentColor.copy(alpha = 0.3f)
+                                    )
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = if (isRomanizationFirst) 18.dp else 8.dp,
+                                        topEnd = if (isRomanizationFirst) 18.dp else 8.dp,
+                                        bottomStart = if (isRomanizationLast) 24.dp else 8.dp,
+                                        bottomEnd = if (isRomanizationLast) 24.dp else 8.dp
+                                    )
+                                )
+                                .background(itemBackgroundColor)
+                                .clickable { onShowRomanizationChange(!showRomanization) },
+                            colors = ListItemDefaults.colors(
+                                containerColor = Color.Transparent,
+                                headlineColor = contentColor,
+                                leadingIconColor = contentColor
+                            )
+                        )
+                    }
+
+                    if (isTranslationVisible) {
                         ListItem(
                             headlineContent = { Text("Show Translations") },
                             leadingContent = {
@@ -312,7 +381,14 @@ fun LyricsMoreBottomSheet(
                             },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = if (isTranslationFirst) 18.dp else 8.dp,
+                                        topEnd = if (isTranslationFirst) 18.dp else 8.dp,
+                                        bottomStart = if (isTranslationLast) 24.dp else 8.dp,
+                                        bottomEnd = if (isTranslationLast) 24.dp else 8.dp
+                                    )
+                                )
                                 .background(itemBackgroundColor)
                                 .clickable { onShowTranslationChange(!showTranslation) },
                             colors = ListItemDefaults.colors(
@@ -324,39 +400,48 @@ fun LyricsMoreBottomSheet(
                     }
 
                     // Immersive Mode Toggle
-                    ListItem(
-                        headlineContent = { Text("Disable Immersive (Once)") },
-                        leadingContent = {
-                            Icon(
-                                imageVector = Icons.Rounded.VisibilityOff,
-                                contentDescription = null
-                            )
-                        },
-                        trailingContent = {
-                             Switch(
-                                modifier = Modifier,
-                                checked = isImmersiveTemporarilyDisabled,
-                                onCheckedChange = { 
-                                    onSetImmersiveTemporarilyDisabled(it)
-                                },
-                                colors = SwitchDefaults.colors(
-                                    checkedThumbColor = onAccentColor,
-                                    checkedTrackColor = accentColor,
-                                    uncheckedThumbColor = contentColor,
-                                    uncheckedTrackColor = contentColor.copy(alpha = 0.3f)
+                    if (isImmersiveVisible) {
+                        ListItem(
+                            headlineContent = { Text("Disable Immersive (Once)") },
+                            leadingContent = {
+                                Icon(
+                                    imageVector = Icons.Rounded.VisibilityOff,
+                                    contentDescription = null
                                 )
+                            },
+                            trailingContent = {
+                                Switch(
+                                    modifier = Modifier,
+                                    checked = isImmersiveTemporarilyDisabled,
+                                    onCheckedChange = {
+                                        onSetImmersiveTemporarilyDisabled(it)
+                                    },
+                                    colors = SwitchDefaults.colors(
+                                        checkedThumbColor = onAccentColor,
+                                        checkedTrackColor = accentColor,
+                                        uncheckedThumbColor = contentColor,
+                                        uncheckedTrackColor = contentColor.copy(alpha = 0.3f)
+                                    )
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = 8.dp,
+                                        topEnd = 8.dp,
+                                        bottomStart = 24.dp,
+                                        bottomEnd = 24.dp
+                                    )
+                                )
+                                .background(itemBackgroundColor),
+                            colors = ListItemDefaults.colors(
+                                containerColor = Color.Transparent,
+                                headlineColor = contentColor,
+                                leadingIconColor = contentColor
                             )
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomStart = 24.dp, bottomEnd = 24.dp))
-                            .background(itemBackgroundColor),
-                        colors = ListItemDefaults.colors(
-                            containerColor = Color.Transparent,
-                            headlineColor = contentColor,
-                            leadingIconColor = contentColor
                         )
-                    )
+                    }
                 }
             }
             

--- a/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
@@ -108,7 +108,20 @@ object MultiLangRomanizer {
     fun isHindi(text: String) = text.any { it in '\u0900'..'\u097F' }
     fun isPunjabi(text: String) = text.any { it in '\u0A00'..'\u0A7F' }
     fun isCyrillic(text: String) = text.any { it in '\u0400'..'\u04FF' }
-    fun isChinese(text: String) = text.any { it in '\u4E00'..'\u9FFF' } && !isJapanese(text) && !isKorean(text)
+    fun isChinese(text: String) = text.any { it in '\u4E00'..'\u9FFF' }
+
+    fun isScriptThatNeedsRomanization(text: String): Boolean {
+        return text.any { char ->
+            val code = char.code
+            code in 0x3040..0x309F || // Hiragana
+            code in 0x30A0..0x30FF || // Katakana
+            code in 0x4E00..0x9FFF || // CJK Unified Ideographs (Chinese)
+            code in 0xAC00..0xD7A3 || // Hangul (Korean)
+            code in 0x0900..0x097F || // Devanagari (Hindi)
+            code in 0x0A00..0x0A7F || // Gurmukhi (Punjabi)
+            code in 0x0400..0x04FF    // Cyrillic
+        }
+    }
 
     private fun isRussian(text: String) = text.any { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
     private fun isUkrainian(text: String) = text.any { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
@@ -393,6 +406,7 @@ object LyricsUtils {
     private val LRC_WORD_SPLIT_REGEX = Regex("(?=<\\d{2}:\\d{2}[.:]\\d{2,3}>)")
     private val LRC_TIMESTAMP_TAG_REGEX = Regex("\\[\\d{1,2}:\\d{2}(?:[.:]\\d{1,3})?]")
     private val TRANSLATION_CREDIT_REGEX = Regex("^\\s*by\\s*[:：].+", RegexOption.IGNORE_CASE)
+    private val LRC_METADATA_PATTERN = Pattern.compile("^\\[[a-zA-Z]+:.*]$")
 
     /**
      * Parsea un String que contiene una letra en formato LRC o texto plano.
@@ -410,7 +424,7 @@ object LyricsUtils {
 
         lyricsText.lines().forEach { rawLine ->
             val line = sanitizeLrcLine(rawLine)
-            if (line.isEmpty()) return@forEach
+            if (line.isEmpty() || LRC_METADATA_PATTERN.matcher(line).matches()) return@forEach
 
             val lineMatcher = LRC_LINE_REGEX.matcher(line)
             if (lineMatcher.matches()) {
@@ -514,26 +528,15 @@ object LyricsUtils {
 
                 val origTrans = line.translation?.trim()
 
-                val newTranslation = if (!romanized.isNullOrEmpty()) {
-                    if (origTrans.isNullOrEmpty()) {
-                        romanized
-                    } else {
-                        val cleanRom = romanized.replace(Regex("[^a-zA-Z0-9]"), "").lowercase()
-                        val cleanTrans = origTrans.replace(Regex("[^a-zA-Z0-9]"), "").lowercase()
-
-                        if (cleanTrans.contains(cleanRom) || cleanRom.contains(cleanTrans)) {
-                            origTrans
-                        } else {
-                            "$romanized\n$origTrans"
-                        }
-                    }
-                } else {
-                    origTrans
-                }
-
-                line.copy(translation = newTranslation)
+                line.copy(romanization = romanized)
             }
-            val plainVersion = pairedLines.map { it.line }
+            val plainVersion = pairedLines.map { line ->
+                buildString {
+                    append(line.line)
+                    if (!line.romanization.isNullOrEmpty()) append("\n").append(line.romanization)
+                    if (!line.translation.isNullOrEmpty()) append("\n").append(line.translation)
+                }
+            }
             Lyrics(synced = pairedLines, plain = plainVersion)
         } else {
             val processedPlain = plainLines.map { line ->


### PR DESCRIPTION
### Summary
This PR improves the lyrics display system by decoupling controls and optimizing parsing performance.

### Key Changes:
- **Independent Toggles**: Decoupled "Show Translations" and "Show Romanization" with independent persistent preferences.
- **Improved Display**: Added smart script detection for static lyrics to avoid hiding original lines and implemented automated LRC metadata filtering.
- **UI**: Hide "Disable Immersive (once)" toggle if Immersive Mode not enabled in settings and added dynamic corner rounding for list groups.
- **Performance**: Optimized script detection with single-pass scanning and pre-compiled regex for better lyrics parsing.

### Screnshots
Hide "Disable Immersive (Once)" toggle if not enabled in the **Settings > Appearance**
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/f2419ac7-1e13-4d4c-9959-7d255cbade6d" />

Show "Show Romanization" toggle if the lyrics can have generated romanize lyrics
<img width="300" height="550" alt="image" src="https://github.com/user-attachments/assets/95936b9f-523d-4ae6-be5f-e8e859e1cf6d" />

Show "Show Translations" toggle if the lrc has translation lyric, eg.
```
[00:19.34] Although loneliness has always been a friend of mine
[00:19.34] Aunque la soledad siempre ha sido una amiga mía
````

Additionaly show "Disable Immersive (Once)" toggle since now it's enabled in the settings
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/fd0144d7-d301-4416-8e40-cadd7bd2b069" />
