### PR TITLE
fix: harden backup rules, widget receiver exposure, and AI/QQ runtime safety

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -222,7 +222,7 @@
                 tools:node="remove" />
         </provider>
 
-        <receiver android:name=".ui.glancewidget.WidgetUpdateReceiver" android:exported="true">
+        <receiver android:name=".ui.glancewidget.WidgetUpdateReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="com.theveloper.pixelplay.ACTION_WIDGET_UPDATE_PLAYBACK_STATE" />
             </intent-filter>

--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/AiOrchestrator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/AiOrchestrator.kt
@@ -8,11 +8,12 @@ import com.theveloper.pixelplay.data.database.AiCacheEntity
 import com.theveloper.pixelplay.data.preferences.AiPreferencesRepository
 import com.theveloper.pixelplay.data.database.AiUsageDao
 import com.theveloper.pixelplay.data.database.AiUsageEntity
+import com.theveloper.pixelplay.di.AppScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withTimeout
+import timber.log.Timber
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,7 +24,8 @@ class AiOrchestrator @Inject constructor(
     private val clientFactory: AiClientFactory,
     private val cacheDao: AiCacheDao,
     private val usageDao: AiUsageDao,
-    private val promptEngine: AiSystemPromptEngine
+    private val promptEngine: AiSystemPromptEngine,
+    @AppScope private val appScope: CoroutineScope
 ) {
     // Cooldown timer: Provider -> Expiry Timestamp
     private val providerCooldowns = mutableMapOf<AiProvider, Long>()
@@ -219,18 +221,22 @@ class AiOrchestrator @Inject constructor(
                 val estimatedOutputTokens = response.length / 4
                 val estimatedThoughtTokens = if (isThinkingModel) (estimatedOutputTokens * 1.5).toInt() else 0
 
-                kotlinx.coroutines.GlobalScope.launch(kotlinx.coroutines.Dispatchers.IO) {
-                    usageDao.insertUsage(
-                        AiUsageEntity(
-                            timestamp = now,
-                            provider = provider.displayName,
-                            model = provider.name,
-                            promptType = type.name,
-                            promptTokens = estimatedPromptTokens,
-                            outputTokens = estimatedOutputTokens,
-                            thoughtTokens = estimatedThoughtTokens
+                appScope.launch {
+                    runCatching {
+                        usageDao.insertUsage(
+                            AiUsageEntity(
+                                timestamp = now,
+                                provider = provider.displayName,
+                                model = provider.name,
+                                promptType = type.name,
+                                promptTokens = estimatedPromptTokens,
+                                outputTokens = estimatedOutputTokens,
+                                thoughtTokens = estimatedThoughtTokens
+                            )
                         )
-                    )
+                    }.onFailure { error ->
+                        Timber.tag("AiOrchestrator").e(error, "Failed to persist AI usage")
+                    }
                 }
 
                 cacheDao.insert(AiCacheEntity(promptHash = hash, responseJson = response, timestamp = System.currentTimeMillis()))

--- a/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQSignGenerator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQSignGenerator.kt
@@ -1,10 +1,12 @@
 package com.theveloper.pixelplay.data.remote.qqmusic
 
 import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Base64
 import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import org.json.JSONArray
@@ -69,7 +71,20 @@ class QQSignGenerator(private val context: Context) {
                 val readyLatch = CountDownLatch(1)
                 readyLatchRef.set(readyLatch)
                 val instance = WebView(appContext).apply {
-                    settings.javaScriptEnabled = true
+                    settings.apply {
+                        javaScriptEnabled = true
+                        domStorageEnabled = true
+                        allowFileAccess = false
+                        allowContentAccess = false
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                            allowFileAccessFromFileURLs = false
+                            allowUniversalAccessFromFileURLs = false
+                        }
+                        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            safeBrowsingEnabled = true
+                        }
+                    }
                     webViewClient = object : WebViewClient() {
                         override fun onPageFinished(view: WebView?, url: String?) {
                             webViewReady = true

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -54,7 +54,9 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -101,6 +103,13 @@ object AppModule {
             ignoreUnknownKeys = true
             coerceInputValues = true
         }
+    }
+
+    @Singleton
+    @Provides
+    @AppScope
+    fun provideAppCoroutineScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 
     @Singleton

--- a/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt
@@ -22,3 +22,10 @@ annotation class FastOkHttpClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class BackupGson
+
+/**
+ * Qualifier for application-lifetime coroutine scope.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AppScope

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,4 +6,7 @@
     <exclude domain="sharedpref" path="netease_prefs.xml"/>
     <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
     <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
+
+    <!-- Exclude DataStore preferences that may contain API keys/sensitive settings -->
+    <exclude domain="file" path="datastore/settings.preferences_pb"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -7,6 +7,9 @@
         <exclude domain="sharedpref" path="netease_prefs.xml"/>
         <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
         <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
+
+        <!-- Exclude DataStore preferences that may contain API keys/sensitive settings -->
+        <exclude domain="file" path="datastore/settings.preferences_pb"/>
     </cloud-backup>
     <device-transfer>
         <!-- Also exclude from device-to-device transfers — user must re-authenticate -->
@@ -15,5 +18,8 @@
         <exclude domain="sharedpref" path="netease_prefs.xml"/>
         <exclude domain="sharedpref" path="gdrive_prefs.xml"/>
         <exclude domain="sharedpref" path="qqmusic_prefs.xml"/>
+
+        <!-- Keep device-to-device behavior aligned with cloud backup -->
+        <exclude domain="file" path="datastore/settings.preferences_pb"/>
     </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

This PR applies the first set of security/robustness hardening items from the PixelPlayer plan:

- Excludes DataStore `settings.preferences_pb` from backup/device-transfer rules
- Replaces `GlobalScope` usage in `AiOrchestrator` with an app-lifetime injected `CoroutineScope`
- Adds explicit error logging for async AI usage persistence failures
- Restricts `WidgetUpdateReceiver` to internal app use (`android:exported="false"`)
- Hardens `QQSignGenerator` WebView settings (mixed content, file/content access, safe browsing, etc.)

## Files changed

- `app/src/main/res/xml/backup_rules.xml`
- `app/src/main/res/xml/data_extraction_rules.xml`
- `app/src/main/java/com/theveloper/pixelplay/di/Qualifiers.kt`
- `app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt`
- `app/src/main/java/com/theveloper/pixelplay/data/ai/AiOrchestrator.kt`
- `app/src/main/AndroidManifest.xml`
- `app/src/main/java/com/theveloper/pixelplay/data/remote/qqmusic/QQSignGenerator.kt`

## Notes

- `preferencesDataStore` usage was searched across the project and only `settings` exists currently.
- Build/test execution is environment-limited in this workspace because Android SDK path is not configured (`local.properties` / `ANDROID_HOME`).

## Follow-up (not included in this PR)

- `SharedArtworkContentProvider` exported/access model validation with cross-UID regression testing
- P3 Room/AI data separation strategy
