### PR TITLE
feat(ui): add marquee support for long song and album titles

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/EnhancedSongListItem.kt
@@ -342,7 +342,7 @@ fun EnhancedSongListItem(
                     modifier = Modifier
                         .weight(1f)
                 ) {
-                    if (applyTextMarquee && !isSelectionMode) {
+                    if (isHighlighted && !isSelectionMode) {
                         AutoScrollingTextOnDemand(
                             text = song.title,
                             style = MaterialTheme.typography.bodyLarge,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
@@ -53,6 +53,7 @@ import coil.request.ImageRequest
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Artist
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.presentation.components.AutoScrollingTextOnDemand
 import com.theveloper.pixelplay.presentation.components.ExpressiveTopBarContent
 import com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar
 import com.theveloper.pixelplay.presentation.components.GenreSortBottomSheet
@@ -791,13 +792,23 @@ fun GenreAlbumHeader(
             )
             Spacer(Modifier.width(16.dp))
             Column(Modifier.weight(1f)) {
-                Text(
-                    text = album.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    fontWeight = FontWeight.SemiBold
-                )
+                val shouldScroll = album.name.length > 20
+                if (shouldScroll) {
+                    AutoScrollingTextOnDemand(
+                        text = album.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        gradientEdgeColor = MaterialTheme.colorScheme.surface,
+                        expansionFractionProvider = { 1f },
+                    )
+                } else {
+                    Text(
+                        text = album.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
                 Text(
                     text = "${album.songs.size} songs",
                     style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
- Enable auto-scrolling for currently playing song title
- Add marquee for long album names to prevent truncation
- Keep ellipsis fallback for shorter text
- No changes to public API