### PR TITLE
Refactor playback statistics logic, optimize database song queries, a…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -57,6 +57,16 @@ private const val SONG_DETAIL_PROJECTION = """
     songs.source_type AS source_type
 """
 
+// Projection for list queries: excludes lyrics to prevent CursorWindow overflow (2MB limit)
+// when loading large libraries. Lyrics are only needed for the Now Playing screen (getSongById).
+private const val SONG_LIST_PROJECTION = """
+    id, title, artist_name, artist_id, album_artist, album_name, album_id,
+    content_uri_string, album_art_uri_string, duration, genre, file_path,
+    parent_directory_path, is_favorite, NULL AS lyrics, track_number, disc_number,
+    year, date_added, mime_type, bitrate, sample_rate, telegram_chat_id,
+    telegram_file_id, artists_json, source_type
+"""
+
 @Dao
 interface MusicDao {
 
@@ -320,8 +330,8 @@ interface MusicDao {
 
     // --- Song Queries ---
     // Updated getSongs to include Telegram songs (negative IDs) regardless of directory filter
-    @Query("""
-        SELECT * FROM songs
+    @Query("SELECT " + SONG_LIST_PROJECTION + """
+        FROM songs
         WHERE (:applyDirectoryFilter = 0 OR id < 0 OR parent_directory_path IN (:allowedParentDirs))
         ORDER BY title ASC
     """)
@@ -330,7 +340,7 @@ interface MusicDao {
         applyDirectoryFilter: Boolean
     ): Flow<List<SongEntity>>
 
-    @Query("SELECT * FROM songs WHERE id IN (:songIds)")
+    @Query("SELECT " + SONG_LIST_PROJECTION + " FROM songs WHERE id IN (:songIds)")
     suspend fun getSongsByIdsListSimple(songIds: List<Long>): List<SongEntity>
 
     @Query(
@@ -361,9 +371,8 @@ interface MusicDao {
     )
     suspend fun getSongByPath(path: String): SongEntity?
 
-    //@Query("SELECT * FROM songs WHERE id IN (:songIds)")
-    @Query("""
-        SELECT * FROM songs
+    @Query("SELECT " + SONG_LIST_PROJECTION + """
+        FROM songs
         WHERE id IN (:songIds)
         AND (:applyDirectoryFilter = 0 OR id < 0 OR parent_directory_path IN (:allowedParentDirs))
     """)
@@ -1198,7 +1207,7 @@ interface MusicDao {
     @Query("UPDATE songs SET lyrics = NULL")
     suspend fun resetAllLyrics()
 
-    @Query("SELECT * FROM songs")
+    @Query("SELECT " + SONG_LIST_PROJECTION + " FROM songs")
     suspend fun getAllSongsList(): List<SongEntity>
 
     @Query("SELECT id, title, artist_name, album_name, duration FROM songs WHERE source_type = 0")

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -1463,7 +1463,7 @@ constructor(
 
     val folderBackGestureNavigationFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.FOLDER_BACK_GESTURE_NAVIGATION] ?: false
+            preferences[PreferencesKeys.FOLDER_BACK_GESTURE_NAVIGATION] ?: true
         }
 
     val useSmoothCornersFlow: Flow<Boolean> = dataStore.data
@@ -1538,11 +1538,11 @@ constructor(
 
     /**
      * Whether tapping the background area of the player sheet closes it.
-     * Default is true for intuitive dismissal, but power users may prefer to disable this.
+     * Default is false to avoid accidental dismissals while interacting with the full player.
      */
     val tapBackgroundClosesPlayerFlow: Flow<Boolean> =
         dataStore.data.map { preferences ->
-            preferences[PreferencesKeys.TAP_BACKGROUND_CLOSES_PLAYER] ?: true
+            preferences[PreferencesKeys.TAP_BACKGROUND_CLOSES_PLAYER] ?: false
         }
 
     suspend fun setTapBackgroundClosesPlayer(enabled: Boolean) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
@@ -210,19 +210,13 @@ class PlaybackStatsRepository @Inject constructor(
             val clippedStart = max(start, lowerBound)
             val clippedEnd = min(end, endBound)
             val clippedDuration = (clippedEnd - clippedStart).coerceAtLeast(0L)
-            val baseDuration = event.durationMs.coerceAtLeast(0L)
-            val effectiveDuration = when {
-                clippedDuration > 0L -> clippedDuration
-                baseDuration > 0L -> baseDuration
-                else -> 0L
-            }
-            if (effectiveDuration <= 0L) {
+            if (clippedDuration <= 0L) {
                 return@mapNotNull null
             }
 
             event.copy(
                 timestamp = clippedEnd,
-                durationMs = effectiveDuration,
+                durationMs = clippedDuration,
                 startTimestamp = clippedStart,
                 endTimestamp = clippedEnd
             )
@@ -1075,8 +1069,8 @@ class PlaybackStatsRepository @Inject constructor(
 
 enum class StatsTimeRange(val displayName: String) {
     DAY("Today"),
-    WEEK("This Week"),
-    MONTH("This Month"),
-    YEAR("This Year"),
+    WEEK("Week to Date"),
+    MONTH("Month to Date"),
+    YEAR("Year to Date"),
     ALL("All Time")
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerUiState.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerUiState.kt
@@ -49,7 +49,7 @@ data class PlayerUiState(
     val currentAlbumSortOption: SortOption = SortOption.AlbumTitleAZ,
     val currentArtistSortOption: SortOption = SortOption.ArtistNameAZ,
     val currentFolderSortOption: SortOption = SortOption.FolderNameAZ,
-    val folderBackGestureNavigationEnabled: Boolean = false,
+    val folderBackGestureNavigationEnabled: Boolean = true,
     val currentSongSortOption: SortOption = SortOption.SongTitleAZ,
     // val songCount: Int = 0, // REMOVED
     val isGeneratingAiMetadata: Boolean = false,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -496,7 +496,7 @@ class PlayerViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = true
+            initialValue = false
         )
 
     val hapticsEnabled: StateFlow<Boolean> = userPreferencesRepository.hapticsEnabledFlow
@@ -1187,7 +1187,7 @@ class PlayerViewModel @Inject constructor(
         val navBarStyle: String = NavBarStyle.DEFAULT,
         val carouselStyle: String = CarouselStyle.NO_PEEK,
         val fullPlayerLoadingTweaks: FullPlayerLoadingTweaks = FullPlayerLoadingTweaks(),
-        val tapBackgroundClosesPlayer: Boolean = true,
+        val tapBackgroundClosesPlayer: Boolean = false,
         val useSmoothCorners: Boolean = true,
         val playerThemePreference: String = ThemePreference.ALBUM_ART
     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SettingsViewModel.kt
@@ -67,7 +67,7 @@ data class SettingsUiState(
     val isCrossfadeEnabled: Boolean = false,
     val crossfadeDuration: Int = 2000,
     val persistentShuffleEnabled: Boolean = false,
-    val folderBackGestureNavigation: Boolean = false,
+    val folderBackGestureNavigation: Boolean = true,
     val lyricsSourcePreference: LyricsSourcePreference = LyricsSourcePreference.EMBEDDED_FIRST,
     val autoScanLrcFiles: Boolean = false,
     val blockedDirectories: Set<String> = emptySet(),
@@ -81,7 +81,7 @@ data class SettingsUiState(
     val usePlayerSheetV2: Boolean = true,
     // Developer Options
     val albumArtQuality: AlbumArtQuality = AlbumArtQuality.MEDIUM,
-    val tapBackgroundClosesPlayer: Boolean = true,
+    val tapBackgroundClosesPlayer: Boolean = false,
     val hapticsEnabled: Boolean = true,
     val immersiveLyricsEnabled: Boolean = false,
     val immersiveLyricsTimeout: Long = 4000L,

--- a/app/src/test/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepositoryTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepositoryTest.kt
@@ -1,0 +1,69 @@
+package com.theveloper.pixelplay.data.stats
+
+import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.Song
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.io.path.createTempDirectory
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class PlaybackStatsRepositoryTest {
+
+    @Test
+    fun `loadSummary excludes event that only touches the start boundary`() = runTest {
+        val repository = createRepository()
+        val zoneId = ZoneId.systemDefault()
+        val now = LocalDate.of(2026, 4, 10)
+            .atStartOfDay(zoneId)
+            .toInstant()
+            .toEpochMilli()
+
+        val boundaryTouchingEvent = PlaybackStatsRepository.PlaybackEvent(
+            songId = "song-1",
+            timestamp = now,
+            durationMs = 10_000L,
+            startTimestamp = now - 10_000L,
+            endTimestamp = now
+        )
+
+        repository.importEventsFromBackup(listOf(boundaryTouchingEvent))
+
+        val summary = repository.loadSummary(
+            range = StatsTimeRange.DAY,
+            songs = listOf(song("song-1")),
+            nowMillis = now
+        )
+
+        assertThat(summary.totalDurationMs).isEqualTo(0L)
+        assertThat(summary.totalPlayCount).isEqualTo(0)
+    }
+
+    private fun createRepository(): PlaybackStatsRepository {
+        val uniqueDir = createTempDirectory(
+            "playback-stats-test-${Instant.now().toEpochMilli()}-"
+        ).toFile()
+        val testContext = mockk<android.content.Context>(relaxed = true)
+        every { testContext.filesDir } returns uniqueDir
+        return PlaybackStatsRepository(testContext)
+    }
+
+    private fun song(songId: String): Song = Song(
+        id = songId,
+        title = "Song $songId",
+        artist = "Artist",
+        artistId = 1L,
+        album = "Album",
+        albumId = 1L,
+        path = "/music/$songId.mp3",
+        contentUriString = "content://media/external/audio/media/$songId",
+        albumArtUriString = null,
+        duration = 5 * 60 * 1000L,
+        mimeType = "audio/mpeg",
+        bitrate = 320_000,
+        sampleRate = 44_100
+    )
+}


### PR DESCRIPTION
…nd update default user preferences.

### Data & Statistics
- **Playback Stats Refinement**: Updated `PlaybackStatsRepository` to strictly use clipped duration for playback events, ensuring events that only touch boundary timeframes are excluded. Added unit tests for boundary case validation.
- **Stats UI**: Renamed `StatsTimeRange` display labels from "This [Period]" to "[Period] to Date" (e.g., "Month to Date") for better clarity.

### Database Optimization
- **Memory Management**: Introduced `SONG_LIST_PROJECTION` in `MusicDao` to exclude lyrics from bulk song queries. This prevents `CursorWindow` overflow errors (2MB limit) when loading large music libraries, while maintaining lyric access for the individual "Now Playing" view.

### User Preferences & UI
- **New Defaults**:
    - Changed `folderBackGestureNavigation` default to `true`.
    - Changed `tapBackgroundClosesPlayer` default to `false` to prevent accidental dismissals of the player sheet.
- **State Management**: Updated `SettingsViewModel`, `PlayerViewModel`, and `PlayerUiState` to reflect the new default preference values and ensure consistent initial states.