### PR TITLE
fix: Navidrome sync failing silently

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -431,7 +431,11 @@ class NavidromeRepository @Inject constructor(
             // Sync playlists
             val playlistResult = syncPlaylists().getOrElse {
                 // Playlists failed but library songs may have synced
-                syncUnifiedLibrarySongsFromNavidrome()
+                try {
+                    syncUnifiedLibrarySongsFromNavidrome()
+                } catch (e: Exception) {
+                    Timber.e(e, "$TAG: Failed to sync unified library after playlist fetch failure")
+                }
                 return@withContext Result.success(
                     BulkSyncResult(
                         playlistCount = 0,
@@ -453,7 +457,11 @@ class NavidromeRepository @Inject constructor(
             }
 
             // Sync to unified library once after everything is synced
-            syncUnifiedLibrarySongsFromNavidrome()
+            try {
+                syncUnifiedLibrarySongsFromNavidrome()
+            } catch (e: Exception) {
+                Timber.e(e, "$TAG: Failed to sync unified library")
+            }
 
             Result.success(
                 BulkSyncResult(
@@ -642,7 +650,8 @@ class NavidromeRepository @Inject constructor(
                     artistId = primaryArtistId,
                     songCount = 0,
                     year = navidromeSong.year,
-                    albumArtUriString = getCoverArtUrl(navidromeSong.coverArtId)
+                    albumArtUriString = navidromeSong.coverArtId?.takeIf { it.isNotBlank() }
+                        ?.let { "navidrome_cover://$it" }
                 )
             )
 
@@ -656,7 +665,8 @@ class NavidromeRepository @Inject constructor(
                     albumName = albumName,
                     albumId = albumId,
                     contentUriString = "navidrome://${navidromeSong.navidromeId}",
-                    albumArtUriString = getCoverArtUrl(navidromeSong.coverArtId),
+                    albumArtUriString = navidromeSong.coverArtId?.takeIf { it.isNotBlank() }
+                        ?.let { "navidrome_cover://$it" },
                     duration = navidromeSong.duration,
                     genre = navidromeSong.genre ?: NAVIDROME_GENRE,
                     filePath = navidromeSong.path,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -7,6 +7,7 @@ import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import timber.log.Timber
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -37,8 +38,8 @@ class NavidromeDashboardViewModel @Inject constructor(
     val isLoggedIn: StateFlow<Boolean> = repository.isLoggedInFlow
 
     init {
-        // Auto-sync playlists when the dashboard opens
-        syncPlaylists()
+        // Auto-sync full library (songs + playlists) when dashboard opens
+        syncAllPlaylistsAndSongs()
     }
 
     fun syncAllPlaylistsAndSongs() {
@@ -80,8 +81,11 @@ class NavidromeDashboardViewModel @Inject constructor(
             val result = repository.syncPlaylistSongs(playlistId)
             result.fold(
                 onSuccess = { count ->
-                    // Sync to unified library after successfully syncing individual playlist
-                    repository.syncUnifiedLibrarySongsFromNavidrome()
+                    try {
+                        repository.syncUnifiedLibrarySongsFromNavidrome()
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to sync unified library after playlist sync")
+                    }
                     _syncMessage.value = "Synced $count songs"
                 },
                 onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }


### PR DESCRIPTION
fixes: ﻿#1421 

The url builder for cover art which used the auth layer could throw at sync time, changed it to lazily load at display time instead and use the coil fetcher instead and wrapped syncUnifiedLibrarySongsFromNavidrome() calls in try-catch so exceptions during unified library sync no longer crash the entire sync.