### PR TITLE
Improve seek reliability for local M4A/MP4 files and update `MediaIte…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -14,6 +14,8 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.mp4.Mp4Extractor
 //import androidx.media3.exoplayer.ffmpeg.FfmpegAudioRenderer
 import com.theveloper.pixelplay.data.model.TransitionSettings
 import com.theveloper.pixelplay.utils.envelope
@@ -340,6 +342,10 @@ class DualPlayerEngine @Inject constructor(
         
         val dataSourceFactory = DefaultDataSource.Factory(context)
         val resolvingFactory = ResolvingDataSource.Factory(dataSourceFactory, resolver)
+        val extractorsFactory = DefaultExtractorsFactory()
+            // Some vendor-produced M4A files expose broken edit lists that make seek
+            // drift or snap back. Ignore them so MP4-family local playback stays seekable.
+            .setMp4ExtractorFlags(Mp4Extractor.FLAG_WORKAROUND_IGNORE_EDIT_LISTS)
 
         // Tune LoadControl to prevent "loop of death" (underrun -> start -> underrun)
         // Increase bufferForPlaybackMs to wait for more data before starting/resuming.
@@ -353,7 +359,7 @@ class DualPlayerEngine @Inject constructor(
             .build()
 
         return ExoPlayer.Builder(context, renderersFactory)
-            .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingFactory))
+            .setMediaSourceFactory(DefaultMediaSourceFactory(resolvingFactory, extractorsFactory))
             .setLoadControl(loadControl)
             .build().apply {
             setAudioAttributes(audioAttributes, handleAudioFocus)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2825,7 +2825,8 @@ class PlayerViewModel @Inject constructor(
 
             mediaItems += MediaItem.Builder()
                 .setMediaId(song.id)
-                .setUri(MediaItemBuilder.playbackUri(song.contentUriString))
+                .setUri(MediaItemBuilder.playbackUri(song))
+                .setMimeType(song.mimeType)
                 .setMediaMetadata(metadataBuilder.build())
                 .build()
         }
@@ -2898,7 +2899,7 @@ class PlayerViewModel @Inject constructor(
 
             // Pre-resolve the starting song's cloud URI before ExoPlayer touches it.
             // This populates the resolvedUriCache so resolveDataSpec finds it instantly.
-            val startingUri = MediaItemBuilder.playbackUri(effectiveStartSong.contentUriString)
+            val startingUri = MediaItemBuilder.playbackUri(effectiveStartSong)
             if (startingUri.scheme == "telegram" || startingUri.scheme == "netease" || startingUri.scheme == "qqmusic") {
                 if (startingUri.scheme == "telegram") {
                     ensureTelegramPlaybackObserversStarted()
@@ -2965,7 +2966,8 @@ class PlayerViewModel @Inject constructor(
 
         val mediaItem = MediaItem.Builder()
             .setMediaId(song.id)
-            .setUri(MediaItemBuilder.playbackUri(song.contentUriString))
+            .setUri(MediaItemBuilder.playbackUri(song))
+            .setMimeType(song.mimeType)
             .setMediaMetadata(MediaItemBuilder.build(song).mediaMetadata)
             .build()
         if (controller.currentMediaItem?.mediaId == song.id) {
@@ -3037,7 +3039,8 @@ class PlayerViewModel @Inject constructor(
         mediaController?.let { controller ->
             val mediaItem = MediaItem.Builder()
                 .setMediaId(song.id)
-                .setUri(MediaItemBuilder.playbackUri(song.contentUriString))
+                .setUri(MediaItemBuilder.playbackUri(song))
+                .setMimeType(song.mimeType)
                 .setMediaMetadata(MediaMetadata.Builder()
                     .setTitle(song.title)
                     .setArtist(song.displayArtist)
@@ -3053,7 +3056,8 @@ class PlayerViewModel @Inject constructor(
         mediaController?.let { controller ->
             val mediaItem = MediaItem.Builder()
                 .setMediaId(song.id)
-                .setUri(MediaItemBuilder.playbackUri(song.contentUriString))
+                .setUri(MediaItemBuilder.playbackUri(song))
+                .setMimeType(song.mimeType)
                 .setMediaMetadata(
                     MediaMetadata.Builder()
                         .setTitle(song.title)

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
@@ -13,6 +13,28 @@ import java.io.File
 object MediaItemBuilder {
     private const val EXTERNAL_MEDIA_ID_PREFIX = "external:"
     private const val EXTERNAL_EXTRA_PREFIX = "com.theveloper.pixelplay.external."
+    private val DIRECT_FILE_URI_MIME_TYPES = setOf(
+        "audio/mp4",
+        "audio/m4a",
+        "audio/x-m4a",
+        "audio/mp4a-latm",
+        "audio/aac",
+        "audio/x-aac",
+        "audio/3gp",
+        "audio/3gpp",
+        "audio/3gpp2",
+    )
+    private val DIRECT_FILE_URI_EXTENSIONS = setOf(
+        "m4a",
+        "m4b",
+        "m4p",
+        "mp4",
+        "aac",
+        "3ga",
+        "3gp",
+        "3gpp",
+        "alac",
+    )
     private val SUPPORTED_ARTWORK_SCHEMES = setOf(
         "content",
         "file",
@@ -37,7 +59,8 @@ object MediaItemBuilder {
     fun build(song: Song): MediaItem {
         return MediaItem.Builder()
             .setMediaId(song.id)
-            .setUri(playbackUri(song.contentUriString))
+            .setUri(playbackUri(song))
+            .setMimeType(song.mimeType)
             .setMediaMetadata(buildMediaMetadataForSong(song))
             .build()
     }
@@ -45,7 +68,8 @@ object MediaItemBuilder {
     fun buildForExternalController(context: Context, song: Song): MediaItem {
         return MediaItem.Builder()
             .setMediaId(song.id)
-            .setUri(playbackUri(song.contentUriString))
+            .setUri(playbackUri(song))
+            .setMimeType(song.mimeType)
             .setMediaMetadata(
                 buildMediaMetadataForSong(
                     song = song,
@@ -55,13 +79,20 @@ object MediaItemBuilder {
             .build()
     }
 
-    fun playbackUri(contentUriString: String): Uri {
+    fun playbackUri(song: Song): Uri = playbackUri(
+        contentUriString = song.contentUriString,
+        filePath = song.path,
+        mimeType = song.mimeType
+    )
+
+    fun playbackUri(
+        contentUriString: String,
+        filePath: String? = null,
+        mimeType: String? = null
+    ): Uri {
+        directLocalFileUri(contentUriString, filePath, mimeType)?.let { return it }
         val uri = runCatching { Uri.parse(contentUriString) }.getOrNull()
-            ?: return if (contentUriString.startsWith("/")) {
-                Uri.fromFile(File(contentUriString))
-            } else {
-                Uri.fromFile(File(contentUriString))
-            }
+            ?: return Uri.fromFile(File(contentUriString))
         // Telegram downloaded files can be stored as absolute paths (without file://).
         // Normalize them so ExoPlayer always gets a canonical local-file URI.
         return if (uri.scheme.isNullOrBlank() && contentUriString.startsWith("/")) {
@@ -69,6 +100,49 @@ object MediaItemBuilder {
         } else {
             uri
         }
+    }
+
+    private fun directLocalFileUri(
+        contentUriString: String,
+        filePath: String?,
+        mimeType: String?
+    ): Uri? {
+        val normalizedPath = filePath?.takeIf { it.startsWith("/") } ?: return null
+        if (!shouldPreferDirectLocalFileUri(contentUriString, normalizedPath, mimeType)) {
+            return null
+        }
+
+        return Uri.fromFile(File(normalizedPath))
+    }
+
+    internal fun shouldPreferDirectLocalFileUri(
+        contentUriString: String,
+        filePath: String?,
+        mimeType: String?
+    ): Boolean {
+        val normalizedPath = filePath?.takeIf { it.startsWith("/") } ?: return false
+        if (!LocalArtworkUri.isLikelyLocalMedia(contentUriString)) {
+            return false
+        }
+
+        if (!contentUriString.startsWith("content://")) {
+            return false
+        }
+
+        return shouldPreferDirectFileUri(normalizedPath, mimeType)
+    }
+
+    private fun shouldPreferDirectFileUri(
+        filePath: String,
+        mimeType: String?
+    ): Boolean {
+        val normalizedMimeType = mimeType?.lowercase()
+        if (normalizedMimeType != null && normalizedMimeType in DIRECT_FILE_URI_MIME_TYPES) {
+            return true
+        }
+
+        val extension = filePath.substringAfterLast('.', "").lowercase()
+        return extension in DIRECT_FILE_URI_EXTENSIONS
     }
 
     /**

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
@@ -436,7 +436,7 @@ class PlayerViewModelTest {
                 .build()
             val mockedPlaybackUri = mockk<android.net.Uri>(relaxed = true)
             every { mockedPlaybackUri.scheme } returns "file"
-            every { MediaItemBuilder.playbackUri(any()) } returns mockedPlaybackUri
+            every { MediaItemBuilder.playbackUri(any<Song>()) } returns mockedPlaybackUri
         }
 
         @Test

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaItemBuilderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaItemBuilderTest.kt
@@ -1,0 +1,40 @@
+package com.theveloper.pixelplay.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MediaItemBuilderTest {
+
+    @Test
+    fun shouldPreferDirectLocalFileUri_prefersDirectFileUriForLocalM4aMediaStoreItems() {
+        val shouldPreferFile = MediaItemBuilder.shouldPreferDirectLocalFileUri(
+            contentUriString = "content://media/external/audio/media/42",
+            filePath = "/storage/emulated/0/Music/test-track.m4a",
+            mimeType = "audio/mp4"
+        )
+
+        assertThat(shouldPreferFile).isTrue()
+    }
+
+    @Test
+    fun shouldPreferDirectLocalFileUri_keepsContentUriForFormatsThatAlreadySeekCorrectly() {
+        val shouldPreferFile = MediaItemBuilder.shouldPreferDirectLocalFileUri(
+            contentUriString = "content://media/external/audio/media/24",
+            filePath = "/storage/emulated/0/Music/test-track.flac",
+            mimeType = "audio/flac"
+        )
+
+        assertThat(shouldPreferFile).isFalse()
+    }
+
+    @Test
+    fun shouldPreferDirectLocalFileUri_keepsCloudUrisUntouched() {
+        val shouldPreferFile = MediaItemBuilder.shouldPreferDirectLocalFileUri(
+            contentUriString = "telegram://123/456",
+            filePath = "/storage/emulated/0/Download/cached-track.m4a",
+            mimeType = "audio/mp4"
+        )
+
+        assertThat(shouldPreferFile).isFalse()
+    }
+}


### PR DESCRIPTION
…m` construction

- **DualPlayerEngine**: Configure `Mp4Extractor` with `FLAG_WORKAROUND_IGNORE_EDIT_LISTS` to prevent seek drift and snap-back issues caused by broken edit lists in vendor-produced M4A files.
- **MediaItemBuilder**:
    - Update `playbackUri` to prefer direct file URIs over `content://` URIs for specific local audio formats (M4A, MP4, AAC, 3GP, etc.) to improve playback stability.
    - Implement `shouldPreferDirectLocalFileUri` to identify when a direct file path should be used based on MIME type and file extension.
    - Centralize `MediaItem` URI generation by accepting `Song` objects directly.
- **PlayerViewModel**: Update `MediaItem` creation to include MIME types and use the updated `MediaItemBuilder.playbackUri` signature.
- **Tests**:
    - Add `MediaItemBuilderTest` to verify direct file URI selection logic.
    - Update `PlayerViewModelTest` to match the new `playbackUri` signature.