### PR TITLE
Optimize location permissions and connectivity handling for Android 12+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,9 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"/>
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
@@ -21,10 +23,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/> <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
-    <!-- For Android 10+ -->
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!-- Required only on Android 11 and below for legacy Bluetooth discovery and Wi-Fi SSID access. -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
     <!-- For disabling battery optimization -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -144,6 +144,7 @@ object AppModule {
             PixelPlayDatabase.MIGRATION_35_36
         )
             .addCallback(PixelPlayDatabase.createRuntimeArtifactsCallback())
+            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
 
         // P2-4: Only allow destructive migration in debug builds.
         // In release, a migration bug will crash the app (revealing the problem)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -190,7 +190,9 @@ fun CastBottomSheet(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 add(Manifest.permission.NEARBY_WIFI_DEVICES)
             }
-            add(Manifest.permission.ACCESS_FINE_LOCATION)
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+                add(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
         }
     }
     var missingPermissions by remember { mutableStateOf(missingCastPermissions(context, requiredPermissions)) }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ConnectivityStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ConnectivityStateHolder.kt
@@ -91,8 +91,7 @@ class ConnectivityStateHolder @Inject constructor(
      * Manually refresh local connection info (e.g. WiFi SSID).
      */
     fun refreshLocalConnectionInfo(refreshBluetoothDevices: Boolean = false) {
-        val activeNetwork = connectivityManager.activeNetwork
-        updateWifiInfo(activeNetwork)
+        updateWifiInfo()
         if (refreshBluetoothDevices) {
             refreshBluetoothAudioDevices()
         } else {
@@ -133,7 +132,7 @@ class ConnectivityStateHolder @Inject constructor(
         updateWifiRadioState()
         _isWifiEnabled.value = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
         if (_isWifiEnabled.value) {
-            updateWifiInfo(activeNetwork)
+            updateWifiInfo()
         }
         
         _isOnline.value = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true &&
@@ -164,7 +163,7 @@ class ConnectivityStateHolder @Inject constructor(
                 
                 if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
                     _isWifiEnabled.value = true
-                    updateWifiInfo(network)
+                    updateWifiInfo()
                 }
             }
 
@@ -255,23 +254,13 @@ class ConnectivityStateHolder @Inject constructor(
         _isWifiRadioOn.value = wifiManager?.isWifiEnabled == true
     }
 
-    @SuppressLint("MissingPermission")
-    private fun updateWifiInfo(network: Network?) {
-         if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-             val info = wifiManager?.connectionInfo
-             if (info != null && info.supplicantState == android.net.wifi.SupplicantState.COMPLETED) {
-                 var ssid = info.ssid
-                 if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
-                     ssid = ssid.substring(1, ssid.length - 1)
-                 }
-                 _wifiName.value = ssid
-             } else {
-                 _wifiName.value = null
-             }
-         } else {
-             // Basic fallback purely on network capabilities if we don't have permission (unlikely for system app but good practice)
-             _wifiName.value = "WiFi Connected" 
-         }
+    private fun updateWifiInfo() {
+        _wifiName.value = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R && hasFineLocationPermission()) {
+            readConnectedWifiSsid()
+        } else {
+            // On Android 12+ we intentionally avoid SSID reads so the cast flow does not look like location usage.
+            "WiFi Connected"
+        }
     }
 
     private fun updateBluetoothName(connectedAudioDevices: List<String>) {
@@ -379,10 +368,10 @@ class ConnectivityStateHolder @Inject constructor(
         val adapter = bluetoothAdapter ?: return
         if (!canStartBluetoothDiscovery()) return
 
-        if (runCatching { adapter.isDiscovering }.getOrDefault(false)) {
-            runCatching { adapter.cancelDiscovery() }
+        if (isBluetoothDiscoveryActive(adapter)) {
+            cancelBluetoothDiscovery(adapter)
         }
-        runCatching { adapter.startDiscovery() }
+        startBluetoothDiscovery(adapter)
     }
 
     private fun sanitizeBluetoothAudioDeviceState(
@@ -413,14 +402,13 @@ class ConnectivityStateHolder @Inject constructor(
         _isBluetoothEnabled.value = if (!hasBluetoothConnectPermission()) {
             false
         } else {
-            safeBluetoothCall(false) { bluetoothAdapter?.isEnabled ?: false }
+            readBluetoothEnabledState()
         }
     }
 
     private fun resolveLocalBluetoothAdapterName(): String? {
         if (!hasBluetoothConnectPermission()) return null
-        return safeBluetoothCall("") { bluetoothAdapter?.name?.trim().orEmpty() }
-            .takeIf { it.isNotEmpty() }
+        return readLocalBluetoothAdapterName()
     }
 
     private fun resolveLocalBluetoothDeviceNames(): Set<String> {
@@ -440,9 +428,13 @@ class ConnectivityStateHolder @Inject constructor(
             ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
     }
 
+    private fun hasFineLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+    }
+
     private fun hasBluetoothDiscoveryLocationPermission(): Boolean {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ||
-            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+            hasFineLocationPermission()
     }
 
     private fun canStartBluetoothDiscovery(): Boolean {
@@ -468,6 +460,7 @@ class ConnectivityStateHolder @Inject constructor(
         return address?.takeIf { it.isNotBlank() } ?: "name:${name.lowercase()}"
     }
 
+    @SuppressLint("MissingPermission")
     private fun BluetoothDevice.toBluetoothAudioDeviceState(isConnected: Boolean): BluetoothAudioDeviceState? {
         if (!hasBluetoothConnectPermission()) return null
 
@@ -500,11 +493,63 @@ class ConnectivityStateHolder @Inject constructor(
         }.getOrNull()?.takeIf { it in 0..100 }
     }
 
+    @SuppressLint("MissingPermission")
     private fun BluetoothDevice.isAudioOutputCandidate(): Boolean {
         if (!hasBluetoothConnectPermission()) return false
+
         val deviceClass = safeBluetoothCall<BluetoothClass?>(null) { bluetoothClass } ?: return false
         return deviceClass.majorDeviceClass == BluetoothClass.Device.Major.AUDIO_VIDEO ||
             deviceClass.hasService(BluetoothClass.Service.RENDER)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun readConnectedWifiSsid(): String? {
+        if (!hasFineLocationPermission()) return null
+
+        val info = wifiManager?.connectionInfo ?: return null
+        if (info.supplicantState != android.net.wifi.SupplicantState.COMPLETED) return null
+
+        var ssid = info.ssid
+        if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
+            ssid = ssid.substring(1, ssid.length - 1)
+        }
+        return ssid
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun readBluetoothEnabledState(): Boolean {
+        if (!hasBluetoothConnectPermission()) return false
+
+        return safeBluetoothCall(false) { bluetoothAdapter?.isEnabled ?: false }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun readLocalBluetoothAdapterName(): String? {
+        if (!hasBluetoothConnectPermission()) return null
+
+        return safeBluetoothCall("") { bluetoothAdapter?.name?.trim().orEmpty() }
+            .takeIf { it.isNotEmpty() }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun isBluetoothDiscoveryActive(adapter: BluetoothAdapter): Boolean {
+        if (!hasBluetoothScanPermission()) return false
+
+        return runCatching { adapter.isDiscovering }.getOrDefault(false)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun cancelBluetoothDiscovery(adapter: BluetoothAdapter) {
+        if (!hasBluetoothScanPermission()) return
+
+        runCatching { adapter.cancelDiscovery() }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun startBluetoothDiscovery(adapter: BluetoothAdapter) {
+        if (!hasBluetoothScanPermission()) return
+
+        runCatching { adapter.startDiscovery() }
     }
 
     private inline fun <T> safeBluetoothCall(defaultValue: T, block: () -> T): T {
@@ -534,8 +579,8 @@ class ConnectivityStateHolder @Inject constructor(
             runCatching { context.unregisterReceiver(it) }
         }
         if (hasBluetoothScanPermission()) {
-            bluetoothAdapter?.takeIf { runCatching { it.isDiscovering }.getOrDefault(false) }?.let {
-                runCatching { it.cancelDiscovery() }
+            bluetoothAdapter?.takeIf { isBluetoothDiscoveryActive(it) }?.let {
+                cancelBluetoothDiscovery(it)
             }
         }
         discoveredBluetoothAudioDevices.clear()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -415,7 +415,8 @@ class PlayerViewModel @Inject constructor(
             "DEEPSEEK" -> deepseekKey.isNotBlank()
             else -> geminiKey.isNotBlank()
         }
-    }.stateIn(
+    }.distinctUntilChanged()
+        .stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = false
@@ -1005,7 +1006,8 @@ class PlayerViewModel @Inject constructor(
         favoriteSongIds
     ) { songId, ids ->
         songId?.let { ids.contains(it) } ?: false
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+    }.distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     // ---------------------------------------------------------------------------
     // FullPlayerSlice — consolidates 11 independent flows into ONE subscription.

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -65,7 +66,8 @@ class SongInfoBottomSheetViewModel @Inject constructor(
         activeWatchTransfer
     ) { isRequesting, activeTransfer ->
         isRequesting || activeTransfer != null
-    }.stateIn(
+    }.distinctUntilChanged()
+        .stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000L),
         initialValue = false,


### PR DESCRIPTION
This commit refactors connectivity and location permission usage to comply with modern Android privacy standards, specifically targeting Android 12 (API 31) and above by decoupling network/Bluetooth metadata from location access.

### Permissions & Security
- **Location Access Refinement:** Updated `AndroidManifest.xml` and `CastBottomSheet` to restrict `ACCESS_FINE_LOCATION` to Android 11 (API 30) and below.
- **Bluetooth Scan Flags:** Added `neverForLocation` flag to `BLUETOOTH_SCAN` in the manifest to declare that Bluetooth scanning is not used for location tracking.
- **Cleanup:** Removed unnecessary `ACCESS_MEDIA_LOCATION` and `ACCESS_COARSE_LOCATION` permissions.

### Connectivity & State Management
- **SSID Privacy:** Modified `ConnectivityStateHolder` to skip reading Wi-Fi SSIDs on Android 12+. On these versions, the UI now displays a generic "WiFi Connected" label to avoid triggering location-related permission prompts.
- **Connectivity Logic:** Refactored `updateWifiInfo` and Bluetooth discovery methods to use internal permission checks and helper functions for safer, cleaner execution.
- **Flow Optimizations:** Applied `distinctUntilChanged()` to several `StateFlow` definitions in `PlayerViewModel`, `SongInfoBottomSheetViewModel`, and other components to reduce unnecessary UI recompositions when state values haven't changed.

### Database
- **Performance:** Enabled `WRITE_AHEAD_LOGGING` (WAL) journal mode for the Room database in `AppModule` to improve concurrency and write performance.