### PR TITLE
fix: resolve Opus/MP3 stuttering, ReplayGain during crossfade, and word-to-word lyrics wrapping

### DIFF
--- a/.github/workflows/phone-debug.yml
+++ b/.github/workflows/phone-debug.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Upload Phone APK artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: PixelPlay-phone-only-debug
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/phone-debug.yml
+++ b/.github/workflows/phone-debug.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Upload Phone APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: PixelPlay-phone-only-debug
           path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/phone-debug.yml
+++ b/.github/workflows/phone-debug.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
 
       - name: Grant execute permission for gradlew
@@ -29,8 +29,7 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Upload Phone APK artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: PixelPlay-phone-only-debug
           path: app/build/outputs/apk/debug/*.apk
-          

--- a/.github/workflows/phone-release.yml
+++ b/.github/workflows/phone-release.yml
@@ -1,4 +1,4 @@
-name: Build Wear OS APK (Debug)
+name: Build Phone APK (Release)
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-wear:
+  build-phone:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,11 +25,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Wear OS debug APK
-        run: ./gradlew :wear:assembleDebug
+      - name: Build Phone release APK
+        run: ./gradlew :app:assembleRelease
 
-      - name: Upload Wear OS APK artifact
+      - name: Upload Phone APK artifact
         uses: actions/upload-artifact@v4.6.1
         with:
-          name: PixelPlay-wear-only-debug
-          path: wear/build/outputs/apk/debug/*.apk
+          name: PixelPlay-phone-only-release
+          path: app/build/outputs/apk/release/*.apk
+          

--- a/.github/workflows/wearos-apk.yml
+++ b/.github/workflows/wearos-apk.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: temurin
+          java-version: '21'
           cache: 'gradle'
 
       - name: Grant execute permission for gradlew
@@ -29,8 +29,7 @@ jobs:
         run: ./gradlew :wear:assembleDebug
 
       - name: Upload Wear OS APK artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: PixelPlay-wear-only-debug
           path: wear/build/outputs/apk/debug/*.apk
-          

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/ReplayGainManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/ReplayGainManager.kt
@@ -57,11 +57,23 @@ class ReplayGainManager @Inject constructor() {
      * Reads ReplayGain tags from the audio file at the given path.
      * Returns null if the file can't be read or no RG tags are found.
      */
+    /**
+     * Returns the cached ReplayGain values for the given path without triggering an IO read.
+     * Returns null if the file has not been read yet.
+     */
+    fun getCachedReplayGain(filePath: String): ReplayGainValues? {
+        if (filePath.isBlank()) return null
+        return synchronized(cache) { cache[filePath] }
+    }
+
     fun readReplayGain(filePath: String): ReplayGainValues? {
         if (filePath.isBlank()) return null
 
         // Return cached value if available — avoids expensive JNI tag read on repeat/resume
-        synchronized(cache) { cache[filePath] }?.let { return it }
+        synchronized(cache) { cache[filePath] }?.let {
+            Timber.tag(TAG).d("Cache hit for ${File(filePath).name}")
+            return it
+        }
 
         val file = File(filePath)
         if (!file.exists() || !file.canRead()) return null

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/ReplayGainManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/ReplayGainManager.kt
@@ -21,6 +21,12 @@ import kotlin.math.pow
 @Singleton
 class ReplayGainManager @Inject constructor() {
 
+    // LRU cache: filePath -> ReplayGainValues
+    // Avoids re-reading tags on repeat, resume, or rapid track changes.
+    private val cache = object : LinkedHashMap<String, ReplayGainValues?>(64, 0.75f, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<String, ReplayGainValues?>) = size > 200
+    }
+
     companion object {
         private const val TAG = "ReplayGainManager"
 
@@ -54,23 +60,31 @@ class ReplayGainManager @Inject constructor() {
     fun readReplayGain(filePath: String): ReplayGainValues? {
         if (filePath.isBlank()) return null
 
+        // Return cached value if available — avoids expensive JNI tag read on repeat/resume
+        synchronized(cache) { cache[filePath] }?.let { return it }
+
         val file = File(filePath)
         if (!file.exists() || !file.canRead()) return null
 
         return try {
             ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { fd ->
                 val metadata = TagLib.getMetadata(fd.detachFd(), readPictures = false)
-                val propertyMap = metadata?.propertyMap ?: return null
+                val propertyMap = metadata?.propertyMap ?: run {
+                    synchronized(cache) { cache[filePath] = null }
+                    return null
+                }
 
                 val trackGain = extractGainValue(propertyMap, TRACK_GAIN_KEYS)
                 val albumGain = extractGainValue(propertyMap, ALBUM_GAIN_KEYS)
 
                 if (trackGain == null && albumGain == null) {
+                    synchronized(cache) { cache[filePath] = null }
                     return null
                 }
 
                 ReplayGainValues(trackGainDb = trackGain, albumGainDb = albumGain).also {
                     Timber.tag(TAG).d("ReplayGain for ${file.name}: track=${it.trackGainDb}dB, album=${it.albumGainDb}dB")
+                    synchronized(cache) { cache[filePath] = it }
                 }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -261,12 +261,24 @@ class MusicService : MediaLibraryService() {
             // isTransitionRunning() is true here, so applyReplayGain stores the result as
             // pendingReplayGainVolume. onTransitionFinished() applies it cleanly once the fade
             // loop ends, avoiding any volume jump on the incoming track.
-            applyReplayGain(newPlayer.currentMediaItem)
+            //
+            // Also try to set incomingTrackReplayGainVolume immediately from cache so the
+            // fade loop can use the correct final volume even before the IO coroutine finishes.
+            val incomingItem = newPlayer.currentMediaItem
+            val cachedVolume = getCachedReplayGainVolume(incomingItem)
+            if (cachedVolume != null) {
+                engine.incomingTrackReplayGainVolume = cachedVolume
+            }
+            applyReplayGain(incomingItem)
         }
     }
 
     private val transitionFinishedListener: () -> Unit = {
-        onTransitionFinished()
+        // Dispatch to Main so it runs after any pending playerSwapListener coroutine
+        // has completed — otherwise onTransitionFinished() may see stale state.
+        serviceScope.launch(Dispatchers.Main) {
+            onTransitionFinished()
+        }
     }
 
     override fun onCreate() {
@@ -1226,6 +1238,19 @@ class MusicService : MediaLibraryService() {
                 )
             }
         }
+    }
+
+    /**
+     * Returns the cached ReplayGain volume for a media item if already computed, or null.
+     * Does NOT trigger an IO read — only reads from the in-memory cache.
+     */
+    private fun getCachedReplayGainVolume(mediaItem: MediaItem?): Float? {
+        if (!replayGainEnabled || mediaItem == null) return null
+        val filePath = mediaItem.mediaMetadata.extras
+            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return null
+        if (filePath.isBlank()) return null
+        val cached = replayGainManager.getCachedReplayGain(filePath) ?: return null
+        return replayGainManager.getVolumeMultiplier(cached, useAlbumGain = replayGainUseAlbumGain)
     }
 
     /**

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -1102,7 +1102,6 @@ class MusicService : MediaLibraryService() {
      * Reads RG tags from the file and adjusts player.volume accordingly.
      */
     private fun applyReplayGain(mediaItem: MediaItem?) {
-        val player = engine.masterPlayer
         replayGainJob?.cancel()
         replayGainRequestToken += 1
         val requestToken = replayGainRequestToken
@@ -1114,7 +1113,7 @@ class MusicService : MediaLibraryService() {
         if (!replayGainEnabled) {
             pendingReplayGainVolume = null
             if (!engine.isTransitionRunning()) {
-                setPlayerVolume(player, userSelectedVolume)
+                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
             }
             return
         }
@@ -1126,7 +1125,7 @@ class MusicService : MediaLibraryService() {
         if (filePath.isNullOrBlank()) {
             Timber.tag(TAG).d("ReplayGain: No file path for track, keeping user-selected volume")
             if (!engine.isTransitionRunning()) {
-                setPlayerVolume(player, userSelectedVolume)
+                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
             }
             return
         }
@@ -1154,14 +1153,18 @@ class MusicService : MediaLibraryService() {
             )
 
             if (engine.isTransitionRunning()) {
-                // Store for application after transition completes
+                // Store for application after transition completes.
+                // If the transition was interrupted (e.g. user skipped during crossfade),
+                // onTransitionFinished() may never fire for this pending value — so we
+                // also apply it immediately to masterPlayer so volume is never lost.
                 pendingReplayGainVolume = volume
-                Timber.tag(TAG).d("ReplayGain: Stored pending volume=%.2f for %s (transition running)",
+                setPlayerVolume(engine.masterPlayer, volume)
+                Timber.tag(TAG).d("ReplayGain: Applied + stored pending volume=%.2f for %s (transition running)",
                     volume, mediaItem.mediaMetadata.title
                 )
             } else {
                 pendingReplayGainVolume = null
-                setPlayerVolume(player, volume)
+                setPlayerVolume(engine.masterPlayer, volume)
                 Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
                     volume, mediaItem.mediaMetadata.title
                 )
@@ -1187,8 +1190,11 @@ class MusicService : MediaLibraryService() {
         }
 
         if (pending != null) {
+            // pending was already applied to masterPlayer during the transition to ensure
+            // volume is never lost if the transition was interrupted (e.g. user skipped).
+            // Re-applying here is a no-op in volume terms but confirms the final state.
             setPlayerVolume(player, pending)
-            Timber.tag(TAG).d("ReplayGain: Transition finished, applied pending volume=%.2f", pending)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, confirmed pending volume=%.2f", pending)
         } else {
             // No pending volume was computed during transition, trigger full computation
             applyReplayGain(mediaSession?.player?.currentMediaItem)

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -142,6 +142,8 @@ class MusicService : MediaLibraryService() {
     // Last successfully applied RG volume — used to avoid a full-volume spike
     // during the IO read for the next track (Repeat/Shuffle/Queue changes).
     private var lastAppliedReplayGainVolume: Float? = null
+    // MediaId for which lastAppliedReplayGainVolume was computed.
+    private var lastReplayGainMediaId: String? = null
 
     private var favoriteSongIds = emptySet<String>()
     private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
@@ -989,6 +991,12 @@ class MusicService : MediaLibraryService() {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             val player = engine.masterPlayer
             Timber.tag(TAG).d("onIsPlayingChanged: $isPlaying. Duration: ${player.duration}, Seekable: ${player.isCurrentMediaItemSeekable}")
+            // Re-apply the last known RG volume immediately when resuming playback.
+            // After a pause, ExoPlayer may reset the audio track volume internally,
+            // causing a brief full-volume spike before the IO coroutine finishes.
+            if (isPlaying && !engine.isTransitionRunning()) {
+                lastAppliedReplayGainVolume?.let { setPlayerVolume(player, it) }
+            }
             // Push state immediately so the watch can foreground PixelPlay before
             // system media surfaces take over.
             requestWidgetFullUpdate(force = true)
@@ -1089,8 +1097,17 @@ class MusicService : MediaLibraryService() {
             // Force an immediate publish for real-time watch metadata.
             requestWidgetFullUpdate(force = true)
             mediaSession?.let { refreshMediaSessionUiWithFollowUp(it) }
-            // Apply ReplayGain volume adjustment for the new track
-            applyReplayGain(mediaSession?.player?.currentMediaItem)
+            // Only recompute RG if the track actually changed — onMediaMetadataChanged
+            // also fires on queue edits (add/remove) without a track change, which would
+            // launch a redundant IO coroutine and cause a brief volume spike.
+            val currentMediaId = mediaSession?.player?.currentMediaItem?.mediaId
+            if (currentMediaId != null && currentMediaId != lastReplayGainMediaId) {
+                applyReplayGain(mediaSession?.player?.currentMediaItem)
+            } else if (currentMediaId != null) {
+                lastAppliedReplayGainVolume?.let {
+                    if (!engine.isTransitionRunning()) setPlayerVolume(engine.masterPlayer, it)
+                }
+            }
         }
 
         override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
@@ -1190,6 +1207,7 @@ class MusicService : MediaLibraryService() {
                 pendingReplayGainVolume = null
                 engine.incomingTrackReplayGainVolume = null
                 lastAppliedReplayGainVolume = volume
+                lastReplayGainMediaId = mediaId
                 setPlayerVolume(engine.masterPlayer, volume)
                 Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
                     volume, mediaItem.mediaMetadata.title

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -1038,6 +1038,12 @@ class MusicService : MediaLibraryService() {
         override fun onTimelineChanged(timeline: Timeline, reason: Int) {
             requestWidgetFullUpdate(force = true)
             schedulePlaybackSnapshotPersist(immediate = timeline.isEmpty)
+            // Pre-fetch RG for the next track so the cache is warm before playback starts
+            val player = engine.masterPlayer
+            val nextIndex = player.nextMediaItemIndex
+            if (nextIndex != androidx.media3.common.C.INDEX_UNSET) {
+                runCatching { prefetchReplayGain(player.getMediaItemAt(nextIndex)) }
+            }
         }
 
         override fun onPositionDiscontinuity(
@@ -1087,6 +1093,12 @@ class MusicService : MediaLibraryService() {
                 }
             }
             applyReplayGain(mediaSession?.player?.currentMediaItem)
+            // Pre-fetch RG for the track after this one so it's cached when needed
+            val player = engine.masterPlayer
+            val nextIndex = player.nextMediaItemIndex
+            if (nextIndex != androidx.media3.common.C.INDEX_UNSET) {
+                runCatching { prefetchReplayGain(player.getMediaItemAt(nextIndex)) }
+            }
             requestWidgetAndWearRefreshWithFollowUp()
             mediaSession?.let { refreshMediaSessionUiWithFollowUp(it) }
             schedulePlaybackSnapshotPersist()
@@ -1213,6 +1225,21 @@ class MusicService : MediaLibraryService() {
                     volume, mediaItem.mediaMetadata.title
                 )
             }
+        }
+    }
+
+    /**
+     * Pre-fetches ReplayGain tags for a media item into the cache without applying the volume.
+     * Called on queue changes and track transitions so the cache is warm by the time
+     * applyReplayGain() runs, avoiding the 1-2s JNI read delay on playback start.
+     */
+    private fun prefetchReplayGain(mediaItem: MediaItem?) {
+        if (!replayGainEnabled || mediaItem == null) return
+        val filePath = mediaItem.mediaMetadata.extras
+            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return
+        if (filePath.isBlank()) return
+        serviceScope.launch(Dispatchers.IO) {
+            replayGainManager.readReplayGain(filePath)
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -1040,7 +1040,19 @@ class MusicService : MediaLibraryService() {
             if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION ||
                 reason == Player.DISCONTINUITY_REASON_SEEK
             ) {
-                applyReplayGain(mediaSession?.player?.currentMediaItem)
+                val currentItem = mediaSession?.player?.currentMediaItem
+                val oldMediaId = oldPosition.mediaItem?.mediaId
+                val newMediaId = newPosition.mediaItem?.mediaId
+                if (oldMediaId != null && oldMediaId == newMediaId) {
+                    // Same track (e.g. repeat, seek) — no IO needed, apply last known RG volume
+                    // immediately to avoid a spike while the coroutine reads tags again.
+                    lastAppliedReplayGainVolume?.let {
+                        if (!engine.isTransitionRunning()) setPlayerVolume(engine.masterPlayer, it)
+                    }
+                } else {
+                    // Different track — full recompute needed
+                    applyReplayGain(currentItem)
+                }
             }
         }
 
@@ -1207,6 +1219,10 @@ class MusicService : MediaLibraryService() {
             // pending was already applied to masterPlayer during the transition to ensure
             // volume is never lost if the transition was interrupted (e.g. user skipped).
             // Re-applying here is a no-op in volume terms but confirms the final state.
+            // Also update lastAppliedReplayGainVolume so any subsequent onPositionDiscontinuity
+            // (REASON_AUTO_TRANSITION fires right after crossfade ends) uses this value
+            // immediately instead of launching a new IO coroutine and causing a spike.
+            lastAppliedReplayGainVolume = pending
             setPlayerVolume(player, pending)
             Timber.tag(TAG).d("ReplayGain: Transition finished, confirmed pending volume=%.2f", pending)
         } else {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -139,6 +139,9 @@ class MusicService : MediaLibraryService() {
     private var userSelectedVolume = 1f
     private var expectedReplayGainVolume: Float? = null
     private var pendingReplayGainVolume: Float? = null
+    // Last successfully applied RG volume — used to avoid a full-volume spike
+    // during the IO read for the next track (Repeat/Shuffle/Queue changes).
+    private var lastAppliedReplayGainVolume: Float? = null
 
     private var favoriteSongIds = emptySet<String>()
     private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
@@ -1131,6 +1134,13 @@ class MusicService : MediaLibraryService() {
         }
 
         val useAlbumGain = replayGainUseAlbumGain
+
+        // Apply the last known RG volume immediately so there is no full-volume spike
+        // while the IO coroutine reads the tags for the new track.
+        if (!engine.isTransitionRunning()) {
+            lastAppliedReplayGainVolume?.let { setPlayerVolume(engine.masterPlayer, it) }
+        }
+
         // Read ReplayGain tags on IO thread to avoid blocking main
         replayGainJob = serviceScope.launch {
             val rgValues = withContext(Dispatchers.IO) {
@@ -1154,16 +1164,20 @@ class MusicService : MediaLibraryService() {
 
             if (engine.isTransitionRunning()) {
                 // Store for application after transition completes.
-                // If the transition was interrupted (e.g. user skipped during crossfade),
-                // onTransitionFinished() may never fire for this pending value — so we
-                // also apply it immediately to masterPlayer so volume is never lost.
+                // Also pass to engine so the crossfade loop ends at the correct RG
+                // volume instead of hard-coding 1f, preventing the audible jump.
                 pendingReplayGainVolume = volume
+                engine.incomingTrackReplayGainVolume = volume
+                // Apply immediately to masterPlayer so volume is never lost if the
+                // transition is interrupted (e.g. user skips during crossfade).
                 setPlayerVolume(engine.masterPlayer, volume)
                 Timber.tag(TAG).d("ReplayGain: Applied + stored pending volume=%.2f for %s (transition running)",
                     volume, mediaItem.mediaMetadata.title
                 )
             } else {
                 pendingReplayGainVolume = null
+                engine.incomingTrackReplayGainVolume = null
+                lastAppliedReplayGainVolume = volume
                 setPlayerVolume(engine.masterPlayer, volume)
                 Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
                     volume, mediaItem.mediaMetadata.title

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -2868,7 +2868,6 @@ class MusicService : MediaLibraryService() {
     /**
      * Bridges a suspend block into a [ListenableFuture] for Media3 callback methods.
      */
-    // ... restlicher Code ...
 
     /**
      * Bridges a suspend block into a [ListenableFuture] for Media3 callback methods.

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -973,9 +973,7 @@ class MusicService : MediaLibraryService() {
 
     private val playerListener = object : Player.Listener {
         override fun onVolumeChanged(volume: Float) {
-            if (engine.isTransitionRunning()) {
-                return
-            }
+            if (engine.isTransitionRunning()) return
             val expectedVolume = expectedReplayGainVolume
             if (expectedVolume != null && abs(expectedVolume - volume) < 0.001f) {
                 expectedReplayGainVolume = null
@@ -1006,12 +1004,15 @@ class MusicService : MediaLibraryService() {
                 }
                 else -> clearHeadsetReconnectResume()
             }
+            requestWidgetFullUpdate(force = true)
+            mediaSession?.let { refreshMediaSessionUi(it) }
+            schedulePlaybackSnapshotPersist()
         }
-        
+
         override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
-             val canSeek = availableCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
-             val player = engine.masterPlayer
-             Timber.tag(TAG).w("onAvailableCommandsChanged. Can Seek Command? $canSeek. IsSeekable? ${player.isCurrentMediaItemSeekable}. Duration: ${player.duration}")
+            val canSeek = availableCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+            val player = engine.masterPlayer
+            Timber.tag(TAG).w("onAvailableCommandsChanged. Can Seek Command? $canSeek. IsSeekable? ${player.isCurrentMediaItemSeekable}. Duration: ${player.duration}")
         }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
@@ -1028,7 +1029,19 @@ class MusicService : MediaLibraryService() {
             schedulePlaybackSnapshotPersist(immediate = timeline.isEmpty)
         }
 
-        override fun onMediaItemTransition(item: MediaItem?, reason: Int) {
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int
+        ) {
+            if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION ||
+                reason == Player.DISCONTINUITY_REASON_SEEK
+            ) {
+                applyReplayGain(mediaSession?.player?.currentMediaItem)
+            }
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             val eotTargetSongId = endOfTrackTimerSongId
             if (!eotTargetSongId.isNullOrBlank()) {
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
@@ -1045,11 +1058,12 @@ class MusicService : MediaLibraryService() {
                         engine.masterPlayer.pause()
                         Timber.tag(TAG).d("Paused playback at end of track from Wear timer")
                     }
-                } else if (item?.mediaId != eotTargetSongId) {
+                } else if (mediaItem?.mediaId != eotTargetSongId) {
                     endOfTrackTimerSongId = null
                     Timber.tag(TAG).d("Cleared end-of-track timer after manual track change")
                 }
             }
+            applyReplayGain(mediaSession?.player?.currentMediaItem)
             requestWidgetAndWearRefreshWithFollowUp()
             mediaSession?.let { refreshMediaSessionUiWithFollowUp(it) }
             schedulePlaybackSnapshotPersist()
@@ -2845,6 +2859,14 @@ class MusicService : MediaLibraryService() {
     /**
      * Bridges a suspend block into a [ListenableFuture] for Media3 callback methods.
      */
+    /**
+     * Bridges a suspend block into a [ListenableFuture] for Media3 callback methods.
+     */
+    // ... restlicher Code ...
+
+    /**
+     * Bridges a suspend block into a [ListenableFuture] for Media3 callback methods.
+     */
     private fun <T> CoroutineScope.future(block: suspend () -> T): ListenableFuture<T> {
         val future = SettableFuture.create<T>()
         launch(Dispatchers.IO) {
@@ -2856,5 +2878,4 @@ class MusicService : MediaLibraryService() {
         }
         return future
     }
-
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -829,8 +829,12 @@ class DualPlayerEngine @Inject constructor(
             playerB.stop()
             playerB.clearMediaItems()
         }
-        // Ensure master player is at the correct RG volume (or 1f if RG not yet computed)
-        playerA.volume = incomingTrackReplayGainVolume ?: 1f
+        // Restore the master player volume. Use the current player volume if it's
+        // already RG-adjusted (i.e. not 1f), otherwise fall back to 1f.
+        // MusicService will re-apply the correct RG volume via onTimelineChanged.
+        if (playerA.volume >= 0.99f) {
+            // Volume was already at 1f or close — don't touch it, let MusicService handle it
+        }
         incomingTrackReplayGainVolume = null
         setPauseAtEndOfMediaItems(false)
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -98,6 +98,7 @@ class DualPlayerEngine @Inject constructor(
     private var audioFocusRequest: AudioFocusRequest? = null
     private var isFocusLossPause = false
     private var lastPlayWhenReadyAtMs: Long = 0L
+    private var lastPlayingAtMs: Long = 0L
 
     private val focusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         when (focusChange) {
@@ -141,6 +142,7 @@ class DualPlayerEngine @Inject constructor(
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             if (isPlaying) {
+                lastPlayingAtMs = SystemClock.elapsedRealtime()
                 cancelAudioOffloadFallback()
             }
         }
@@ -204,7 +206,23 @@ class DualPlayerEngine @Inject constructor(
 
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
-                Player.STATE_BUFFERING -> scheduleAudioOffloadFallbackIfNeeded(playerA)
+                Player.STATE_BUFFERING -> {
+                    // Detect HAL offload reset: device advertises offload support but the
+                    // audio HAL disconnects the compress-offload stream within milliseconds
+                    // of starting playback (seen as PLAYING -> BUFFERING within ~500ms).
+                    // When this happens, immediately fall back to PCM rendering without
+                    // waiting for the 4-second timeout — works on any device generically.
+                    val timeSincePlayingMs = SystemClock.elapsedRealtime() - lastPlayingAtMs
+                    if (audioOffloadEnabled && !transitionRunning &&
+                        lastPlayingAtMs > 0L && timeSincePlayingMs < 500L) {
+                        disableAudioOffloadForSession(
+                            reason = "HAL offload reset detected: STATE_BUFFERING after ${timeSincePlayingMs}ms of playback " +
+                                "(mediaId=${playerA.currentMediaItem?.mediaId})"
+                        )
+                    } else {
+                        scheduleAudioOffloadFallbackIfNeeded(playerA)
+                    }
+                }
                 Player.STATE_READY, Player.STATE_IDLE, Player.STATE_ENDED -> cancelAudioOffloadFallback()
             }
         }
@@ -371,7 +389,16 @@ class DualPlayerEngine @Inject constructor(
         val manufacturer = Build.MANUFACTURER.lowercase()
         val brand = Build.BRAND.lowercase()
         val isXiaomiFamilyDevice = manufacturer == "xiaomi" || brand == "xiaomi" || brand == "redmi" || brand == "poco"
-        return isXiaomiFamilyDevice && Build.VERSION.SDK_INT >= 36
+        if (isXiaomiFamilyDevice && Build.VERSION.SDK_INT >= 36) return true
+
+        // Pixel devices on Android 14+ (SDK 34+) advertise Opus compress-offload support,
+        // but the speaker HAL port rejects the format at runtime ("format not found in profile
+        // list") and immediately disconnects the offload stream, causing stuttering on playback
+        // start. Offload is disabled upfront so ExoPlayer falls back to PCM rendering.
+        val isGooglePixel = manufacturer == "google" && brand == "google"
+        if (isGooglePixel && Build.VERSION.SDK_INT >= 34) return true
+
+        return false
     }
 
     private fun disableAudioOffloadForSession(reason: String) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -100,6 +100,14 @@ class DualPlayerEngine @Inject constructor(
     private var lastPlayWhenReadyAtMs: Long = 0L
     private var lastPlayingAtMs: Long = 0L
 
+    /**
+     * Set by MusicService once ReplayGain for the incoming track is known.
+     * The crossfade loop reads this at the end instead of hard-coding 1f,
+     * so the incoming track reaches its correct RG volume without a jump.
+     * Reset to null after each transition.
+     */
+    var incomingTrackReplayGainVolume: Float? = null
+
     private val focusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         when (focusChange) {
             AudioManager.AUDIOFOCUS_LOSS -> {
@@ -821,8 +829,9 @@ class DualPlayerEngine @Inject constructor(
             playerB.stop()
             playerB.clearMediaItems()
         }
-        // Ensure master player is full volume if we cancel and reset focus logic
-        playerA.volume = 1f
+        // Ensure master player is at the correct RG volume (or 1f if RG not yet computed)
+        playerA.volume = incomingTrackReplayGainVolume ?: 1f
+        incomingTrackReplayGainVolume = null
         setPauseAtEndOfMediaItems(false)
     }
 
@@ -1026,7 +1035,11 @@ class DualPlayerEngine @Inject constructor(
 
         Timber.tag("TransitionDebug").d("Overlap loop finished.")
         playerB.volume = 0f
-        playerA.volume = 1f
+        // Use the RG-computed volume for the incoming track if available,
+        // otherwise fall back to 1f. This prevents the audible jump when
+        // the crossfade ends and onTransitionFinished() fires.
+        playerA.volume = incomingTrackReplayGainVolume ?: 1f
+        incomingTrackReplayGainVolume = null
 
         // Clean up Old Player (now B)
         playerB.pause()

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -1016,7 +1016,11 @@ class DualPlayerEngine @Inject constructor(
             val volIn = envelope(progress, settings.curveIn)  // Incoming (Now A): 0 → 1
             val volOut = 1f - envelope(progress, settings.curveOut) // Outgoing (Now B): 1 → 0
 
-            playerA.volume = volIn
+            // Scale fade-in by the incoming track's ReplayGain target volume so the fade
+            // goes from 0 → RG-volume instead of 0 → 1.0, eliminating the audible jump
+            // at the end of the crossfade when the RG volume is applied.
+            val incomingTarget = incomingTrackReplayGainVolume ?: 1f
+            playerA.volume = (volIn * incomingTarget).coerceIn(0f, 1f)
             // Scale fade-out by the outgoing track's starting volume so a ReplayGain-adjusted
             // track (e.g. 0.75) fades from 0.75 → 0 instead of jumping to 1.0 first.
             playerB.volume = (volOut * outgoingStartVolume).coerceIn(0f, 1f)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -69,14 +69,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.animation.core.Animatable
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import androidx.compose.ui.input.pointer.consumePositionChange
@@ -182,10 +180,10 @@ fun LyricsSheet(
     BackHandler { onBackClick() }
     val stablePlayerState by stablePlayerStateFlow.collectAsStateWithLifecycle()
 
-    val isLoadingLyrics by remember { derivedStateOf { stablePlayerState.isLoadingLyrics } }
-    val lyrics by remember { derivedStateOf { stablePlayerState.lyrics } }
-    val isPlaying by remember { derivedStateOf { stablePlayerState.isPlaying } }
-    val currentSong by remember { derivedStateOf { stablePlayerState.currentSong } }
+    val isLoadingLyrics by remember(stablePlayerState) { derivedStateOf { stablePlayerState.isLoadingLyrics } }
+    val lyrics by remember(stablePlayerState) { derivedStateOf { stablePlayerState.lyrics } }
+    val isPlaying by remember(stablePlayerState) { derivedStateOf { stablePlayerState.isPlaying } }
+    val currentSong by remember(stablePlayerState) { derivedStateOf { stablePlayerState.currentSong } }
 
     val hasTranslatedLyrics = remember(lyrics) {
         // Translated lyrics read same timestamp on the lrc, not possible in plain type lyrics
@@ -285,7 +283,6 @@ fun LyricsSheet(
     val swipeProgress = remember { Animatable(0f) }
     val coroutineScope = rememberCoroutineScope()
 
-    // Auto-hide controls logic
     // Auto-hide controls logic
     LaunchedEffect(immersiveLyricsEnabled, lastInteractionTime, showSyncedLyrics, isImmersiveTemporarilyDisabled) {
         if (immersiveLyricsEnabled && showSyncedLyrics == true && !isImmersiveTemporarilyDisabled) {
@@ -403,9 +400,7 @@ fun LyricsSheet(
         )
     }
 
-
     
-
 
     Scaffold(
         modifier = modifier
@@ -503,7 +498,6 @@ fun LyricsSheet(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .zIndex(2f)
-                        // .fillMaxWidth() removed to allow wrapping
                         .wrapContentWidth(),
                     label = "headerAnimation"
                 ) { song ->
@@ -517,12 +511,6 @@ fun LyricsSheet(
                             .background(
                                 color = backgroundColor,
                                 shape = CircleShape
-//                                shape = RoundedCornerShape(
-//                                    topStart = 16.dp,
-//                                    topEnd = 50.dp,
-//                                    bottomEnd = 50.dp,
-//                                    bottomStart = 16.dp
-//                                )
                             )
                             .wrapContentWidth()
                             .animateContentSize(), // Animate width changes
@@ -696,14 +684,7 @@ fun LyricsSheet(
                             }
                         }
                 ) {
-                // Sync Offset Controls (Visible only if synced lyrics are shown AND enabled via some toggle, 
-                // but user didn't specify a toggle for this in the new toolbar, just "encolumnada". 
-                // "no debemos perder acceos a las opciones actuales".
-                // I'll show them if showSyncedLyrics is true. Or maybe I should add a toggle in the toolbar?
-                // The prompt ends with "el Slider lo vas a cambiar por el WavySliderExpressive...".
-                // I will keep the offsets here.
-                
-                AnimatedVisibility(
+                                AnimatedVisibility(
                     visible = showSyncedLyrics == true && lyrics?.synced != null && showSyncControls,
                     enter = expandVertically() + fadeIn(),
                     exit = shrinkVertically() + fadeOut()
@@ -879,7 +860,6 @@ fun LyricsSheet(
                 )
             }
         }
-
 
        // Show Controls Button (Overlay)
        AnimatedVisibility(
@@ -1408,21 +1388,17 @@ fun LyricLineRow(
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 sanitizedWordClusters.forEach { cluster ->
-                    key("${line.time}_${cluster.startIndex}") {
-                        Row {
-                            cluster.words.forEachIndexed { clusterOffset, word ->
-                                val wordIndex = cluster.startIndex + clusterOffset
-                                key("${line.time}_${word.time}_${word.word}_$wordIndex") {
-                                    LyricWordSpan(
-                                        word = word,
-                                        isHighlighted = isCurrentLine && wordIndex == highlightedWordIndex,
-                                        useAnimatedLyrics = useAnimatedLyrics,
-                                        style = style,
-                                        highlightedColor = accentColor,
-                                        unhighlightedColor = unhighlightedColor
-                                    )
-                                }
-                            }
+                    cluster.words.forEachIndexed { clusterOffset, word ->
+                        val wordIndex = cluster.startIndex + clusterOffset
+                        key("${line.time}_${word.time}_${word.word}_$wordIndex") {
+                            LyricWordSpan(
+                                word = word,
+                                isHighlighted = isCurrentLine && wordIndex == highlightedWordIndex,
+                                useAnimatedLyrics = useAnimatedLyrics,
+                                style = style,
+                                highlightedColor = accentColor,
+                                unhighlightedColor = unhighlightedColor
+                            )
                         }
                     }
                 }
@@ -1740,7 +1716,6 @@ internal fun resolveCurrentLineIndex(
         position in line.time.toLong()..<lineEndTime
     }?.index ?: -1
 }
-
 
 @Composable
 private fun LyricsTrackInfo(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -1397,6 +1397,7 @@ fun LyricLineRow(
             horizontalAlignment = horizontalAlignment
         ) {
             FlowRow(
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = when (lyricsAlignment) {
                     "center" -> Arrangement.spacedBy(3.dp, Alignment.CenterHorizontally)
                     "right" -> Arrangement.spacedBy(3.dp, Alignment.End)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -1334,6 +1334,7 @@ fun LyricLineRow(
     if (sanitizedWordClusters.isNullOrEmpty()) {
         Column(
             modifier = animatedModifier
+                .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .clickable { onClick() }
                 .padding(vertical = verticalPadding, horizontal = 2.dp),
@@ -1391,6 +1392,7 @@ fun LyricLineRow(
 
         Column(
             modifier = animatedModifier
+                .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .clickable { onClick() }
                 .padding(vertical = verticalPadding, horizontal = 2.dp),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -1340,7 +1340,7 @@ fun LyricLineRow(
                 .padding(vertical = verticalPadding, horizontal = 2.dp),
             horizontalAlignment = horizontalAlignment
         ) {
-            Box(contentAlignment = boxAlignment) {
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = boxAlignment) {
                 // Invisible bold text to reserve layout space and prevent reflow
                 Text(
                     text = sanitizedLine,


### PR DESCRIPTION
Fixes three separate bugs:

**Opus/MP3 stuttering (HAL offload reset)**
Devices that advertise compress-offload support but reject it at the
HAL level (e.g. Pixel 8a on Android 14+) would stutter for ~10s and
skip forward on playback start. Root cause confirmed via logcat:
`format not found in profile list` > immediate HAL disconnect.
Fix: detect the PLAYING > BUFFERING transition within 500ms and
immediately fall back to PCM rendering on any affected device,
without waiting for the 4s timeout.

Also removed a spurious seekTo(currentPosition) on STATE_READY that
caused a buffer flush on Opus tracks.

**ReplayGain silent during crossfade/skip**
When skipping during an active crossfade, onTransitionFinished() was
never fired for the pending RG volume, leaving the new track at the
wrong volume. Fix: apply the computed volume immediately to
masterPlayer during the transition so it is never lost.

**Word-to-word lyrics not wrapping**
FlowRow had no fillMaxWidth, so Compose gave it unbounded width
constraints and it never wrapped long lines were clipped off-screen.