### PR TITLE
Refactor and centralize `MediaStore` selection logic to improve audio…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MediaStoreSongRepository.kt
@@ -19,6 +19,7 @@ import com.theveloper.pixelplay.utils.AlbumArtUtils
 import com.theveloper.pixelplay.utils.DirectoryRuleResolver
 import com.theveloper.pixelplay.utils.DirectoryFilterUtils
 import com.theveloper.pixelplay.utils.LogUtils
+import com.theveloper.pixelplay.utils.buildLocalAudioSelection
 import com.theveloper.pixelplay.utils.normalizeMetadataText
 import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 import com.theveloper.pixelplay.utils.extractArtistsFromTitle
@@ -59,12 +60,6 @@ class MediaStoreSongRepository @Inject constructor(
     private val musicDao: MusicDao,
     private val userPreferencesRepository: UserPreferencesRepository
 ) : SongRepository {
-
-    private fun getBaseSelection(minDurationMs: Int = 10000): String {
-        // Relaxed filter: Remove IS_MUSIC to include all audio strings (WhatsApp, Recs, etc.)
-        // We filter by duration based on user preference (default 10s).
-        return "${MediaStore.Audio.Media.DURATION} >= $minDurationMs AND ${MediaStore.Audio.Media.TITLE} != ''"
-    }
 
     private suspend fun getFavoriteIds(): Set<Long> {
         return favoritesDao.getFavoriteSongIdsOnce().toSet()
@@ -121,6 +116,7 @@ class MediaStoreSongRepository @Inject constructor(
         extraSelectionArgs: Array<String>? = null
     ): List<Song> = withContext(Dispatchers.IO) {
         val songs = mutableListOf<Song>()
+        val (baseSelection, baseSelectionArgs) = buildLocalAudioSelection(minDurationMs)
         val projection = arrayOf(
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
@@ -144,12 +140,17 @@ class MediaStoreSongRepository @Inject constructor(
         // Assuming minSdk is high enough or columns exist (ALBUM_ARTIST is API 30+, need check if app supports lower)
 
         val selection = buildString {
-            append(getBaseSelection(minDurationMs))
+            append(baseSelection)
             if (!extraSelection.isNullOrBlank()) {
                 append(" AND (")
                 append(extraSelection)
                 append(")")
             }
+        }
+        val selectionArgs = if (extraSelectionArgs.isNullOrEmpty()) {
+            baseSelectionArgs
+        } else {
+            baseSelectionArgs + extraSelectionArgs
         }
 
         val songIdToGenreMap = getSongIdToGenreMap(context.contentResolver)
@@ -159,7 +160,7 @@ class MediaStoreSongRepository @Inject constructor(
                 MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                 projection,
                 selection,
-                extraSelectionArgs,
+                selectionArgs,
                 "${MediaStore.Audio.Media.TITLE} ASC"
             )?.use { cursor ->
                 val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
@@ -401,14 +402,14 @@ class MediaStoreSongRepository @Inject constructor(
     private suspend fun getFilteredSongIds(allowedDirs: List<String>, blockedDirs: List<String>, minDurationMs: Int = 10000): List<Long> = withContext(Dispatchers.IO) {
         val ids = mutableListOf<Long>()
         val projection = arrayOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.DATA)
-        val selection = getBaseSelection(minDurationMs)
+        val (selection, selectionArgs) = buildLocalAudioSelection(minDurationMs)
 
         try {
             context.contentResolver.query(
                 MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                 projection,
                 selection,
-                null,
+                selectionArgs,
                 "${MediaStore.Audio.Media.TITLE} ASC"
             )?.use { cursor ->
                 val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -34,6 +34,7 @@ import com.theveloper.pixelplay.utils.AlbumArtUtils
 import com.theveloper.pixelplay.utils.AudioMetaUtils.getAudioMetadata
 import com.theveloper.pixelplay.utils.DirectoryRuleResolver
 import com.theveloper.pixelplay.utils.LocalArtworkUri
+import com.theveloper.pixelplay.utils.buildLocalAudioSelection
 import com.theveloper.pixelplay.utils.normalizeMetadataTextOrEmpty
 import com.theveloper.pixelplay.utils.splitArtistsByDelimiters
 import dagger.assisted.Assisted
@@ -722,7 +723,7 @@ constructor(
                         MediaStore.Audio.Media.DATE_MODIFIED
                 )
 
-        val (baseSelection, baseArgs) = getBaseSelection(minSongDurationMs)
+        val (baseSelection, baseArgs) = buildLocalAudioSelection(minSongDurationMs)
         val selectionBuilder = StringBuilder(baseSelection)
         val selectionArgsList = baseArgs.toMutableList()
 
@@ -1213,7 +1214,7 @@ constructor(
     private fun fetchMediaStoreIds(directoryResolver: DirectoryRuleResolver): Set<Long> {
         val ids = mutableSetOf<Long>()
         val projection = arrayOf(MediaStore.Audio.Media._ID, MediaStore.Audio.Media.DATA)
-        val (selection, selectionArgs) = getBaseSelection(minSongDurationMs)
+        val (selection, selectionArgs) = buildLocalAudioSelection(minSongDurationMs)
 
         contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
@@ -1238,12 +1239,6 @@ constructor(
         return ids
     }
 
-    private fun getBaseSelection(minDuration: Int): Pair<String, Array<String>> {
-        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0 AND ${MediaStore.Audio.Media.DURATION} >= ?"
-        val selectionArgs = arrayOf(minDuration.toString())
-        return selection to selectionArgs
-    }
-
     /**
      * Fetches all file paths currently known to MediaStore.
      * Used to identify new files that need scanning.
@@ -1251,7 +1246,7 @@ constructor(
     private fun fetchMediaStoreFilePaths(): Set<String> {
         val paths = HashSet<String>()
         val projection = arrayOf(MediaStore.Audio.Media.DATA)
-        val (selection, selectionArgs) = getBaseSelection(minSongDurationMs)
+        val (selection, selectionArgs) = buildLocalAudioSelection(minSongDurationMs)
         
         contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtils.kt
@@ -1,0 +1,20 @@
+package com.theveloper.pixelplay.utils
+
+import android.provider.MediaStore
+
+/**
+ * Builds the baseline MediaStore selection for user-facing local audio.
+ *
+ * We intentionally do not rely on [MediaStore.Audio.Media.IS_MUSIC] here because some devices
+ * and scanners leave valid songs flagged as non-music, which makes library sync and folder
+ * browsing appear to "cap out" below the real file count for specific users.
+ */
+fun buildLocalAudioSelection(minDurationMs: Int): Pair<String, Array<String>> {
+    val clampedMinDurationMs = minDurationMs.coerceAtLeast(0)
+    val selection = buildString {
+        append("${MediaStore.Audio.Media.DURATION} >= ?")
+        append(" AND COALESCE(${MediaStore.Audio.Media.TITLE}, '') != ''")
+        append(" AND ${MediaStore.Audio.Media.DATA} IS NOT NULL")
+    }
+    return selection to arrayOf(clampedMinDurationMs.toString())
+}

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtilsTest.kt
@@ -1,0 +1,27 @@
+package com.theveloper.pixelplay.utils
+
+import android.provider.MediaStore
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MediaStoreSelectionUtilsTest {
+
+    @Test
+    fun `buildLocalAudioSelection does not depend on is music flag`() {
+        val (selection, selectionArgs) = buildLocalAudioSelection(10_000)
+
+        assertFalse(selection.contains(MediaStore.Audio.Media.IS_MUSIC))
+        assertTrue(selection.contains(MediaStore.Audio.Media.DURATION))
+        assertTrue(selection.contains(MediaStore.Audio.Media.TITLE))
+        assertArrayEquals(arrayOf("10000"), selectionArgs)
+    }
+
+    @Test
+    fun `buildLocalAudioSelection clamps negative durations`() {
+        val (_, selectionArgs) = buildLocalAudioSelection(-250)
+
+        assertArrayEquals(arrayOf("0"), selectionArgs)
+    }
+}


### PR DESCRIPTION
… file discovery

- **MediaStoreSelectionUtils**: Introduced a new utility to build a unified baseline selection for local audio. It bypasses the `IS_MUSIC` flag to include valid media often misclassified by the system, ensuring better coverage for library sync and folder browsing. It also adds safety checks for empty titles and null data paths.
- **MediaStoreSongRepository**: Updated to use the new `buildLocalAudioSelection` utility. Refactored query logic to use parameterized selection arguments instead of hardcoded strings, improving security and consistency across repository methods.
- **SyncWorker**: Standardized `SyncWorker` queries using the new utility. Removed local `getBaseSelection` implementation, which previously relied on the restrictive `IS_MUSIC` flag, ensuring the background sync matches the repository's discovery logic.
- **Tests**: Added `MediaStoreSelectionUtilsTest` to verify the absence of the `IS_MUSIC` flag, correct duration filtering, and clamping of negative duration inputs.