### PR TITLE
fix: include navigation bar inset in genre screen FAB padding

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/GenreDetailScreen.kt
@@ -116,6 +116,7 @@ fun GenreDetailScreen(
     val lazyListState = rememberLazyListState()
 
     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val minTopBarHeight = 58.dp + statusBarHeight // Reduced by 6dp from 64.dp
     val maxTopBarHeight = 200.dp
     val minTopBarHeightPx = with(density) { minTopBarHeight.toPx() }
@@ -247,7 +248,7 @@ fun GenreDetailScreen(
     )
     val isMiniPlayerVisible = stablePlayerState.currentSong != null
     val fabBottomPadding by animateDpAsState(
-        targetValue = if (isMiniPlayerVisible) MiniPlayerHeight + 16.dp else 16.dp,
+        targetValue = if (isMiniPlayerVisible) MiniPlayerHeight + systemNavBarInset + 16.dp else systemNavBarInset + 16.dp,
         label = "fabPadding"
     )
 


### PR DESCRIPTION
Fixes #1889

## Problem
The sort/options FAB and the song list content in `GenreDetailScreen` were not accounting for the system navigation bar height. On devices using gesture navigation or 3-button nav, the FAB and list bottom edge overlap the navbar.

## Root Cause
`GenreDetailScreen` computed `fabBottomPadding` without a `WindowInsets.navigationBars` offset. Every other equivalent screen — `ArtistDetailScreen`, `StatsScreen`, `SettingsScreen`, `EqualizerScreen`, `PlaylistDetailScreen` — already includes this correctly.

## Fix
Added `systemNavBarInset` and folded it into `fabBottomPadding`, matching the pattern used by every other screen:

```kotlin
val systemNavBarInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
val fabBottomPadding by animateDpAsState(
    targetValue = if (isMiniPlayerVisible) MiniPlayerHeight + systemNavBarInset + 16.dp
                  else systemNavBarInset + 16.dp,
    label = "fabPadding"
)
```

Since `fabBottomPadding` drives both the FAB position and `LazyColumn` content padding, this 2-line change fixes the overlap for all elements simultaneously.

## Testing
- [ ] Gesture navigation — FAB sits above the gesture handle area
- [ ] 3-button nav bar — FAB clears the nav bar  
- [ ] Mini player visible — FAB stays above both mini player and nav bar
- [ ] No mini player — FAB correctly at nav bar height + 16dp