### PR TITLE
Implement reactive theme generation based on artwork changes in `Play…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -763,6 +763,18 @@ class PlayerViewModel @Inject constructor(
         playbackStateHolder.initialize(viewModelScope)
         themeStateHolder.initialize(viewModelScope)
 
+        stablePlayerState
+            .map { it.currentSong?.albumArtUriString?.takeIf { uri -> uri.isNotBlank() } }
+            .distinctUntilChanged()
+            .onEach { artworkUri ->
+                themeStateHolder.extractAndGenerateColorScheme(
+                    albumArtUriAsUri = artworkUri?.toUri(),
+                    currentSongUriString = artworkUri,
+                    isPreload = false
+                )
+            }
+            .launchIn(viewModelScope)
+
         viewModelScope.launch {
             lyricsStateHolder.songUpdates.collect { update: Pair<com.theveloper.pixelplay.data.model.Song, com.theveloper.pixelplay.data.model.Lyrics?> ->
                 val song = update.first


### PR DESCRIPTION
…erViewModel`

- **Dynamic Theming**: Added a flow subscription to `stablePlayerState` that monitors changes to the current song's album art URI.
- **Automated Color Extraction**: Integrated `themeStateHolder.extractAndGenerateColorScheme` to automatically update the application color scheme whenever a new valid artwork URI is detected, ensuring the UI remains synchronized with the playing media.