### PR TITLE
fix: artist custom images and genre ellipsis

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/ArtistImageRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/ArtistImageRepository.kt
@@ -318,9 +318,12 @@ class ArtistImageRepository @Inject constructor(
         val bounds = BitmapFactory.Options().apply {
             inJustDecodeBounds = true
         }
+        
+        // Fetch dimensions without loading the full bitmap into memory.
+        // decodeStream returns null when inJustDecodeBounds is true.
         resolver.openInputStream(sourceUri)?.use { inputStream ->
             BitmapFactory.decodeStream(inputStream, null, bounds)
-        } ?: return null
+        }
 
         val width = bounds.outWidth
         val height = bounds.outHeight

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ExpressiveTopBarContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ExpressiveTopBarContent.kt
@@ -54,7 +54,7 @@ fun ExpressiveTopBarContent(
     val titleContainerHeight = lerp(containerHeightRange.first, containerHeightRange.second, clampedFraction)
     val subtitleAlpha = if (fadeSubtitleOnCollapse) 1f - clampedFraction else 1f
     val subtitleMaxLines = if (clampedFraction < 0.5f) expandedSubtitleMaxLines else collapsedSubtitleMaxLines
-    val titleFontSize = titleFontSizeRange?.let { lerp(it.first, it.second, clampedFraction) } ?: titleStyle.fontSize
+    val titleFontSize = (titleFontSizeRange?.let { lerp(it.first, it.second, clampedFraction) } ?: titleStyle.fontSize) * titleScale
 
     Box(modifier = modifier.fillMaxSize()) {
         Box(
@@ -76,8 +76,8 @@ fun ExpressiveTopBarContent(
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                     lineHeight = titleFontSize * 1.1f,
                     modifier = Modifier.graphicsLayer {
-                        scaleX = titleScale
-                        scaleY = titleScale
+                        // Removed scaleX/scaleY scaling from graphicsLayer to allow proper ellipsis during layout.
+                        // Scaling font size directly ensures Text component is measured with correct constraints.
                         transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0f, 0.5f) // Scale from left center
                     }
                 )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ArtistDetailViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ArtistDetailViewModel.kt
@@ -191,8 +191,10 @@ class ArtistDetailViewModel @Inject constructor(
 
                     _artistColorScheme.value = newScheme
                     _uiState.update { state ->
+                        // Cache-busting: add timestamp to internalPath to force Coil to reload
+                        val effectiveUrlWithBust = "$internalPath?t=${System.currentTimeMillis()}"
                         state.copy(
-                            effectiveImageUrl = internalPath,
+                            effectiveImageUrl = effectiveUrlWithBust,
                             artist = state.artist?.copy(customImageUri = internalPath)
                         )
                     }


### PR DESCRIPTION
- Fix where changing artist image to custom doesn't work by fixed bitmap decoding logic and add cache-busting
- Fix genre detail screen title where text is overflowing without ellipsis