### PR TITLE
Implement reactive telegram topic updates

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/TelegramDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/TelegramDao.kt
@@ -70,6 +70,9 @@ interface TelegramDao {
     @Query("DELETE FROM telegram_topics WHERE chat_id = :chatId")
     suspend fun deleteTopicsByChannel(chatId: Long)
 
+    @Query("SELECT * FROM telegram_topics ORDER BY name ASC")
+    fun getAllTopics(): Flow<List<TelegramTopicEntity>>
+
     @Query("DELETE FROM telegram_topics WHERE id = :id")
     suspend fun deleteTopic(id: String)
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
@@ -326,6 +326,7 @@ interface MusicRepository {
     /** Replaces the full topic list for a channel, deleting any topics that no longer exist. */
     suspend fun replaceTopicsForChannel(chatId: Long, freshTopics: List<com.theveloper.pixelplay.data.database.TelegramTopicEntity>)
     suspend fun getTopicsForChannel(chatId: Long): List<com.theveloper.pixelplay.data.database.TelegramTopicEntity>
+    fun getAllTelegramTopics(): Flow<List<com.theveloper.pixelplay.data.database.TelegramTopicEntity>>
     suspend fun replaceTelegramSongsForTopic(chatId: Long, threadId: Long, topicName: String, songs: List<Song>)
 
     val telegramRepository: com.theveloper.pixelplay.data.telegram.TelegramRepository

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -1047,6 +1047,9 @@ class MusicRepositoryImpl @Inject constructor(
     override suspend fun getTopicsForChannel(chatId: Long): List<TelegramTopicEntity> {
         return telegramDao.getTopicsByChannelOnce(chatId)
     }
+    override fun getAllTelegramTopics(): Flow<List<TelegramTopicEntity>> {
+        return telegramDao.getAllTopics()
+    }
 
     override suspend fun replaceTelegramSongsForTopic(
         chatId: Long,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchViewModel.kt
@@ -14,6 +14,8 @@ import org.drinkless.tdlib.TdApi
 import javax.inject.Inject
 
 import com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
+import com.theveloper.pixelplay.data.database.TelegramChannelEntity
+import com.theveloper.pixelplay.data.database.TelegramTopicEntity
 
 @HiltViewModel
 class TelegramChannelSearchViewModel @Inject constructor(
@@ -91,39 +93,66 @@ class TelegramChannelSearchViewModel @Inject constructor(
         _statusMessage.value = "Syncing songs from channel..."
 
         viewModelScope.launch {
-            val fetchedSongs = telegramRepository.getAudioMessages(chatId)
+            try {
+                val isForum = telegramRepository.isForum(chatId)
+                val chat = _foundChat.value ?: return@launch
 
-            if (fetchedSongs.isNotEmpty()) {
-                musicRepository.replaceTelegramSongsForChannel(chatId, fetchedSongs)
+                val allSongs = telegramRepository.getAudioMessages(chatId)
+                musicRepository.replaceTelegramSongsForChannel(chatId, allSongs)
 
-                // Save Channel Entity
-                val chat = _foundChat.value
-                val currentQuery = _searchQuery.value
-                if (chat != null) {
-                    var localPhotoPath: String? = null
-                    val photoFileId = chat.photo?.small?.id
-                    if (photoFileId != null) {
-                        localPhotoPath = telegramRepository.downloadFileAwait(photoFileId)
-                    }
-
-                    val entity = com.theveloper.pixelplay.data.database.TelegramChannelEntity(
-                        chatId = chat.id,
-                        title = chat.title,
-                        username = _resolvedUsername.value,
-                        songCount = fetchedSongs.size,
-                        lastSyncTime = System.currentTimeMillis(),
-                        photoPath = localPhotoPath
-                    )
-                    musicRepository.saveTelegramChannel(entity)
+                var localPhotoPath: String? = null
+                val photoFileId = chat.photo?.small?.id
+                if (photoFileId != null) {
+                    localPhotoPath = telegramRepository.downloadFileAwait(photoFileId)
                 }
 
-                _statusMessage.value = "Success! ${fetchedSongs.size} songs added to library. You can close this window."
-            } else {
-                _statusMessage.value = "No audio songs found in this channel."
+                val baseEntity = TelegramChannelEntity(
+                    chatId = chat.id,
+                    title = chat.title,
+                    username = _resolvedUsername.value,
+                    songCount = allSongs.size,
+                    lastSyncTime = System.currentTimeMillis(),
+                    photoPath = localPhotoPath
+                )
+
+                // Always save base entity first for channel playlist
+                musicRepository.saveTelegramChannel(baseEntity)
+
+                if (isForum) {
+                    val topics = telegramRepository.getForumTopics(chatId)
+                    if (topics.isNotEmpty()) {
+                        musicRepository.replaceTopicsForChannel(chatId, topics)
+                        var totalSongs = 0
+                        topics.forEach { topic ->
+                            val topicSongs = telegramRepository.getAudioMessagesByTopic(chatId, topic.threadId)
+                            totalSongs += topicSongs.size
+                            musicRepository.replaceTelegramSongsForTopic(
+                                chatId = chatId,
+                                threadId = topic.threadId,
+                                topicName = topic.name,
+                                songs = topicSongs
+                            )
+                            musicRepository.saveTelegramTopics(chatId, listOf(
+                                topic.copy(
+                                    songCount = topicSongs.size,
+                                    lastSyncTime = System.currentTimeMillis()
+                                )
+                            ))
+                        }
+                        musicRepository.saveTelegramChannel(baseEntity.copy(songCount = totalSongs))
+                        _statusMessage.value = "Success! $totalSongs songs across ${topics.size} topics added. You can close this window."
+                    } else {
+                        _statusMessage.value = "Success! ${allSongs.size} songs added to library. You can close this window."
+                    }
+                } else {
+                    _statusMessage.value = "Success! ${allSongs.size} songs added to library. You can close this window."
+                }
+            } catch (e: Exception) {
+                _statusMessage.value = "Sync failed: ${e.message}"
+            } finally {
+                _songs.value = emptyList()
+                _isLoading.value = false
             }
-            // We do NOT update _songs to avoid showing the list
-            _songs.value = emptyList()
-            _isLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
@@ -131,12 +131,6 @@ fun TelegramDashboardScreen(
         }
     }
 
-    // Load cached topics for all channels on first composition
-    LaunchedEffect(channels) {
-        channels.forEach { channel ->
-            viewModel.loadTopicsForChannel(channel.chatId)
-        }
-    }
 
     if (!isOnline) {
         NoInternetScreen(onRetry = viewModel::refreshChannels)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -35,8 +36,9 @@ class TelegramDashboardViewModel @Inject constructor(
     val statusMessage = _statusMessage.asStateFlow()
 
     // Topics per channel: channelChatId -> list of topics
-    private val _topicsMap = MutableStateFlow<Map<Long, List<TelegramTopicEntity>>>(emptyMap())
-    val topicsMap = _topicsMap.asStateFlow()
+    val topicsMap = musicRepository.getAllTelegramTopics()
+        .map { topics -> topics.groupBy { it.chatId } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
 
     // Track which channels are expanded to show topics
     private val _expandedChannels = MutableStateFlow<Set<Long>>(emptySet())
@@ -95,16 +97,13 @@ class TelegramDashboardViewModel @Inject constructor(
         }
 
         // Replace topics in DB — this deletes any topics removed from Telegram
-        // and inserts the fresh list, so the dashboard stays in sync
+        // and inserts the fresh list. The reactive topicsMap flow will detect this.
         musicRepository.replaceTopicsForChannel(channel.chatId, topics)
-        _topicsMap.value = _topicsMap.value + (channel.chatId to topics)
         if (channel.chatId !in _expandedChannels.value) {
             _expandedChannels.value = _expandedChannels.value + channel.chatId
         }
 
         var totalSongs = 0
-        val updatedTopics = mutableListOf<TelegramTopicEntity>()
-
         topics.forEach { topic ->
             val topicSongs = telegramRepository.getAudioMessagesByTopic(channel.chatId, topic.threadId)
             totalSongs += topicSongs.size
@@ -122,12 +121,8 @@ class TelegramDashboardViewModel @Inject constructor(
                 songCount = topicSongs.size,
                 lastSyncTime = System.currentTimeMillis()
             )
-            updatedTopics.add(updatedTopic)
             musicRepository.saveTelegramTopics(channel.chatId, listOf(updatedTopic))
         }
-
-        // Refresh UI with final song counts across all topics
-        _topicsMap.value = _topicsMap.value + (channel.chatId to updatedTopics)
 
         // Update channel metadata (total across all topics)
         val updatedChannel = channel.copy(
@@ -137,16 +132,6 @@ class TelegramDashboardViewModel @Inject constructor(
         musicRepository.saveTelegramChannel(updatedChannel)
 
         _statusMessage.value = "Synced $totalSongs songs across ${topics.size} topics in ${channel.title}"
-    }
-
-    /** Load cached topics for a channel from DB (no network call). */
-    fun loadTopicsForChannel(chatId: Long) {
-        viewModelScope.launch {
-            val topics = musicRepository.getTopicsForChannel(chatId)
-            if (topics.isNotEmpty()) {
-                _topicsMap.value = _topicsMap.value + (chatId to topics)
-            }
-        }
     }
 
     fun removeChannel(chatId: Long) {


### PR DESCRIPTION
### Summary

- Implemented a database-driven reactive flow for Telegram topics, ensuring the UI stays in sync automatically with databases.
- Added `getAllTopics()` to `TelegramDao` and exposed it via `MusicRepository` to provide a real-time stream of all channel topics.
- Updated `TelegramDashboardViewModel` to derive its topic state from the database, eliminating the need for manual `loadTopicsForChannel` calls.
- Implement topics fetching for telegram forum to immediately add topics after adding channel in `TelegramChannelSearchViewModel`.