### PR TITLE
Implement a dedicated artist picker bottom sheet and enhance artist i…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -107,6 +108,7 @@ class MusicRepositoryImpl @Inject constructor(
     private val repositoryScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     // Tracks the active prefetch job so a new flow emission cancels the previous one.
     @Volatile private var prefetchJob: Job? = null
+    @Volatile private var currentSongArtistPrefetchJob: Job? = null
     @Volatile private var telegramDownloadSyncObserverStarted = false
     private val telegramCacheManager: com.theveloper.pixelplay.data.telegram.TelegramCacheManager
         get() = telegramCacheManagerProvider.get()
@@ -128,6 +130,13 @@ class MusicRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    private fun List<Artist>.missingImageCandidates(): List<Pair<Long, String>> =
+        asSequence()
+            .filter { it.effectiveImageUrl.isNullOrBlank() && it.name.isNotBlank() }
+            .map { it.id to it.name }
+            .distinctBy { (_, name) -> name.trim().lowercase() }
+            .toList()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getAudioFiles(): Flow<List<Song>> {
@@ -269,11 +278,7 @@ class MusicRepositoryImpl @Inject constructor(
                 .map { entities ->
                     val artists = entities.map { it.toArtist() }
                     // Trigger prefetch for missing images (non-blocking)
-                    val missingImages = artists.asSequence()
-                        .filter { it.imageUrl.isNullOrEmpty() && it.name.isNotBlank() }
-                        .map { it.id to it.name }
-                        .distinctBy { (_, name) -> name.trim().lowercase() }
-                        .toList()
+                    val missingImages = artists.missingImageCandidates()
                     if (missingImages.isNotEmpty()) {
                         // Cancel any in-flight prefetch before starting a new one — the flow
                         // can emit multiple times during sync, and concurrent launches would
@@ -299,9 +304,19 @@ class MusicRepositoryImpl @Inject constructor(
     }
 
     override fun getArtistsForSong(songId: Long): Flow<List<Artist>> {
-        return musicDao.getArtistsForSong(songId).map { entities ->
-            entities.map { it.toArtist() }
-        }.flowOn(Dispatchers.IO)
+        return musicDao.getArtistsForSong(songId)
+            .map { entities -> entities.map { it.toArtist() } }
+            .distinctUntilChanged()
+            .onEach { artists ->
+                val missingImages = artists.missingImageCandidates()
+                if (missingImages.isNotEmpty()) {
+                    currentSongArtistPrefetchJob?.cancel()
+                    currentSongArtistPrefetchJob = repositoryScope.launch {
+                        artistImageRepository.prefetchArtistImages(missingImages)
+                    }
+                }
+            }
+            .flowOn(Dispatchers.IO)
     }
 
     override fun getSongsForArtist(artistId: Long): Flow<List<Song>> {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -49,7 +49,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.CircularWavyProgressIndicator
@@ -57,12 +56,10 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 // import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults // Removed
 // import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState // Removed
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -958,43 +955,18 @@ fun FullPlayerContent(
         )
     }
 
-    val artistPickerSheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val artistPickerSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     if (showArtistPicker && currentSongArtists.isNotEmpty()) {
-        ModalBottomSheet(
-            onDismissRequest = { showArtistPicker = false },
-            sheetState = artistPickerSheetState
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Text(
-                    text = stringResource(R.string.artist_picker_title), // short label; keep UI minimal
-                    style = MaterialTheme.typography.titleMedium,
-                    color = LocalMaterialTheme.current.onPrimaryContainer,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
-                currentSongArtists.forEachIndexed { index, artistItem ->
-                    Text(
-                        text = artistItem.name,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = LocalMaterialTheme.current.onPrimaryContainer,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 10.dp)
-                            .clickable {
-                                playerViewModel.triggerArtistNavigationFromPlayer(artistItem.id)
-                                showArtistPicker = false
-                            }
-                    )
-                    if (index != currentSongArtists.lastIndex) {
-                        HorizontalDivider(color = LocalMaterialTheme.current.outlineVariant)
-                    }
-                }
+        PlayerArtistPickerBottomSheet(
+            song = song,
+            artists = currentSongArtists,
+            sheetState = artistPickerSheetState,
+            onDismiss = { showArtistPicker = false },
+            onArtistClick = { artist ->
+                playerViewModel.triggerArtistNavigationFromPlayer(artist.id)
+                showArtistPicker = false
             }
-        }
+        )
     }
 }
 
@@ -1878,11 +1850,13 @@ private fun EfficientTimeLabels(
             Text(
                 posStr,
                 style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                fontWeight = FontWeight.SemiBold,
                 color = textColor
             )
             Text(
                 durStr,
                 style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp),
+                fontWeight = FontWeight.SemiBold,
                 color = textColor
             )
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerArtistPickerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerArtistPickerBottomSheet.kt
@@ -1,0 +1,284 @@
+package com.theveloper.pixelplay.presentation.components.player
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.size.Size
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.data.model.Artist
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.presentation.components.SmartImage
+import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+
+private data class PlayerArtistShortcutItem(
+    val artist: Artist,
+    val isPrimary: Boolean
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun PlayerArtistPickerBottomSheet(
+    song: Song,
+    artists: List<Artist>,
+    sheetState: SheetState,
+    onDismiss: () -> Unit,
+    onArtistClick: (Artist) -> Unit
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val shortcutItems = remember(song.id, song.artistId, song.artists, artists) {
+        val primaryArtist = song.primaryArtist
+        val computedItems = artists.mapIndexed { index, artist ->
+            val isPrimary = when {
+                primaryArtist.id > 0L -> artist.id == primaryArtist.id
+                primaryArtist.name.isNotBlank() -> artist.name.equals(primaryArtist.name, ignoreCase = true)
+                else -> index == 0
+            }
+            PlayerArtistShortcutItem(
+                artist = artist,
+                isPrimary = isPrimary
+            )
+        }
+
+        val hasPrimary = computedItems.any { it.isPrimary }
+        val normalizedItems = if (hasPrimary || computedItems.isEmpty()) {
+            computedItems
+        } else {
+            computedItems.mapIndexed { index, item ->
+                item.copy(isPrimary = index == 0)
+            }
+        }
+        normalizedItems.sortedByDescending { it.isPrimary }
+    }
+
+    val countLabel = when (shortcutItems.size) {
+        1 -> stringResource(R.string.artist_picker_count_single)
+        else -> stringResource(R.string.artist_picker_count_multiple, shortcutItems.size)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                color = colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+            )
+        },
+        containerColor = colorScheme.surfaceContainerHigh,
+        tonalElevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.artist_picker_title),
+                style = MaterialTheme.typography.headlineMedium,
+                fontFamily = GoogleSansRounded,
+                fontWeight = FontWeight.Bold,
+                color = colorScheme.onSurface
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(26.dp)),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                shortcutItems.forEachIndexed { index, item ->
+                    PlayerArtistShortcutCard(
+                        artist = item.artist,
+                        isPrimary = item.isPrimary,
+                        shape = artistShortcutShape(
+                            index = index,
+                            count = shortcutItems.size
+                        ),
+                        onClick = { onArtistClick(item.artist) }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}
+
+@Composable
+private fun PlayerArtistShortcutCard(
+    artist: Artist,
+    isPrimary: Boolean,
+    shape: RoundedCornerShape,
+    onClick: () -> Unit
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val containerColor = if (isPrimary) {
+        colorScheme.secondaryContainer
+    } else {
+        colorScheme.surfaceContainerLow
+    }
+    val contentColor = if (isPrimary) {
+        colorScheme.onSecondaryContainer
+    } else {
+        colorScheme.onSurface
+    }
+    val labelContainerColor = if (isPrimary) {
+        colorScheme.tertiary
+    } else {
+        colorScheme.surfaceContainerHighest
+    }
+    val labelContentColor = if (isPrimary) {
+        colorScheme.onTertiary
+    } else {
+        colorScheme.onSurfaceVariant
+    }
+    val avatarBackground = if (isPrimary) {
+        colorScheme.onSecondaryContainer.copy(alpha = 0.12f)
+    } else {
+        colorScheme.surfaceContainerHighest
+    }
+    val trailingContainerColor = contentColor.copy(alpha = 0.12f)
+    val avatarSize = 52.dp
+
+    Surface(
+        onClick = onClick,
+        color = containerColor,
+        contentColor = contentColor,
+        shape = shape,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(avatarSize)
+                    .clip(CircleShape)
+                    .background(avatarBackground),
+                contentAlignment = Alignment.Center
+            ) {
+                SmartImage(
+                    model = artist.effectiveImageUrl,
+                    contentDescription = artist.name,
+                    modifier = Modifier.fillMaxSize(),
+                    placeholderResId = R.drawable.rounded_artist_24,
+                    errorResId = R.drawable.rounded_artist_24,
+                    shape = CircleShape,
+                    contentScale = ContentScale.Crop,
+                    targetSize = Size(180, 180),
+                    placeHolderBackgroundColor = Color.Transparent
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = artist.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = GoogleSansRounded,
+                    fontWeight = FontWeight.SemiBold,
+                    color = contentColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Surface(
+                    color = labelContainerColor,
+                    shape = CircleShape
+                ) {
+                    Text(
+                        text = stringResource(
+                            if (isPrimary) {
+                                R.string.artist_picker_primary_label
+                            } else {
+                                R.string.artist_picker_shortcut_label
+                            }
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = labelContentColor,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(38.dp)
+                    .clip(CircleShape)
+                    .background(trailingContainerColor),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentDescription = null,
+                    tint = contentColor
+                )
+            }
+        }
+    }
+}
+
+private fun artistShortcutShape(
+    index: Int,
+    count: Int
+): RoundedCornerShape {
+    val outerCorner = 26.dp
+    val innerCorner = 10.dp
+    return when {
+        count <= 1 -> RoundedCornerShape(outerCorner)
+        index == 0 -> RoundedCornerShape(
+            topStart = outerCorner,
+            topEnd = outerCorner,
+            bottomStart = innerCorner,
+            bottomEnd = innerCorner
+        )
+        index == count - 1 -> RoundedCornerShape(
+            topStart = innerCorner,
+            topEnd = innerCorner,
+            bottomStart = outerCorner,
+            bottomEnd = outerCorner
+        )
+        else -> RoundedCornerShape(innerCorner)
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,6 +47,11 @@
     <string name="unknown_artist">Artista desconocido</string>
     <string name="unknown_album">Álbum desconocido</string>
     <string name="artist_picker_title">Selecciona un artista</string>
+    <string name="artist_picker_supporting_text">Abre cualquiera de los artistas acreditados en esta canción.</string>
+    <string name="artist_picker_count_single">1 artista</string>
+    <string name="artist_picker_count_multiple">%1$d artistas</string>
+    <string name="artist_picker_primary_label">Artista principal</string>
+    <string name="artist_picker_shortcut_label">Página del artista</string>
     <string name="external_queue_label">Reproducción rápida</string>
     <string name="external_playback_error">No se puede abrir ese archivo de audio.</string>
     <string name="open_full_player">Abrir reproductor completo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,11 @@
     <string name="unknown_artist">Unknown artist</string>
     <string name="unknown_album">Unknown album</string>
     <string name="artist_picker_title">Pick an Artist</string>
+    <string name="artist_picker_supporting_text">Open any credited artist for this track.</string>
+    <string name="artist_picker_count_single">1 artist</string>
+    <string name="artist_picker_count_multiple">%1$d artists</string>
+    <string name="artist_picker_primary_label">Primary artist</string>
+    <string name="artist_picker_shortcut_label">Artist page</string>
     <string name="external_queue_label">Quick play</string>
     <string name="external_playback_error">Unable to open that audio file.</string>
     <string name="open_full_player">Open full player</string>


### PR DESCRIPTION
…mage prefetching

- **MusicRepository**:
    - Implement `missingImageCandidates` helper to identify artists needing image metadata.
    - Update `getArtistsForSong` to trigger asynchronous image prefetching for artists associated with the current track.
    - Refactor `getArtists` to use the new prefetch candidate logic.
- **PlayerArtistPickerBottomSheet**:
    - Create a new component to display a rich list of artists for the current song.
    - Feature distinct visual styles for the primary artist versus featured/shortcut artists.
    - Include artist avatars with placeholder support and smooth corner shapes.
- **FullPlayerContent**:
    - Replace the basic `ModalBottomSheet` with the new `PlayerArtistPickerBottomSheet`.
    - Update seek bar time labels with semi-bold font weight for improved legibility.
- **Resources**:
    - Add string resources for artist picker titles, labels, and count formatting (English and Spanish).