### PR TITLE
fix: add genre navigation and improve lyrics toggle state

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
@@ -70,6 +70,7 @@ fun DailyMixSection(
     onClickOpen: () -> Unit = {},
     onNavigateToAlbum: (Song) -> Unit = {},
     onNavigateToArtist: (Song) -> Unit = {},
+    onNavigateToGenre: (Song) -> Unit = {},
 ) {
     val playlistViewModel: PlaylistViewModel = hiltViewModel()
     val favoriteSongIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
@@ -134,6 +135,10 @@ fun DailyMixSection(
             },
             onNavigateToArtist = {
                 onNavigateToArtist(song)
+                showSongInfoSheet = false
+            },
+            onNavigateToGenre = {
+                onNavigateToGenre(song)
                 showSongInfoSheet = false
             },
             onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsFloatingToolbar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsFloatingToolbar.kt
@@ -52,6 +52,7 @@ fun LyricsFloatingToolbar(
     onNavigateBack: () -> Unit,
     showSyncedLyrics: Boolean?,
     onShowSyncedLyricsChange: (Boolean) -> Unit,
+    hasSyncedLyrics: Boolean,
     onMoreClick: () -> Unit,
     backgroundColor: Color,
     onBackgroundColor: Color,
@@ -91,6 +92,7 @@ fun LyricsFloatingToolbar(
             ToggleSegmentButton(
                 modifier = Modifier.weight(1f).height(50.dp),
                 active = showSyncedLyrics,
+                enabled = hasSyncedLyrics,
                 activeColor = accentColor,
                 inactiveColor = backgroundColor,
                 activeContentColor = onAccentColor,
@@ -103,6 +105,7 @@ fun LyricsFloatingToolbar(
             ToggleSegmentButton(
                 modifier = Modifier.weight(1f).height(50.dp),
                 active = !showSyncedLyrics,
+                enabled = true,
                 activeColor = accentColor,
                 inactiveColor = backgroundColor,
                 activeContentColor = onAccentColor,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -265,6 +265,10 @@ fun LyricsSheet(
         )
     }
 
+    val hasSyncedLyrics = remember(lyrics) {
+        !lyrics?.synced.isNullOrEmpty()
+    }
+
     // Immersive Mode State
     var immersiveMode by remember { mutableStateOf(false) }
     var lastInteractionTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
@@ -791,6 +795,7 @@ fun LyricsSheet(
                 LyricsFloatingToolbar(
                     modifier = Modifier.padding(horizontal = 0.dp),
                     showSyncedLyrics = showSyncedLyrics,
+                    hasSyncedLyrics = hasSyncedLyrics,
                     onShowSyncedLyricsChange = { showSyncedLyrics = it },
                     onNavigateBack = {
                         onBackClick()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongInfoBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongInfoBottomSheet.kt
@@ -98,6 +98,7 @@ fun SongInfoBottomSheet(
     onDeleteFromDevice: (activity: Activity, song: Song, onResult: (Boolean) -> Unit) -> Unit,
     onNavigateToAlbum: () -> Unit,
     onNavigateToArtist: () -> Unit,
+    onNavigateToGenre: () -> Unit,
     onEditSong: (title: String, artist: String, album: String, genre: String, lyrics: String, trackNumber: Int, discNumber: Int?, coverArtUpdate: CoverArtUpdate?) -> Unit,
     generateAiMetadata: suspend (List<String>) -> Result<SongMetadata>,
     removeFromListTrigger: () -> Unit,
@@ -650,7 +651,7 @@ fun SongInfoBottomSheet(
                                                         icon = Icons.Rounded.MusicNote,
                                                         iconDescription = "Genre icon",
                                                         shape = infoSegmentItemShape,
-                                                        onClick = onNavigateToArtist,
+                                                        onClick = onNavigateToGenre,
                                                     )
                                                 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ToggleSegmentButton.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ToggleSegmentButton.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
@@ -183,8 +184,9 @@ private fun ToggleSegmentButtonContainer(
     onClick: () -> Unit,
     content: @Composable () -> Unit
 ) {
+    val targetBgColor = if (active) activeColor else inactiveColor
     val bgColor by animateColorAsState(
-        targetValue = if (active) activeColor else inactiveColor,
+        targetValue = if (enabled) targetBgColor else targetBgColor.copy(alpha = 0.5f),
         animationSpec = tween(durationMillis = 250),
         label = ""
     )
@@ -202,6 +204,8 @@ private fun ToggleSegmentButtonContainer(
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
-        content()
+        Box(modifier = Modifier.graphicsLayer(alpha = if (enabled) 1f else 0.38f)) {
+            content()
+        }
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
@@ -159,7 +159,8 @@ internal fun UnifiedPlayerSongInfoLayer(
     currentQueueSourceNameProvider: () -> String,
     onDismissSongInfo: () -> Unit,
     onNavigateToAlbum: (Song) -> Unit,
-    onNavigateToArtist: (Song) -> Unit
+    onNavigateToArtist: (Song) -> Unit,
+    onNavigateToGenre: (Song) -> Unit
 ) {
     selectedSongForInfo?.let { staticSong ->
         val context = LocalContext.current
@@ -212,6 +213,7 @@ internal fun UnifiedPlayerSongInfoLayer(
                 },
                 onNavigateToAlbum = { onNavigateToAlbum(liveSong) },
                 onNavigateToArtist = { onNavigateToArtist(liveSong) },
+                onNavigateToGenre = { onNavigateToGenre(liveSong) },
                 onEditSong = { title, artist, album, genre, lyrics, trackNumber, discNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(
                         liveSong,
@@ -273,7 +275,8 @@ internal fun UnifiedPlayerQueueAndSongInfoHost(
     onEndQueueDrag: (Float, Float) -> Unit,
     onLaunchSaveQueueOverlay: (List<Song>, String, (String, Set<String>) -> Unit) -> Unit,
     onNavigateToAlbum: (Song) -> Unit,
-    onNavigateToArtist: (Song) -> Unit
+    onNavigateToArtist: (Song) -> Unit,
+    onNavigateToGenre: (Song) -> Unit
 ) {
     if (!shouldRenderHost) return
 
@@ -400,7 +403,8 @@ internal fun UnifiedPlayerQueueAndSongInfoHost(
                 currentQueueSourceNameProvider = queueSourceNameProvider,
                 onDismissSongInfo = { onSelectedSongForInfoChange(null) },
                 onNavigateToAlbum = onNavigateToAlbum,
-                onNavigateToArtist = onNavigateToArtist
+                onNavigateToArtist = onNavigateToArtist,
+                onNavigateToGenre = onNavigateToGenre
             )
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheet.kt
@@ -692,7 +692,8 @@ fun UnifiedPlayerSheet(
                     onEndQueueDrag = sheetActionHandlers.endQueueDrag,
                     onLaunchSaveQueueOverlay = sheetActionHandlers.onLaunchSaveQueueOverlay,
                     onNavigateToAlbum = sheetActionHandlers.onNavigateToAlbum,
-                    onNavigateToArtist = sheetActionHandlers.onNavigateToArtist
+                    onNavigateToArtist = sheetActionHandlers.onNavigateToArtist,
+                    onNavigateToGenre = sheetActionHandlers.onNavigateToGenre
                 )
 
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -670,7 +670,8 @@ fun UnifiedPlayerSheetV2(
                 onEndQueueDrag = sheetActionHandlers.endQueueDrag,
                 onLaunchSaveQueueOverlay = sheetActionHandlers.onLaunchSaveQueueOverlay,
                 onNavigateToAlbum = sheetActionHandlers.onNavigateToAlbum,
-                onNavigateToArtist = sheetActionHandlers.onNavigateToArtist
+                onNavigateToArtist = sheetActionHandlers.onNavigateToArtist,
+                onNavigateToGenre = sheetActionHandlers.onNavigateToGenre
             )
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetActionHandlers.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetActionHandlers.kt
@@ -23,7 +23,8 @@ internal data class SheetActionHandlers(
     val onSelectedSongForInfoChange: (Song?) -> Unit,
     val onLaunchSaveQueueOverlay: (List<Song>, String, (String, Set<String>) -> Unit) -> Unit,
     val onNavigateToAlbum: (Song) -> Unit,
-    val onNavigateToArtist: (Song) -> Unit
+    val onNavigateToArtist: (Song) -> Unit,
+    val onNavigateToGenre: (Song) -> Unit
 )
 
 @OptIn(UnstableApi::class)
@@ -98,6 +99,20 @@ internal fun rememberSheetActionHandlers(
             }
         }
     }
+    val onNavigateToGenre = remember(scope, navController) {
+        { song: Song ->
+            scope.launch {
+                sheetMotionControllerState.value.snapCollapsed(sheetCollapsedTargetYState.value)
+            }
+            playerViewModelState.value.collapsePlayerSheet()
+            queueSheetControllerState.value.animate(false)
+            sheetModalOverlayControllerState.value.updateSelectedSongForInfo(null)
+            if (!song.genre.isNullOrEmpty()) {
+                val encodedGenre = java.net.URLEncoder.encode(song.genre, "UTF-8")
+                navController.navigateSafely(Screen.GenreDetail.createRoute(encodedGenre))
+            }
+        }
+    }
 
     return SheetActionHandlers(
         openQueueSheet = openQueueSheet,
@@ -108,6 +123,7 @@ internal fun rememberSheetActionHandlers(
         onSelectedSongForInfoChange = onSelectedSongForInfoChange,
         onLaunchSaveQueueOverlay = onLaunchSaveQueueOverlay,
         onNavigateToAlbum = onNavigateToAlbum,
-        onNavigateToArtist = onNavigateToArtist
+        onNavigateToArtist = onNavigateToArtist,
+        onNavigateToGenre = onNavigateToGenre
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AlbumDetailScreen.kt
@@ -413,6 +413,12 @@ fun AlbumDetailScreen(
                         navController.navigateSafely(Screen.ArtistDetail.createRoute(currentSong.artistId))
                         showSongInfoBottomSheet = false
                     },
+                    onNavigateToGenre = {
+                        currentSong.genre?.let {
+                            navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                        }
+                        showSongInfoBottomSheet = false
+                    },
                     onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                         playerViewModel.editSongMetadata(
                             currentSong,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistDetailScreen.kt
@@ -493,6 +493,12 @@ fun ArtistDetailScreen(
                     navController.navigateSafely(Screen.ArtistDetail.createRoute(currentSong.artistId))
                     showSongInfoBottomSheet = false
                 },
+                onNavigateToGenre = {
+                    currentSong.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
                 onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(currentSong, newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate)
                 },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -189,7 +189,13 @@ fun DailyMixScreen(
                 showSongInfoSheet = false
             },
             onNavigateToArtist = {
-                // TODO: Implement navigation to artist screen. Might require finding artist by name.
+                navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
+                showSongInfoSheet = false
+            },
+            onNavigateToGenre = {
+                song.genre?.let {
+                    navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                }
                 showSongInfoSheet = false
             },
             onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
@@ -491,6 +491,13 @@ fun GenreDetailScreen(
                             }
                             showSongOptionsSheet = null
                         },
+                        onNavigateToGenre = {
+                            song.genre?.let {
+                                val route = com.theveloper.pixelplay.presentation.navigation.Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8"))
+                                navController.navigateSafely(route)
+                            }
+                            showSongOptionsSheet = null
+                        },
                         onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                             playerViewModel.editSongMetadata(song, newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate)
                         },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -318,6 +318,11 @@ fun HomeScreen(
                             onNavigateToArtist = { song ->
                                 navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
                             },
+                            onNavigateToGenre = { song ->
+                                song.genre?.let {
+                                    navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                                }
+                            },
                             playerViewModel = playerViewModel
                         )
                     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -1783,6 +1783,12 @@ fun LibraryScreen(
                     navController.navigateSafely(Screen.ArtistDetail.createRoute(currentSong.artistId))
                     showSongInfoBottomSheet = false
                 },
+                onNavigateToGenre = {
+                    currentSong.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
                 onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(currentSong, newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate)
                 },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -854,6 +854,12 @@ fun PlaylistDetailScreen(
                     navController.navigateSafely(Screen.ArtistDetail.createRoute(currentSong.artistId))
                     showSongInfoBottomSheet = false
                 },
+                onNavigateToGenre = {
+                    currentSong.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
                 onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(
                         currentSong,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/RecentlyPlayedScreen.kt
@@ -284,6 +284,12 @@ fun RecentlyPlayedScreen(
                     navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
                     showSongInfoBottomSheet = false
                 },
+                onNavigateToGenre = {
+                    song.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
                 onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(
                         song,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -438,6 +438,12 @@ fun SearchScreen(
                     navController.navigateSafely(Screen.ArtistDetail.createRoute(currentSong.artistId))
                     showSongInfoBottomSheet = false
                 },
+                onNavigateToGenre = {
+                    currentSong.genre?.let {
+                        navController.navigateSafely(Screen.GenreDetail.createRoute(java.net.URLEncoder.encode(it, "UTF-8")))
+                    }
+                    showSongInfoBottomSheet = false
+                },
                 onEditSong = { newTitle, newArtist, newAlbum, newGenre, newLyrics, newTrackNumber, newDiscNumber, coverArtUpdate ->
                     playerViewModel.editSongMetadata(
                         currentSong,


### PR DESCRIPTION
- Implement `onNavigateToGenre` across screens to allow users to navigate to genre detail screen via `SongInfoBottomSheet`.
- Fix an issue in `SongInfoBottomSheet` where the "Genre" list item was incorrectly invoking the artist navigation callback.
- Update `LyricsFloatingToolbar` and `LyricsSheet` to detect the presence of synced lyrics and disable the synced lyrics tab if none are available.
- Enhance `ToggleSegmentButton` to include visual feedback via alpha transparency and color adjustments for `disabled` state.