### PR TITLE
fix: snapshot lastModified before sort in TelegramCacheManager

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/telegram/TelegramCacheManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/telegram/TelegramCacheManager.kt
@@ -189,8 +189,13 @@ class TelegramCacheManager @Inject constructor(
                     return@launch // Within limits
                 }
                 
-                // Sort by last modified (oldest first) for LRU eviction
-                embeddedArtFiles.sortBy { it.lastModified() }
+                // Sort by last modified (oldest first) for LRU eviction.
+                // Snapshot timestamps before sorting — reading lastModified() inside the
+                // comparator on every pairwise call lets another coroutine's setLastModified()
+                // change the value mid-sort, violating TimSort's comparator contract and
+                // throwing "Comparison method violates its general contract!".
+                val snapshots = embeddedArtFiles.associateWith { it.lastModified() }
+                embeddedArtFiles.sortWith(compareBy { snapshots[it] })
                 
                 var deletedCount = 0
                 for (file in embeddedArtFiles) {


### PR DESCRIPTION
## Problem

`TelegramCacheManager.trimEmbeddedArtCache()` sorted embedded art files with:

```kotlin
embeddedArtFiles.sortBy { it.lastModified() }
```

`File.lastModified()` is called for every pairwise comparison during the sort. If a concurrent coroutine touches any of those files (e.g. a Telegram thumbnail download calling `setLastModified()`), the same file can return a different timestamp in a later comparison — breaking TimSort's transitivity requirement and crashing with:

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
    at java.util.TimSort.mergeLo
```

This is the same root cause as the crash reported in #1886 ("app crash when scanning .lrc"), which occurs during the broad sync sweep that runs album-art caching and Telegram operations in parallel.

## Fix

Snapshot all `lastModified()` timestamps into an immutable map **before** entering the sort, so the comparator always sees a stable value:

```kotlin
val snapshots = embeddedArtFiles.associateWith { it.lastModified() }
embeddedArtFiles.sortWith(compareBy { snapshots[it] })
```

This is exactly the pattern already applied to `AlbumArtCacheManager` (`snapshotFilesForCleanup`).

## Test plan
- [ ] Trigger a full library sync while Telegram channel is active — no `IllegalArgumentException` in logs
- [ ] Verify LRU eviction still deletes oldest embedded art files when cache exceeds limit

Closes #1886