### PR TITLE
Enhance TTML lyrics parsing and improve document normalization

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
@@ -468,6 +468,13 @@ object LyricsUtils {
             return Lyrics(plain = emptyList(), synced = emptyList())
         }
 
+        val normalizedInput = stripLeadingLyricsDocumentNoise(lyricsText)
+        if (looksLikeTtmlDocument(normalizedInput)) {
+            val converted = TtmlLyricsParser.parseToEnhancedLrc(normalizedInput)
+                ?: return Lyrics(plain = emptyList(), synced = emptyList())
+            return parseLyrics(converted)
+        }
+
         val syncedLines = mutableListOf<SyncedLine>()
         val plainLines = mutableListOf<String>()
         var isSynced = false
@@ -725,6 +732,28 @@ object LyricsUtils {
             ""
         }
     }
+}
+
+private fun stripLeadingLyricsDocumentNoise(value: String): String {
+    return value.trimStart { char ->
+        char.isWhitespace() ||
+            char == '\uFEFF' ||
+            Character.getType(char).toByte() == Character.FORMAT
+    }
+}
+
+private fun looksLikeTtmlDocument(value: String): Boolean {
+    if (value.startsWith("<tt", ignoreCase = true)) {
+        return true
+    }
+    if (!value.startsWith("<?xml", ignoreCase = true)) {
+        return false
+    }
+
+    val afterDeclaration = value.substringAfter("?>", missingDelimiterValue = "")
+    return afterDeclaration
+        .trimStart()
+        .startsWith("<tt", ignoreCase = true)
 }
 
 private fun sanitizeLrcLine(rawLine: String): String {

--- a/app/src/main/java/com/theveloper/pixelplay/utils/TtmlLyricsParser.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/TtmlLyricsParser.kt
@@ -14,6 +14,11 @@ internal object TtmlLyricsParser {
 
     fun parseToEnhancedLrc(ttmlText: String): String? {
         return runCatching {
+            val normalizedTtml = normalizeTtmlDocument(ttmlText)
+            if (normalizedTtml.isBlank()) {
+                return null
+            }
+
             val builder = DocumentBuilderFactory.newInstance().apply {
                 isNamespaceAware = true
                 isXIncludeAware = false
@@ -29,7 +34,7 @@ internal object TtmlLyricsParser {
                 setEntityResolver(EntityResolver { _, _ -> InputSource(StringReader("")) })
             }
 
-            val document = builder.parse(InputSource(StringReader(ttmlText)))
+            val document = builder.parse(InputSource(StringReader(normalizedTtml)))
             val paragraphNodes = document.getElementsByTagNameNS("*", "p")
             if (paragraphNodes.length == 0 || paragraphNodes.length > MAX_TTML_PARAGRAPHS) {
                 return null
@@ -47,6 +52,20 @@ internal object TtmlLyricsParser {
                 .joinToString("\n") { it.second }
                 .takeIf { it.isNotBlank() }
         }.getOrNull()
+    }
+
+    private fun normalizeTtmlDocument(raw: String): String {
+        val withoutLeadingNoise = raw.trimStart { char ->
+            char.isWhitespace() ||
+                char == '\uFEFF' ||
+                Character.getType(char).toByte() == Character.FORMAT
+        }
+
+        return if (withoutLeadingNoise.startsWith("<?xml", ignoreCase = true)) {
+            withoutLeadingNoise.substringAfter("?>", missingDelimiterValue = withoutLeadingNoise).trimStart()
+        } else {
+            withoutLeadingNoise
+        }
     }
 
     private fun resolveParagraphStartMs(paragraph: Element): Int? {
@@ -140,6 +159,10 @@ internal object TtmlLyricsParser {
 
         if (normalized.endsWith("s", ignoreCase = true)) {
             val seconds = normalized.removeSuffix("s").toDoubleOrNull() ?: return null
+            return (seconds * 1000).roundToInt()
+        }
+
+        normalized.toDoubleOrNull()?.let { seconds ->
             return (seconds * 1000).roundToInt()
         }
 

--- a/app/src/test/java/com/theveloper/pixelplay/utils/LyricsImportSecurityTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/LyricsImportSecurityTest.kt
@@ -159,6 +159,39 @@ class LyricsImportSecurityTest {
     }
 
     @Test
+    fun validateImportedLyricsFile_acceptsAppleTtmlWithXmlDeclarationAndNamespaces() {
+        val ttml = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <tt xmlns="http://www.w3.org/ns/ttml" xmlns:itunes="http://music.apple.com/lyric-ttml-internal" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" itunes:timing="Word" xml:lang="en">
+              <head>
+                <metadata>
+                  <ttm:agent type="person" xml:id="v1">
+                    <ttm:name type="full">Chase Atlantic</ttm:name>
+                  </ttm:agent>
+                </metadata>
+              </head>
+              <body dur="0:15.000">
+                <div begin="7.531" end="12.005" itunes:songPart="Verse">
+                  <p begin="7.531" end="12.005" itunes:key="L1" ttm:agent="v1"><span begin="7.531" end="7.782">Yeah,</span> <span begin="9.208" end="9.443">I</span> <span begin="9.443" end="9.675">bet</span></p>
+                </div>
+              </body>
+            </tt>
+        """.trimIndent()
+
+        val result = LyricsImportSecurity.validateImportedLyricsFile(
+            fileName = "track.ttml",
+            mimeType = "application/ttml+xml",
+            inputStream = ttml.byteInputStream()
+        )
+
+        assertThat(result).isInstanceOf(LyricsImportValidationResult.Valid::class.java)
+        val valid = result as LyricsImportValidationResult.Valid
+        assertThat(valid.value.sanitizedContent).isEqualTo("[00:07.53]<00:07.53>Yeah, <00:09.20>I <00:09.44>bet")
+        assertThat(valid.value.parsedLyrics.synced).hasSize(1)
+        assertThat(valid.value.parsedLyrics.synced!!.first().line).isEqualTo("Yeah, I bet")
+    }
+
+    @Test
     fun validateImportedLyricsFile_rejectsTtmlWithDoctype() {
         val maliciousTtml = """
             <!DOCTYPE tt [

--- a/app/src/test/java/com/theveloper/pixelplay/utils/LyricsUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/LyricsUtilsTest.kt
@@ -163,6 +163,55 @@ class LyricsUtilsTest {
     }
 
     @Test
+    fun parseLyrics_convertsAppleTtmlWithXmlDeclarationAndNamespaces() {
+        val ttml = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <tt xmlns="http://www.w3.org/ns/ttml" xmlns:itunes="http://music.apple.com/lyric-ttml-internal" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" itunes:timing="Word" xml:lang="en">
+              <head>
+                <metadata>
+                  <ttm:agent type="person" xml:id="v1">
+                    <ttm:name type="full">Chase Atlantic</ttm:name>
+                  </ttm:agent>
+                </metadata>
+              </head>
+              <body dur="0:15.000">
+                <div begin="7.531" end="12.005" itunes:songPart="Verse">
+                  <p begin="7.531" end="12.005" itunes:key="L1" ttm:agent="v1"><span begin="7.531" end="7.782">Yeah,</span> <span begin="9.208" end="9.443">I</span> <span begin="9.443" end="9.675">bet</span></p>
+                </div>
+              </body>
+            </tt>
+        """.trimIndent()
+
+        val lyrics = LyricsUtils.parseLyrics(ttml)
+        val synced = requireNotNull(lyrics.synced)
+        val first = synced.first()
+
+        assertEquals(1, synced.size)
+        assertEquals(7_530, first.time)
+        assertEquals("Yeah, I bet", first.line)
+        assertEquals(listOf("Yeah,", "I", "bet"), requireNotNull(first.words).map { it.word })
+    }
+
+    @Test
+    fun parseLyrics_doesNotExposeBrokenTtmlAsPlainText() {
+        val malformedTtml = """
+            <?xml version='1.0' encoding='utf-8'?>
+            <tt xmlns="http://www.w3.org/ns/ttml">
+              <body>
+                <div>
+                  <p begin="00:01.000">Hello
+                </div>
+              </body>
+            </tt>
+        """.trimIndent()
+
+        val lyrics = LyricsUtils.parseLyrics(malformedTtml)
+
+        assertTrue(lyrics.synced.isNullOrEmpty())
+        assertTrue(lyrics.plain.isNullOrEmpty())
+    }
+
+    @Test
     fun parseLyrics_stripsAdditionalLrcTimestampsFromLines() {
         val lrc = """
             [00:12.57] Sinking under


### PR DESCRIPTION
### Lyrics Parsing & Normalization
- **TTML Support**: Improved support for Apple-style TTML files containing XML declarations and multiple namespaces.
- **Document Normalization**: Introduced `normalizeTtmlDocument` to strip leading whitespace, Byte Order Marks (BOM), and format characters before parsing. It now correctly handles and bypasses `<?xml ... ?>` declarations to focus on the `<tt>` root element.
- **Time Expression Parsing**: Updated `TtmlLyricsParser` to support raw decimal second values (e.g., `"7.531"`) in addition to standard clock and offset time formats.
- **Parser Integration**: Updated `LyricsUtils` to automatically detect and route potential TTML content—even when prefixed with XML declarations—to the `TtmlLyricsParser`.

### Robustness & Security
- **Validation**: Added safeguards to ensure malformed TTML documents do not fall back to being treated as plain text if parsing fails.
- **Stability**: Added checks for empty normalized content and ensured strict paragraph limits are enforced during TTML to Enhanced LRC conversion.

### Testing
- Added comprehensive test cases in `LyricsImportSecurityTest` and `LyricsUtilsTest` to verify handling of complex Apple TTML files, XML declarations, and malformed XML inputs.