### PR TITLE
Refine artwork color extraction with representative fidelity scoring …

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
@@ -389,6 +389,6 @@ class ColorSchemeProcessor @Inject constructor(
     companion object {
         private const val TAG = "ColorSchemeProcessor"
         private const val CACHE_KEY_SEPARATOR = "|"
-        private const val CACHE_ALGORITHM_VERSION = "algo_v5"
+        private const val CACHE_ALGORITHM_VERSION = "algo_v6"
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/theme/ColorRoles.kt
@@ -46,6 +46,11 @@ private data class ScoredHct(
     val score: Double
 )
 
+private data class RepresentativeArtworkColor(
+    val argb: Int,
+    val hct: Hct
+)
+
 private val extractedColorCache = LruCache<Int, Color>(32)
 private const val GRAYSCALE_CHROMA_THRESHOLD = 12.0
 private const val NEUTRAL_PIXEL_CHROMA_THRESHOLD = 8.0
@@ -54,6 +59,21 @@ private const val REQUIRED_NEUTRAL_POPULATION = 0.92
 private const val MAX_HIGH_CHROMA_POPULATION = 0.03
 private const val MAX_WEIGHTED_CHROMA_FOR_NEUTRAL = 9.0
 private const val MAX_GRAYSCALE_CHANNEL_DELTA = 10
+private const val REPRESENTATIVE_PIXEL_CHROMA_THRESHOLD = 10.0
+private const val MIN_REPRESENTATIVE_PIXEL_RATIO = 0.04
+private const val MIN_REFINEMENT_PIXEL_RATIO = 0.08
+private const val MIN_VISIBLE_RGB_SUM = 36
+private const val MIN_VISIBLE_PIXEL_ALPHA = 28
+private const val FIDELITY_HUE_WINDOW = 90.0
+private const val FIDELITY_CHROMA_WINDOW = 32.0
+private const val FIDELITY_TONE_WINDOW = 28.0
+private const val FIDELITY_HUE_WEIGHT = 18.0
+private const val FIDELITY_CHROMA_WEIGHT = 7.0
+private const val FIDELITY_TONE_WEIGHT = 3.0
+private const val EXCESS_CHROMA_PENALTY_START = 18.0
+private const val EXCESS_CHROMA_PENALTY_WEIGHT = 0.18
+private const val LOCAL_REFINEMENT_HUE_WINDOW = 32.0
+private const val LOCAL_REFINEMENT_BLEND_RATIO = 0.42f
 
 fun clearExtractedColorCache() {
     extractedColorCache.evictAll()
@@ -80,21 +100,7 @@ fun extractSeedColor(
             workingBitmap.height
         )
 
-        val fallbackArgb = averageColorArgb(pixels)
-        val quantized = QuantizerCelebi.quantize(pixels, config.quantizerMaxColors)
-        val mostlyNeutralArtwork = isMostlyNeutralArtwork(quantized)
-
-        if (mostlyNeutralArtwork && isArgbNearGrayscale(fallbackArgb)) {
-            return@runCatching Color(fallbackArgb)
-        }
-
-        val rankedSeeds = scoreQuantizedColors(
-            colorsToPopulation = quantized,
-            scoring = config.scoring,
-            fallbackColorArgb = fallbackArgb
-        )
-
-        Color(rankedSeeds.firstOrNull() ?: fallbackArgb)
+        Color(selectSeedColorArgbFromPixels(pixels, config))
     }.getOrElse { DarkColorScheme.primary }
 
     extractedColorCache.put(cacheKey, seedColor)
@@ -148,6 +154,35 @@ fun generateMonochromeColorSchemeFromSeed(seedColor: Color): ColorSchemePair {
     }
 }
 
+internal fun selectSeedColorArgbFromPixels(
+    pixels: IntArray,
+    config: ColorExtractionConfig = ColorExtractionConfig()
+): Int {
+    val fallbackArgb = averageColorArgb(pixels)
+    val quantized = QuantizerCelebi.quantize(pixels, config.quantizerMaxColors)
+    val mostlyNeutralArtwork = isMostlyNeutralArtwork(quantized)
+
+    if (mostlyNeutralArtwork && isArgbNearGrayscale(fallbackArgb)) {
+        return fallbackArgb
+    }
+
+    val representativeColor = calculateRepresentativeArtworkColor(pixels)
+    val rankedSeeds = scoreQuantizedColors(
+        colorsToPopulation = quantized,
+        scoring = config.scoring,
+        fallbackColorArgb = fallbackArgb,
+        representativeColor = representativeColor
+    )
+    val selectedSeed = rankedSeeds.firstOrNull() ?: fallbackArgb
+
+    return refineSeedColorArgb(
+        candidateArgb = selectedSeed,
+        pixels = pixels,
+        representativeColor = representativeColor,
+        cutoffChroma = config.scoring.cutoffChroma
+    )
+}
+
 private fun resizeForExtraction(bitmap: Bitmap, maxDimension: Int): Bitmap {
     if (maxDimension <= 0) return bitmap
     if (bitmap.width <= maxDimension && bitmap.height <= maxDimension) return bitmap
@@ -161,7 +196,8 @@ private fun resizeForExtraction(bitmap: Bitmap, maxDimension: Int): Bitmap {
 private fun scoreQuantizedColors(
     colorsToPopulation: Map<Int, Int>,
     scoring: ColorScoringConfig,
-    fallbackColorArgb: Int
+    fallbackColorArgb: Int,
+    representativeColor: RepresentativeArtworkColor?
 ): List<Int> {
     if (colorsToPopulation.isEmpty()) return listOf(fallbackColorArgb)
 
@@ -201,7 +237,18 @@ private fun scoreQuantizedColors(
         val chromaWeight =
             if (hct.chroma < scoring.targetChroma) scoring.weightChromaBelow else scoring.weightChromaAbove
         val chromaScore = (hct.chroma - scoring.targetChroma) * chromaWeight
-        scoredColors.add(ScoredHct(hct, proportionScore + chromaScore))
+        val fidelityScore = representativeColor?.let { representative ->
+            calculateRepresentativeFidelityScore(hct, representative.hct)
+        } ?: 0.0
+        val excessChromaPenalty = representativeColor?.let { representative ->
+            calculateExcessChromaPenalty(hct, representative.hct)
+        } ?: 0.0
+        scoredColors.add(
+            ScoredHct(
+                hct = hct,
+                score = proportionScore + chromaScore + fidelityScore - excessChromaPenalty
+            )
+        )
     }
 
     if (scoredColors.isEmpty()) return listOf(fallbackColorArgb)
@@ -228,6 +275,167 @@ private fun scoreQuantizedColors(
 
     if (chosen.isEmpty()) return listOf(fallbackColorArgb)
     return chosen.map { it.toInt() }
+}
+
+private fun calculateRepresentativeArtworkColor(pixels: IntArray): RepresentativeArtworkColor? {
+    if (pixels.isEmpty()) return null
+
+    var totalRed = 0.0
+    var totalGreen = 0.0
+    var totalBlue = 0.0
+    var totalWeight = 0.0
+    var representativePixelCount = 0
+
+    for (argb in pixels) {
+        val alpha = (argb ushr 24) and 0xFF
+        if (alpha < MIN_VISIBLE_PIXEL_ALPHA) continue
+
+        val red = (argb ushr 16) and 0xFF
+        val green = (argb ushr 8) and 0xFF
+        val blue = argb and 0xFF
+        if (red + green + blue <= MIN_VISIBLE_RGB_SUM) continue
+
+        val hct = Hct.fromInt(argb)
+        if (hct.chroma < REPRESENTATIVE_PIXEL_CHROMA_THRESHOLD) continue
+
+        val weight = 1.0 +
+            ((hct.chroma - REPRESENTATIVE_PIXEL_CHROMA_THRESHOLD) / 24.0).coerceAtLeast(0.0) +
+            (hct.tone / 100.0)
+
+        totalRed += red * weight
+        totalGreen += green * weight
+        totalBlue += blue * weight
+        totalWeight += weight
+        representativePixelCount++
+    }
+
+    if (totalWeight <= 0.0) return null
+    if (representativePixelCount.toDouble() / pixels.size.toDouble() < MIN_REPRESENTATIVE_PIXEL_RATIO) {
+        return null
+    }
+
+    val argb = (
+        (0xFF shl 24) or
+            ((totalRed / totalWeight).roundToInt().coerceIn(0, 255) shl 16) or
+            ((totalGreen / totalWeight).roundToInt().coerceIn(0, 255) shl 8) or
+            (totalBlue / totalWeight).roundToInt().coerceIn(0, 255)
+        )
+    val hct = Hct.fromInt(argb)
+
+    return RepresentativeArtworkColor(argb = argb, hct = hct)
+}
+
+private fun calculateRepresentativeFidelityScore(candidate: Hct, representative: Hct): Double {
+    val hueDistance = MathUtils.differenceDegrees(candidate.hue, representative.hue)
+    val chromaDistance = abs(candidate.chroma - representative.chroma)
+    val toneDistance = abs(candidate.tone - representative.tone)
+
+    val hueScore =
+        ((FIDELITY_HUE_WINDOW - hueDistance).coerceAtLeast(0.0) / FIDELITY_HUE_WINDOW) * FIDELITY_HUE_WEIGHT
+    val chromaScore =
+        ((FIDELITY_CHROMA_WINDOW - chromaDistance).coerceAtLeast(0.0) / FIDELITY_CHROMA_WINDOW) *
+            FIDELITY_CHROMA_WEIGHT
+    val toneScore =
+        ((FIDELITY_TONE_WINDOW - toneDistance).coerceAtLeast(0.0) / FIDELITY_TONE_WINDOW) * FIDELITY_TONE_WEIGHT
+
+    return hueScore + chromaScore + toneScore
+}
+
+private fun calculateExcessChromaPenalty(candidate: Hct, representative: Hct): Double {
+    val excessChroma = candidate.chroma - representative.chroma - EXCESS_CHROMA_PENALTY_START
+    if (excessChroma <= 0.0) return 0.0
+    return excessChroma * EXCESS_CHROMA_PENALTY_WEIGHT
+}
+
+private fun refineSeedColorArgb(
+    candidateArgb: Int,
+    pixels: IntArray,
+    representativeColor: RepresentativeArtworkColor?,
+    cutoffChroma: Double
+): Int {
+    if (pixels.isEmpty()) return candidateArgb
+
+    val candidateHct = Hct.fromInt(candidateArgb)
+    var totalRed = 0.0
+    var totalGreen = 0.0
+    var totalBlue = 0.0
+    var totalWeight = 0.0
+    var matchingPixelCount = 0
+
+    for (argb in pixels) {
+        val alpha = (argb ushr 24) and 0xFF
+        if (alpha < MIN_VISIBLE_PIXEL_ALPHA) continue
+
+        val red = (argb ushr 16) and 0xFF
+        val green = (argb ushr 8) and 0xFF
+        val blue = argb and 0xFF
+        if (red + green + blue <= MIN_VISIBLE_RGB_SUM) continue
+
+        val hct = Hct.fromInt(argb)
+        if (hct.chroma < cutoffChroma) continue
+
+        val hueDistance = MathUtils.differenceDegrees(candidateHct.hue, hct.hue)
+        if (hueDistance > LOCAL_REFINEMENT_HUE_WINDOW) continue
+
+        val weight = 1.0 +
+            ((LOCAL_REFINEMENT_HUE_WINDOW - hueDistance) / LOCAL_REFINEMENT_HUE_WINDOW) +
+            ((hct.chroma - cutoffChroma) / 32.0).coerceAtLeast(0.0)
+
+        totalRed += red * weight
+        totalGreen += green * weight
+        totalBlue += blue * weight
+        totalWeight += weight
+        matchingPixelCount++
+    }
+
+    if (totalWeight <= 0.0) return candidateArgb
+    if (matchingPixelCount.toDouble() / pixels.size.toDouble() < MIN_REFINEMENT_PIXEL_RATIO) {
+        return candidateArgb
+    }
+
+    val localAverageArgb = (
+        (0xFF shl 24) or
+            ((totalRed / totalWeight).roundToInt().coerceIn(0, 255) shl 16) or
+            ((totalGreen / totalWeight).roundToInt().coerceIn(0, 255) shl 8) or
+            (totalBlue / totalWeight).roundToInt().coerceIn(0, 255)
+        )
+    val localAverageHct = Hct.fromInt(localAverageArgb)
+    if (MathUtils.differenceDegrees(candidateHct.hue, localAverageHct.hue) > LOCAL_REFINEMENT_HUE_WINDOW) {
+        return candidateArgb
+    }
+
+    val refinedArgb = blendArgb(candidateArgb, localAverageArgb, LOCAL_REFINEMENT_BLEND_RATIO)
+    if (representativeColor == null) return refinedArgb
+
+    return if (MathUtils.differenceDegrees(localAverageHct.hue, representativeColor.hct.hue) <= FIDELITY_HUE_WINDOW) {
+        blendArgb(refinedArgb, representativeColor.argb, LOCAL_REFINEMENT_BLEND_RATIO / 2f)
+    } else {
+        refinedArgb
+    }
+}
+
+private fun blendArgb(firstArgb: Int, secondArgb: Int, ratio: Float): Int {
+    val clampedRatio = ratio.coerceIn(0f, 1f)
+    val inverseRatio = 1f - clampedRatio
+
+    val alpha = (
+        ((firstArgb ushr 24) and 0xFF) * inverseRatio +
+            ((secondArgb ushr 24) and 0xFF) * clampedRatio
+        ).roundToInt().coerceIn(0, 255)
+    val red = (
+        ((firstArgb ushr 16) and 0xFF) * inverseRatio +
+            ((secondArgb ushr 16) and 0xFF) * clampedRatio
+        ).roundToInt().coerceIn(0, 255)
+    val green = (
+        ((firstArgb ushr 8) and 0xFF) * inverseRatio +
+            ((secondArgb ushr 8) and 0xFF) * clampedRatio
+        ).roundToInt().coerceIn(0, 255)
+    val blue = (
+        (firstArgb and 0xFF) * inverseRatio +
+            (secondArgb and 0xFF) * clampedRatio
+        ).roundToInt().coerceIn(0, 255)
+
+    return (alpha shl 24) or (red shl 16) or (green shl 8) or blue
 }
 
 private fun createDynamicScheme(

--- a/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/ui/theme/ColorRolesTest.kt
@@ -51,6 +51,50 @@ class ColorRolesTest {
         }
     }
 
+    @Test
+    fun selectSeedColorArgbFromPixels_keepsDistinctGreenAlbumsFromCollapsingIntoSharedAccent() {
+        val sharedAccent = 0xFF39FF88.toInt()
+
+        val warmOliveBase = 0xFF708238.toInt()
+        val warmOliveSupport = 0xFF8A9B4F.toInt()
+        val coolJadeBase = 0xFF2C7A5F.toInt()
+        val coolJadeSupport = 0xFF4C9A7C.toInt()
+
+        val warmSeed = selectSeedColorArgbFromPixels(
+            pixels = pixelsOf(
+                550 to warmOliveBase,
+                300 to warmOliveSupport,
+                150 to sharedAccent
+            )
+        )
+        val coolSeed = selectSeedColorArgbFromPixels(
+            pixels = pixelsOf(
+                550 to coolJadeBase,
+                300 to coolJadeSupport,
+                150 to sharedAccent
+            )
+        )
+
+        assertThat(hueDistance(warmSeed, warmOliveBase))
+            .isLessThan(hueDistance(warmSeed, sharedAccent))
+        assertThat(hueDistance(coolSeed, coolJadeBase))
+            .isLessThan(hueDistance(coolSeed, sharedAccent))
+        assertThat(hueDistance(warmSeed, coolSeed)).isGreaterThan(12.0)
+    }
+
+    @Test
+    fun selectSeedColorArgbFromPixels_keepsMostlyNeutralArtworkNearNeutral() {
+        val result = selectSeedColorArgbFromPixels(
+            pixels = pixelsOf(
+                940 to 0xFF7A7A7A.toInt(),
+                40 to 0xFF848484.toInt(),
+                20 to 0xFF70758A.toInt()
+            )
+        )
+
+        assertThat(Hct.fromInt(result).chroma).isLessThan(12.0)
+    }
+
     private fun expectedScheme(
         style: AlbumArtPaletteStyle,
         sourceHct: Hct,
@@ -174,5 +218,20 @@ class ColorRolesTest {
         val hsl = FloatArray(3)
         ColorUtils.colorToHSL(argb, hsl)
         return hsl[1] == 0f
+    }
+
+    private fun pixelsOf(vararg entries: Pair<Int, Int>): IntArray {
+        return buildList {
+            entries.forEach { (count, color) ->
+                repeat(count) { add(color) }
+            }
+        }.toIntArray()
+    }
+
+    private fun hueDistance(firstArgb: Int, secondArgb: Int): Double {
+        return com.google.android.material.color.utilities.MathUtils.differenceDegrees(
+            Hct.fromInt(firstArgb).hue,
+            Hct.fromInt(secondArgb).hue
+        )
     }
 }


### PR DESCRIPTION
…and seed color refinement

- **ColorRoles.kt**:
    - Introduce `RepresentativeArtworkColor` to track the dominant visual character of an image.
    - Implement `selectSeedColorArgbFromPixels` to replace the basic quantization-only approach with a multi-stage selection process.
    - Add `calculateRepresentativeArtworkColor` to compute a weighted average color based on pixel chroma and tone.
    - Implement `calculateRepresentativeFidelityScore` and `calculateExcessChromaPenalty` to weight candidate seeds based on their proximity to the representative artwork color.
    - Add `refineSeedColorArgb` to blend the selected seed with local pixel averages for better color accuracy.
    - Define several new constants to tune extraction thresholds, fidelity windows, and weighting factors.
- **ColorSchemeProcessor.kt**: Increment `CACHE_ALGORITHM_VERSION` to `algo_v6` to invalidate existing cached color schemes.
- **ColorRolesTest.kt**: Add unit tests to verify that distinct album palettes remain separated and that mostly neutral artwork preserves neutral seed colors.