### PR TITLE
Fix buffer indicator: move buffering state to active Player.Listener …

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1502,8 +1502,7 @@ private fun SongMetadataDisplaySection(
         ) {
             Surface(
                 shape = CircleShape,
-                tonalElevation = 6.dp, 
-                color = LocalMaterialTheme.current.onPrimary,
+                color = chipColor,
                 modifier = Modifier.padding(end = 8.dp)
             ) {
                 Box(
@@ -1512,7 +1511,7 @@ private fun SongMetadataDisplaySection(
                 ) {
                     LoadingIndicator(
                         modifier = Modifier.size(28.dp),
-                        color = LocalMaterialTheme.current.primary
+                        color = chipContentColor
                     )
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1150,7 +1150,7 @@ class PlayerViewModel @Inject constructor(
     private val _isMediaControllerReady = MutableStateFlow(false)
     val isMediaControllerReady: StateFlow<Boolean> = _isMediaControllerReady.asStateFlow()
     // SessionToken injected via constructor
-    private val mediaControllerListener = object : MediaController.Listener, Player.Listener {
+    private val mediaControllerListener = object : MediaController.Listener {
         override fun onCustomCommand(
             controller: MediaController,
             command: SessionCommand,
@@ -1169,27 +1169,6 @@ class PlayerViewModel @Inject constructor(
                 return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
             }
             return Futures.immediateFuture(SessionResult(SessionError.ERROR_NOT_SUPPORTED))
-        }
-
-        override fun onPlaybackStateChanged(playbackState: Int) {
-            super.onPlaybackStateChanged(playbackState)
-            
-            // Debounce buffering state to avoid flickering
-            bufferingDebounceJob?.cancel()
-            
-            if (playbackState == Player.STATE_BUFFERING) {
-                bufferingDebounceJob = viewModelScope.launch {
-                    delay(150) // Wait 150ms before showing buffering indicator
-                    playbackStateHolder.updateStablePlayerState { state ->
-                        state.copy(isBuffering = true)
-                    }
-                }
-            } else {
-                // Immediately hide buffering when not buffering
-                playbackStateHolder.updateStablePlayerState { state ->
-                    state.copy(isBuffering = false)
-                }
-            }
         }
     }
     private val mediaControllerFuture: ListenableFuture<MediaController> =
@@ -2810,6 +2789,23 @@ class PlayerViewModel @Inject constructor(
             override fun onPlaybackStateChanged(playbackState: Int) {
                 if (isRemoteSessionControllingPlayback()) return
                 refreshPlaybackAudioMetadata(playerCtrl)
+
+                // Debounce buffering state to avoid flickering
+                bufferingDebounceJob?.cancel()
+                if (playbackState == Player.STATE_BUFFERING) {
+                    bufferingDebounceJob = viewModelScope.launch {
+                        delay(150) // Wait 150ms before showing buffering indicator
+                        playbackStateHolder.updateStablePlayerState { state ->
+                            state.copy(isBuffering = true)
+                        }
+                    }
+                } else {
+                    // Immediately hide buffering when not buffering
+                    playbackStateHolder.updateStablePlayerState { state ->
+                        state.copy(isBuffering = false)
+                    }
+                }
+
                 if (playbackState == Player.STATE_READY) {
                     clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
                     val readyPosition = playerCtrl.currentPosition.coerceAtLeast(0L)


### PR DESCRIPTION
The original buffer indicator commit (841ecafe) registered the buffering detection in mediaControllerListener and added addListener() to register it as a Player.Listener. A later refactoring removed the addListener() call, making the onPlaybackStateChanged buffering logic dead code.

This fix:
- Moves the buffering debounce logic to the active mediaControllerPlaybackListener (in setupMediaControllerListeners) where onPlaybackStateChanged is actually called
- Removes the dead Player.Listener interface and orphaned onPlaybackStateChanged from mediaControllerListener
- Fixes indicator colors from onPrimary/primary to chipColor/ chipContentColor to match the lyrics button and ensure visibility against the player background