### PR TITLE
improve(i18n): refine Spanish (es) translation and add Wear OS strings

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+﻿<resources>
     <string name="app_name">PixelPlayer</string>
     <string name="app_name_change_title">Cambio de nombre de la app</string>
     <string name="app_name_change_message">Hemos cambiado el nombre de nuestra app de PixelPlay a PixelPlayer debido a un problema de marca registrada. ¡Sigue reproduciendo!</string>
@@ -47,9 +47,10 @@
     <string name="reset_imported_lyrics">Restablecer letras importadas</string>
     <string name="lyrics_sync_offset">Ajuste de sincronización de letras</string>
     <string name="lyrics_sync_offset_format">%+.1fs</string>
+    <!-- "Adelantar" y "Retrasar" son más naturales en el contexto de sincronización de letras -->
     <string name="lyrics_sync_offset_reset">Restablecer</string>
-    <string name="lyrics_earlier">Más temprano</string>
-    <string name="lyrics_later">Más tarde</string>
+    <string name="lyrics_earlier">Adelantar</string>
+    <string name="lyrics_later">Retrasar</string>
 
     <!-- Sync/Progress strings -->
     <string name="sync_scanning">Escaneando archivos de música…</string>
@@ -82,12 +83,12 @@
     <!-- AI Playlist -->
     <string name="ai_error_api_key">Por favor, configura una clave de API válida para el proveedor de IA seleccionado en Ajustes.</string>
     <string name="ai_error_generic">Error de IA: %s</string>
-    <string name="ai_error_quota">El proveedor de IA rechazó la solicitud porque la cuenta no tiene créditos o cuota disponible.</string>
+    <string name="ai_error_quota">El proveedor de IA rechazó la solicitud porque la cuenta no tiene créditos ni cuota disponible.</string>
     <string name="ai_error_model_unavailable">El modelo de IA seleccionado ya no está disponible. PixelPlayer intentó cambiar automáticamente a un modelo compatible.</string>
-    <string name="ai_no_songs_found">IA no pudo encontrar canciones para tu indicación.</string>
+    <string name="ai_no_songs_found">La IA no pudo encontrar canciones para tu búsqueda.</string>
     <string name="ai_prompt_empty">Escribe una idea para tu Mix Diario</string>
     <string name="ai_daily_mix_updated">Mix Diario actualizado con IA</string>
-    <string name="ai_no_songs_for_mix">IA no pudo encontrar canciones para este mix</string>
+    <string name="ai_no_songs_for_mix">La IA no pudo encontrar canciones para este mix</string>
 
     <!-- Launcher Shortcuts -->
     <string name="shortcut_shuffle_short">Aleatorio</string>
@@ -96,24 +97,24 @@
     <string name="shortcut_playlist_long">Última lista reproducida</string>
 
     <!-- Quick Settings Tiles -->
-    <string name="tile_shuffle_all">Aleatorio todo</string>
+    <string name="tile_shuffle_all">Reproducción aleatoria</string>
     <string name="tile_last_playlist">Última lista</string>
-    <string name="tile_last_playlist_unavailable">No hay lista disponible para abrir</string>
+    <string name="tile_last_playlist_unavailable">No hay ninguna lista disponible para abrir</string>
 
     <!-- Errors -->
-    <string name="invalid_album_id">ID de álbum inválido</string>
+    <string name="invalid_album_id">ID de álbum no válido</string>
     <string name="album_id_not_found">ID de álbum no encontrado</string>
     <string name="error_loading_album">Error al cargar datos del álbum: %s</string>
     <string name="album_not_found">Álbum no encontrado</string>
     <string name="could_not_update">No se pudo actualizar: %s</string>
-    <string name="invalid_artist_id">ID de artista inválido</string>
+    <string name="invalid_artist_id">ID de artista no válido</string>
     <string name="artist_id_not_found">ID de artista no encontrado</string>
     <string name="error_loading_artist">Error al cargar datos del artista: %s</string>
     <string name="could_not_find_artist">No se pudo encontrar el artista</string>
     <string name="no_valid_songs">No se encontraron canciones válidas para reproducir</string>
 
     <!-- Widgets -->
-    <string name="glance_widget_description">Widget responsive que se adapta a su tamaño</string>
+    <string name="glance_widget_description">Widget adaptable que se ajusta a su tamaño</string>
     <string name="widget_bar_4x1_desc">Barra de reproductor compacta</string>
     <string name="widget_control_4x2_desc">Controles completos con aleatorio y repetición</string>
     <string name="widget_grid_2x2_desc">Reproductor cuadrado minimalista</string>

--- a/wear/src/main/res/values-es/strings.xml
+++ b/wear/src/main/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer</string>
+    <string name="not_playing">Sin reproducción</string>
+    <string name="open_on_phone">Abrir en el móvil</string>
+    <string name="connecting">Conectando…</string>
+    <string name="no_phone_connected">No hay móvil conectado</string>
+</resources>


### PR DESCRIPTION
## Summary

This PR improves the existing Spanish translation and adds missing Wear OS strings.

### Changes in `app/src/main/res/values-es/strings.xml`

- `lyrics_earlier` / `lyrics_later`: changed from "Más temprano / Más tarde" to **"Adelantar / Retrasar"** — more natural wording in a lyrics sync context
- `tile_shuffle_all`: "Aleatorio todo" → **"Reproducción aleatoria"** — grammatically correct
- `tile_last_playlist_unavailable`: rephrased for naturalness
- `invalid_album_id` / `invalid_artist_id`: "inválido" → **"no válido"** — preferred form in standard Spanish
- `ai_no_songs_found` / `ai_no_songs_for_mix`: added missing article ("La IA no pudo…")
- `ai_error_quota`: fixed conjunction in negative context ("o" → "ni")
- `glance_widget_description`: removed anglicism "responsive" → **"adaptable"**

### New file: `wear/src/main/res/values-es/strings.xml`

The Wear OS module had no Spanish translation at all. This adds all 5 strings:
- `not_playing`, `open_on_phone`, `connecting`, `no_phone_connected`, `app_name`

### Testing

Verified all string keys match the English base file exactly. No keys added or removed.