### PR TITLE
Improve ALAC/M4A playback stability and refine media type resolution

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -7,6 +7,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.util.UnstableApi
@@ -40,6 +41,7 @@ import com.theveloper.pixelplay.data.telegram.TelegramRepository
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DataSpec
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import android.net.Uri
 import java.io.File
@@ -271,6 +273,23 @@ class DualPlayerEngine @Inject constructor(
     }
 
     private fun buildPlayer(handleAudioFocus: Boolean): ExoPlayer {
+        val mediaCodecSelector = MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+            val decoderInfos = MediaCodecSelector.DEFAULT.getDecoderInfos(
+                mimeType,
+                requiresSecureDecoder,
+                requiresTunnelingDecoder
+            )
+
+            // Some devices advertise ALAC decoders that stall on high-bitrate M4A files.
+            // Prefer stable software codecs when available, otherwise let the FFmpeg
+            // extension renderer handle ALAC by hiding the platform candidates.
+            if (mimeType.equals(MimeTypes.AUDIO_ALAC, ignoreCase = true)) {
+                val softwareDecoders = decoderInfos.filterNot { it.hardwareAccelerated }
+                softwareDecoders.ifEmpty { emptyList() }
+            } else {
+                decoderInfos
+            }
+        }
         val renderersFactory = object : DefaultRenderersFactory(context) {
             override fun buildAudioSink(
                 context: Context,
@@ -292,6 +311,8 @@ class DualPlayerEngine @Inject constructor(
                     .build()
             }
         }.setEnableAudioFloatOutput(false) // Disable Float output helper
+         .setMediaCodecSelector(mediaCodecSelector)
+         .setEnableDecoderFallback(true)
          .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
 
         val audioAttributes = AudioAttributes.Builder()

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
@@ -35,6 +35,14 @@ object MediaItemBuilder {
         "3gpp",
         "alac",
     )
+    private val EXTRACTOR_FIRST_MIME_TYPES = setOf(
+        "audio/mp4",
+        "audio/m4a",
+        "audio/x-m4a",
+        "audio/mp4a-latm",
+        "audio/alac",
+        "audio/x-alac",
+    )
     private val SUPPORTED_INTERNAL_ARTWORK_SCHEMES = setOf(
         LocalArtworkUri.SCHEME,
         "content",
@@ -68,7 +76,7 @@ object MediaItemBuilder {
         return MediaItem.Builder()
             .setMediaId(song.id)
             .setUri(playbackUri(song))
-            .setMimeType(song.mimeType)
+            .setMimeType(playbackMimeType(song))
             .setMediaMetadata(buildMediaMetadataForSong(song))
             .build()
     }
@@ -77,7 +85,7 @@ object MediaItemBuilder {
         return MediaItem.Builder()
             .setMediaId(song.id)
             .setUri(playbackUri(song))
-            .setMimeType(song.mimeType)
+            .setMimeType(playbackMimeType(song))
             .setMediaMetadata(
                 buildMediaMetadataForSong(
                     song = song,
@@ -88,6 +96,12 @@ object MediaItemBuilder {
     }
 
     fun playbackUri(song: Song): Uri = playbackUri(
+        contentUriString = song.contentUriString,
+        filePath = song.path,
+        mimeType = song.mimeType
+    )
+
+    internal fun playbackMimeType(song: Song): String? = playbackMimeType(
         contentUriString = song.contentUriString,
         filePath = song.path,
         mimeType = song.mimeType
@@ -107,6 +121,37 @@ object MediaItemBuilder {
             Uri.fromFile(File(contentUriString))
         } else {
             uri
+        }
+    }
+
+    internal fun playbackMimeType(
+        contentUriString: String,
+        filePath: String?,
+        mimeType: String?
+    ): String? {
+        val normalizedMimeType = mimeType?.trim()?.lowercase()
+        if (normalizedMimeType.isNullOrBlank()) {
+            return null
+        }
+
+        val isLikelyLocalMedia = LocalArtworkUri.isLikelyLocalMedia(contentUriString) ||
+            filePath?.startsWith("/") == true
+        if (!isLikelyLocalMedia) {
+            return mimeType
+        }
+
+        val extension = filePath
+            ?.substringAfterLast('.', "")
+            ?.lowercase()
+            .orEmpty()
+
+        return if (
+            normalizedMimeType in EXTRACTOR_FIRST_MIME_TYPES ||
+            extension in DIRECT_FILE_URI_EXTENSIONS
+        ) {
+            null
+        } else {
+            mimeType
         }
     }
 

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaItemBuilderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaItemBuilderTest.kt
@@ -37,4 +37,26 @@ class MediaItemBuilderTest {
 
         assertThat(shouldPreferFile).isFalse()
     }
+
+    @Test
+    fun playbackMimeType_clearsAmbiguousLocalM4aMimeType() {
+        val playbackMimeType = MediaItemBuilder.playbackMimeType(
+            contentUriString = "content://media/external/audio/media/42",
+            filePath = "/storage/emulated/0/Music/test-track.m4a",
+            mimeType = "audio/mp4"
+        )
+
+        assertThat(playbackMimeType).isNull()
+    }
+
+    @Test
+    fun playbackMimeType_keepsNonMp4MimeTypeForLocalPlayback() {
+        val playbackMimeType = MediaItemBuilder.playbackMimeType(
+            contentUriString = "content://media/external/audio/media/84",
+            filePath = "/storage/emulated/0/Music/test-track.flac",
+            mimeType = "audio/flac"
+        )
+
+        assertThat(playbackMimeType).isEqualTo("audio/flac")
+    }
 }


### PR DESCRIPTION
### Audio Engine & Codec Handling
- **MediaCodec Selection**: Customized `MediaCodecSelector` in `DualPlayerEngine` to bypass hardware-accelerated ALAC decoders that cause stalls on certain devices. It now prefers software codecs or falls back to the FFmpeg extension renderer for improved reliability with high-bitrate M4A files.
- **ExoPlayer Configuration**: Enabled decoder fallback in `DefaultRenderersFactory` to provide more robust handling when a primary codec fails.

### Media Item Resolution
- **MIME Type Sanitization**: Introduced logic in `MediaItemBuilder` to clear ambiguous or problematic MIME types (e.g., `audio/mp4`, `audio/alac`) for local media. This forces the player's extractors to determine the container format from the bitstream, preventing playback failures caused by incorrect system-provided metadata.
- **Smart URI Handling**: Refined `playbackMimeType` logic to distinguish between local files and remote streams, ensuring specific MIME types are preserved for cloud playback while applying stricter sanitization for local storage.

### Testing
- **MediaItemBuilderTest**: Added unit tests to verify that ambiguous M4A MIME types are cleared for local playback while standard formats like FLAC retain their metadata.