### PR TITLE
fix: Resolved an issue where the album image was flickering when cutting a song

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -54,6 +54,7 @@ import com.theveloper.pixelplay.data.model.SearchFilterType
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.model.SortOption
 import com.theveloper.pixelplay.data.model.toLibraryTabIdOrNull
+import com.theveloper.pixelplay.data.provider.SharedArtworkContentProvider
 import com.theveloper.pixelplay.data.preferences.CarouselStyle
 import com.theveloper.pixelplay.data.preferences.LibraryNavigationMode
 import com.theveloper.pixelplay.data.preferences.NavBarStyle
@@ -75,6 +76,7 @@ import com.theveloper.pixelplay.utils.AppShortcutManager
 import com.theveloper.pixelplay.utils.ValidatedLyricsImport
 import com.theveloper.pixelplay.utils.QueueUtils
 import com.theveloper.pixelplay.utils.MediaItemBuilder
+import com.theveloper.pixelplay.utils.LocalArtworkUri
 import com.theveloper.pixelplay.utils.LyricsUtils
 import com.theveloper.pixelplay.utils.StorageType
 import com.theveloper.pixelplay.utils.StorageUtils
@@ -4738,12 +4740,40 @@ class PlayerViewModel @Inject constructor(
 internal fun Song.withRepositoryHydration(repositorySong: Song): Song {
     if (id != repositorySong.id) return this
 
+    val hydratedArtworkUri = when {
+        repositorySong.albumArtUriString.isNullOrBlank() -> albumArtUriString
+        albumArtUriString.isNullOrBlank() -> repositorySong.albumArtUriString
+        areEquivalentArtworkUrisForSong(id, albumArtUriString, repositorySong.albumArtUriString) ->
+            albumArtUriString
+        else -> repositorySong.albumArtUriString
+    }
+
     return repositorySong.copy(
         contentUriString = repositorySong.contentUriString.ifBlank { contentUriString },
-        albumArtUriString = repositorySong.albumArtUriString ?: albumArtUriString,
+        albumArtUriString = hydratedArtworkUri,
         duration = repositorySong.duration.takeIf { it > 0L } ?: duration,
         lyrics = repositorySong.lyrics ?: lyrics
     )
+}
+
+internal fun areEquivalentArtworkUrisForSong(
+    songId: String,
+    firstUri: String?,
+    secondUri: String?
+): Boolean {
+    if (firstUri == secondUri) return true
+    if (firstUri.isNullOrBlank() || secondUri.isNullOrBlank()) return false
+
+    val targetSongId = songId.toLongOrNull() ?: return false
+
+    fun resolveUriSongId(uri: String): Long? {
+        return LocalArtworkUri.parseSongId(uri)
+            ?: SharedArtworkContentProvider.parseSongId(uri)
+    }
+
+    val firstSongId = resolveUriSongId(firstUri)
+    val secondSongId = resolveUriSongId(secondUri)
+    return firstSongId == targetSongId && secondSongId == targetSongId
 }
 
 internal fun Song.improvesLyricsLookupComparedTo(previousSong: Song): Boolean {


### PR DESCRIPTION
fix: Resolved an issue where the album image was flickering when cutting a song
 - Added 'areEquivalentArtworkUrisForSong' function. When backfilling the database data, determine whether the two URIs point to the same song

The URI retrieved from the database is different from the URI synchronized to the UI layer.
<img width="1590" height="867" alt="屏幕截图 2026-04-18 110537_1" src="https://github.com/user-attachments/assets/4c12c19a-94d6-4101-b49e-7c757f043c99" />
<img width="1247" height="812" alt="屏幕截图 2026-04-18 110701_1" src="https://github.com/user-attachments/assets/7f500042-e014-4e26-a879-cacd9dd6bd56" />

Before the modification, the album art would flash for a short period of time when switching songs.

https://github.com/user-attachments/assets/72f1056a-4dda-474c-8c71-c8574c515fe2

After the modification, the flickering issue disappeared.

https://github.com/user-attachments/assets/fc13b577-8d3f-46f0-b293-034b204500b1

