### PR TITLE
Enhance credential security and data privacy across cloud storage rep…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -387,6 +387,9 @@ dependencies {
 
     // Pinyin
     implementation(libs.pinyin4j.core)
+
+    // Encrypted credentials storage
+    implementation(libs.androidx.security.crypto)
 }
 
 tasks.withType<Test> {

--- a/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
@@ -2,6 +2,8 @@ package com.theveloper.pixelplay.data.gdrive
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
 import com.theveloper.pixelplay.data.database.GDriveDao
@@ -50,8 +52,21 @@ class GDriveRepository @Inject constructor(
         const val GDRIVE_GENRE = "Google Drive"
     }
 
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("gdrive_prefs", Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            "gdrive_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        Timber.e(e, "GDriveRepository: Failed to create EncryptedSharedPreferences, falling back to plain")
+        context.getSharedPreferences("gdrive_prefs_plain", Context.MODE_PRIVATE)
+    }
 
     private val _isLoggedInFlow = MutableStateFlow(false)
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()

--- a/app/src/main/java/com/theveloper/pixelplay/data/image/JellyfinCoilFetcher.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/image/JellyfinCoilFetcher.kt
@@ -83,8 +83,10 @@ class JellyfinCoilFetcher(
             return null
         }
 
+        val authHeader = repository.getAuthorizationHeader()
+
         return try {
-            downloadImage(imageUrl, cachedFile)
+            downloadImage(imageUrl, cachedFile, authHeader)
         } catch (e: Exception) {
             if (shouldLogFailure("download_$itemId")) {
                 Timber.w(e, "$TAG: Failed to download cover art for $itemId")
@@ -93,9 +95,10 @@ class JellyfinCoilFetcher(
         }
     }
 
-    private fun downloadImage(url: String, cacheFile: File): FetchResult? {
+    private fun downloadImage(url: String, cacheFile: File, authHeader: String? = null): FetchResult? {
         val request = Request.Builder()
             .url(url)
+            .apply { if (authHeader != null) header("Authorization", authHeader) }
             .get()
             .build()
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/JellyfinRepository.kt
@@ -2,6 +2,8 @@ package com.theveloper.pixelplay.data.jellyfin
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
 import com.theveloper.pixelplay.data.database.JellyfinDao
@@ -48,7 +50,6 @@ class JellyfinRepository @Inject constructor(
         private const val PREFS_NAME = "jellyfin_prefs"
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_USERNAME = "username"
-        private const val KEY_PASSWORD = "password"
         private const val KEY_ACCESS_TOKEN = "access_token"
         private const val KEY_USER_ID = "user_id"
 
@@ -61,7 +62,21 @@ class JellyfinRepository @Inject constructor(
         private const val LIBRARY_PLAYLIST_ID = "__library__"
     }
 
-    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        Timber.e(e, "$TAG: Failed to create EncryptedSharedPreferences, falling back to plain")
+        context.getSharedPreferences("${PREFS_NAME}_plain", Context.MODE_PRIVATE)
+    }
 
     private val _isLoggedInFlow = MutableStateFlow(false)
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()
@@ -75,13 +90,12 @@ class JellyfinRepository @Inject constructor(
     private fun initFromSavedCredentials() {
         val serverUrl = prefs.getString(KEY_SERVER_URL, null)
         val username = prefs.getString(KEY_USERNAME, null)
-        val password = prefs.getString(KEY_PASSWORD, null)
         val accessToken = prefs.getString(KEY_ACCESS_TOKEN, null)
         val userId = prefs.getString(KEY_USER_ID, null)
 
         if (!serverUrl.isNullOrBlank() && !username.isNullOrBlank() &&
             !accessToken.isNullOrBlank() && !userId.isNullOrBlank()) {
-            val credentials = JellyfinCredentials(serverUrl, username, password ?: "", accessToken, userId)
+            val credentials = JellyfinCredentials(serverUrl, username, "", accessToken, userId)
             val validationError = credentials.connectionValidationError()
             if (validationError != null) {
                 Timber.w("$TAG: Ignoring invalid saved Jellyfin server URL: $validationError")
@@ -100,6 +114,8 @@ class JellyfinRepository @Inject constructor(
 
     val serverUrl: String?
         get() = prefs.getString(KEY_SERVER_URL, null)
+
+    fun getAuthorizationHeader(): String? = api.getAuthorizationHeader()
 
     val username: String?
         get() = prefs.getString(KEY_USERNAME, null)
@@ -131,11 +147,10 @@ class JellyfinRepository @Inject constructor(
                 val fullCredentials = credentials.copy(accessToken = accessToken, userId = userId)
                 api.setCredentials(fullCredentials)
 
-                // Save credentials
+                // Save credentials (password is never persisted — token is sufficient)
                 prefs.edit()
                     .putString(KEY_SERVER_URL, fullCredentials.normalizedServerUrl)
                     .putString(KEY_USERNAME, username)
-                    .putString(KEY_PASSWORD, password)
                     .putString(KEY_ACCESS_TOKEN, accessToken)
                     .putString(KEY_USER_ID, userId)
                     .apply()

--- a/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentials.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentials.kt
@@ -1,5 +1,6 @@
 package com.theveloper.pixelplay.data.jellyfin.model
 
+import com.theveloper.pixelplay.data.stream.CloudStreamSecurity
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
@@ -57,15 +58,8 @@ data class JellyfinCredentials(
             val host = parsed.host
             val isPrivate = host == "localhost" ||
                     host == "127.0.0.1" ||
-                    host.startsWith("192.168.") ||
-                    host.startsWith("10.") ||
-                    host.startsWith("172.16.") ||
-                    host.startsWith("172.17.") ||
-                    host.startsWith("172.18.") ||
-                    host.startsWith("172.19.") ||
-                    host.startsWith("172.2") ||
-                    host.startsWith("172.3") ||
-                    host.endsWith(".local")
+                    host.endsWith(".local") ||
+                    CloudStreamSecurity.isPrivateIpv4Literal(host)
             if (!isPrivate) {
                 return "Use https:// for remote Jellyfin servers. HTTP is only allowed for local network addresses."
             }

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -2,6 +2,8 @@ package com.theveloper.pixelplay.data.navidrome
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
 import com.theveloper.pixelplay.data.database.MusicDao
@@ -54,7 +56,7 @@ class NavidromeRepository @Inject constructor(
         private const val PREFS_NAME = "navidrome_prefs"
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_USERNAME = "username"
-        private const val KEY_PASSWORD = "password" // Should be encrypted in production
+        private const val KEY_PASSWORD = "password"
 
         // ID offsets for unified library (following Netease: 3-5, QQ: 6-8)
         // Using negative offsets to prevent collisions with MediaStore IDs
@@ -67,7 +69,21 @@ class NavidromeRepository @Inject constructor(
         private const val LIBRARY_PLAYLIST_ID = "__library__"
     }
 
-    private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        Timber.e(e, "$TAG: Failed to create EncryptedSharedPreferences, falling back to plain")
+        context.getSharedPreferences("${PREFS_NAME}_plain", Context.MODE_PRIVATE)
+    }
 
     private val _isLoggedInFlow = MutableStateFlow(false)
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()

--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
@@ -2,6 +2,8 @@ package com.theveloper.pixelplay.data.netease
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
 import com.theveloper.pixelplay.data.database.MusicDao
@@ -56,8 +58,21 @@ class NeteaseRepository @Inject constructor(
         private const val NETEASE_MAX_PLAYLIST_PAGES = 200
     }
 
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("netease_prefs", Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            "netease_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        Timber.e(e, "NeteaseRepository: Failed to create EncryptedSharedPreferences, falling back to plain")
+        context.getSharedPreferences("netease_prefs_plain", Context.MODE_PRIVATE)
+    }
 
     private val _isLoggedInFlow = MutableStateFlow(false)
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()
@@ -74,7 +89,7 @@ class NeteaseRepository @Inject constructor(
         // Auto-load saved cookies on creation so API client is ready
         initFromSavedCookies()
         _isLoggedInFlow.value = api.hasLogin()
-        Timber.d("NeteaseRepository init: isLoggedIn=${api.hasLogin()}, userId=${prefs.getLong("netease_user_id", -1L)}")
+        Timber.d("NeteaseRepository init: isLoggedIn=${api.hasLogin()}")
     }
 
     // ─── Auth State ────────────────────────────────────────────────────
@@ -115,51 +130,40 @@ class NeteaseRepository @Inject constructor(
     suspend fun loginWithCookies(cookieJson: String): Result<String> {
         return withContext(Dispatchers.IO) {
             try {
-                Timber.d("loginWithCookies: starting, json length=${cookieJson.length}")
                 val cookies = jsonToMap(cookieJson)
-                Timber.d("loginWithCookies: parsed ${cookies.size} cookies, keys=${cookies.keys}")
-                
+
                 if (!cookies.containsKey("MUSIC_U")) {
-                    Timber.w("loginWithCookies: MUSIC_U not found in cookies!")
+                    Timber.w("loginWithCookies: required session cookie not found")
                     return@withContext Result.failure(Exception("MUSIC_U cookie not found"))
                 }
-                Timber.d("loginWithCookies: MUSIC_U found (${cookies["MUSIC_U"]?.take(20)}...)")
 
                 // Persist cookies
                 prefs.edit().putString("netease_cookies", cookieJson).apply()
-                Timber.d("loginWithCookies: cookies saved to prefs")
 
                 // Initialize API client with cookies
                 api.setPersistedCookies(cookies)
-                Timber.d("loginWithCookies: cookies set on API client, hasLogin=${api.hasLogin()}")
 
                 // Fetch user info
-                Timber.d("loginWithCookies: fetching user account info...")
                 val userAccountRaw = api.getCurrentUserAccount()
-                Timber.d("loginWithCookies: got response, length=${userAccountRaw.length}")
-                Timber.d("loginWithCookies: response preview: ${userAccountRaw.take(300)}")
-                
                 val root = JSONObject(userAccountRaw)
                 val code = root.optInt("code", -1)
-                Timber.d("loginWithCookies: response code=$code")
-                
                 val profile = root.optJSONObject("profile")
 
                 if (profile != null) {
                     val uid = profile.optLong("userId")
                     val nickname = profile.optString("nickname", "User")
                     val avatarUrl = profile.optString("avatarUrl", "")
-                    Timber.d("loginWithCookies: SUCCESS! userId=$uid, nickname=$nickname")
+                    Timber.d("loginWithCookies: login successful")
 
                     saveUserInfo(uid, nickname, avatarUrl)
                     _isLoggedInFlow.value = true
                     Result.success(nickname)
                 } else {
-                    Timber.w("loginWithCookies: No profile in response. Full response: ${userAccountRaw.take(500)}")
+                    Timber.w("loginWithCookies: No profile in response (code=$code)")
                     Result.failure(Exception("Failed to fetch user profile (code=$code)"))
                 }
             } catch (e: Exception) {
-                Timber.e(e, "loginWithCookies: FAILED with exception")
+                Timber.e(e, "loginWithCookies: failed")
                 Result.failure(e)
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/jellyfin/JellyfinApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/jellyfin/JellyfinApiService.kt
@@ -58,6 +58,8 @@ class JellyfinApiService @Inject constructor(
 
     fun getServerUrl(): String? = credentials?.normalizedServerUrl
 
+    fun getAuthorizationHeader(): String? = credentials?.let { buildAuthorizationHeader() }
+
     // ─── Authentication ─────────────────────────────────────────────────
 
     private fun buildAuthorizationHeader(): String {
@@ -330,7 +332,7 @@ class JellyfinApiService @Inject constructor(
     fun getImageUrl(itemId: String, imageType: String = "Primary", maxWidth: Int = 500): String {
         val cred = credentials ?: throw IllegalStateException("No credentials configured")
         return "${cred.normalizedServerUrl}/Items/$itemId/Images/$imageType" +
-                "?maxWidth=$maxWidth&quality=90&api_key=${cred.accessToken}"
+                "?maxWidth=$maxWidth&quality=90"
     }
 
     // ─── Lyrics API ──────────────────────────────────────────────────────

--- a/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/qqmusic/QqMusicRepository.kt
@@ -2,6 +2,8 @@ package com.theveloper.pixelplay.data.qqmusic
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import android.util.Base64
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
@@ -63,8 +65,21 @@ class QqMusicRepository @Inject constructor(
         val failedPlaylistCount: Int
     )
 
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("qqmusic_prefs", Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences = try {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            "qqmusic_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    } catch (e: Exception) {
+        Timber.e(e, "QqMusicRepository: Failed to create EncryptedSharedPreferences, falling back to plain")
+        context.getSharedPreferences("qqmusic_prefs_plain", Context.MODE_PRIVATE)
+    }
 
     private val _isLoggedInFlow = MutableStateFlow(false)
     val isLoggedInFlow: StateFlow<Boolean> = _isLoggedInFlow.asStateFlow()

--- a/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurity.kt
@@ -171,7 +171,7 @@ object CloudStreamSecurity {
         }
     }
 
-    private fun isPrivateIpv4Literal(host: String): Boolean {
+    internal fun isPrivateIpv4Literal(host: String): Boolean {
         val parts = host.split('.')
         if (parts.size != 4) return false
 

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Exclude all credential/token stores from backup (pre-API 31 devices) -->
+    <exclude domain="sharedpref" path="jellyfin_prefs.xml"/>
+    <exclude domain="sharedpref" path="navidrome_prefs.xml"/>
+    <exclude domain="sharedpref" path="netease_prefs.xml"/>
+    <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
+    <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Exclude all credential/token stores from cloud backup -->
+        <exclude domain="sharedpref" path="jellyfin_prefs.xml"/>
+        <exclude domain="sharedpref" path="navidrome_prefs.xml"/>
+        <exclude domain="sharedpref" path="netease_prefs.xml"/>
+        <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
+        <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <!-- Also exclude from device-to-device transfers — user must re-authenticate -->
+        <exclude domain="sharedpref" path="jellyfin_prefs.xml"/>
+        <exclude domain="sharedpref" path="navidrome_prefs.xml"/>
+        <exclude domain="sharedpref" path="netease_prefs.xml"/>
+        <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
+        <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ androidxTestCore = "1.6.1"
 junit5 = "5.10.1"
 kuromoji = "0.9.0"
 pinyin4j = "2.5.1"
+securityCrypto = "1.1.0-alpha06"
 
 # DI
 dagger = "2.53.1"
@@ -145,6 +146,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "roomRuntime" }
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 capturable = { module = "dev.shreyaspatil:capturable", version.ref = "capturable" }
 codeview = { module = "io.github.amrdeveloper:codeview", version.ref = "codeview" }


### PR DESCRIPTION
…ositories

### Security & Privacy
- **Encrypted Storage**: Migrated credential storage for Jellyfin, Navidrome, Netease, Google Drive, and QQ Music to `EncryptedSharedPreferences`. Implemented a fallback mechanism to plain `SharedPreferences` with a unique suffix if encryption initialization fails.
- **Backup & Transfer Restrictions**: Updated `backup_rules.xml` and `data_extraction_rules.xml` to explicitly exclude all provider-specific preference files from cloud backups and device-to-device transfers, ensuring users must re-authenticate on new devices.
- **Credential Handling**:
    - Refactored `JellyfinRepository` to stop persisting plain-text passwords, relying solely on access tokens for session persistence.
    - Updated `JellyfinApiService` to use the `Authorization` header for image requests instead of passing the API key as a query parameter.
- **Network Security**: Refactored private IP detection in `JellyfinCredentials` to use a centralized utility in `CloudStreamSecurity`, ensuring consistent enforcement of HTTPS for remote connections.

### Repository & API Improvements
- **Logging Reductions**: Stripped verbose debug logs containing sensitive session information (cookies, user IDs, and response previews) from `NeteaseRepository`.
- **Image Fetching**: Updated `JellyfinCoilFetcher` to include required authentication headers when downloading cover art.
- **Dependency Update**: Added `androidx.security:security-crypto` to manage encrypted preferences.

### Refactoring
- Promoted `isPrivateIpv4Literal` in `CloudStreamSecurity` to `internal` visibility to allow shared usage across data modules.
- Cleaned up redundant initialization logs and unused credential keys across various cloud provider repositories.