### PR TITLE
Bump com.google.genai:google-genai from 1.52.0 to 1.53.0 in the gradle-dependencies group

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 accompanistDrawablepainter = "0.37.3"
 agp = "9.2.0"
 app = "1.7.0"
-googleGenai = "1.52.0"
+googleGenai = "1.53.0"
 googlePlayServicesCast = "22.3.1"
 animation = "1.11.0"
 appcompat = "1.7.1"


### PR DESCRIPTION
Update deps

---

> [!NOTE]
> I care about keeping a codebase up-to-date, because if not, it becomes incredibly hard to manage in the future.