### PR TITLE
feat: (Navidrome/OpenSubsonic) implement playbackReport and scrobble API

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -814,6 +814,40 @@ class NavidromeRepository @Inject constructor(
         }
     }
 
+    // ─── Playback Reporting ──────────────────────────────────────────────
+
+    suspend fun reportPlayback(
+        navidromeId: String,
+        positionMs: Long,
+        state: String,
+        playbackRate: Float = 1.0f,
+        ignoreScrobble: Boolean = false
+    ): Result<Unit> {
+        if (!isLoggedIn) return Result.failure(Exception("Not logged in"))
+        val result = api.reportPlayback(
+            mediaId = navidromeId,
+            positionMs = positionMs,
+            state = state,
+            playbackRate = playbackRate,
+            ignoreScrobble = ignoreScrobble
+        )
+        // Fallback to standard scrobble if reportPlayback is not supported.
+        // PS: The latest release of Navidrome currently doesn't support the
+        // standard OpenSubsonic API (reportPlayback) at the time of writing
+        // See: (https://github.com/navidrome/navidrome/pull/5442), so this is required.
+        if (result.isFailure && result.exceptionOrNull()?.message?.contains("404") == true) {
+            if (state == "playing" || state == "starting") {
+                return api.scrobble(id = navidromeId, submission = false)
+            }
+        }
+        return result
+    }
+
+    suspend fun scrobble(navidromeId: String, submission: Boolean = true): Result<Unit> {
+        if (!isLoggedIn) return Result.failure(Exception("Not logged in"))
+        return api.scrobble(id = navidromeId, submission = submission)
+    }
+
     // ─── Delete ────────────────────────────────────────────────────────────
 
     suspend fun deletePlaylist(playlistId: String) {
@@ -848,6 +882,7 @@ fun NavidromeSong.toSong(): Song {
         year = year,
         trackNumber = trackNumber,
         dateAdded = System.currentTimeMillis(),
-        isFavorite = false
+        isFavorite = false,
+        navidromeId = id
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/network/navidrome/NavidromeApiService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/navidrome/NavidromeApiService.kt
@@ -494,6 +494,52 @@ class NavidromeApiService @Inject constructor(
         }
     }
 
+    // ─── Playback API ────────────────────────────────────────────────────
+
+    /**
+     * Reports playback timeline state for a song.
+     * OpenSubsonic extension: playbackReport
+     */
+    suspend fun reportPlayback(
+        mediaId: String,
+        mediaType: String = "song",
+        positionMs: Long,
+        state: String,
+        playbackRate: Float = 1.0f,
+        ignoreScrobble: Boolean = false
+    ): Result<Unit> {
+        val params = mutableMapOf<String, String>()
+        params["mediaId"] = mediaId
+        params["mediaType"] = mediaType
+        params["positionMs"] = positionMs.toString()
+        params["state"] = state
+        params["playbackRate"] = playbackRate.toString()
+        params["ignoreScrobble"] = ignoreScrobble.toString()
+        return requestAndParse("reportPlayback", params).map { Unit }
+    }
+
+    /**
+     * Standard Subsonic scrobble API.
+     * Used as fallback for now playing and marking as played.
+     */
+    suspend fun scrobble(id: String, submission: Boolean = true): Result<Unit> {
+        val params = mutableMapOf<String, String>()
+        params["id"] = id
+        params["submission"] = submission.toString()
+        
+        Timber.d("$TAG: Calling scrobble API: id=$id, submission=$submission")
+        return requestAndParse("scrobble", params).fold(
+            onSuccess = {
+                Timber.d("$TAG: scrobble API success")
+                Result.success(Unit)
+            },
+            onFailure = {
+                Timber.e(it, "$TAG: scrobble API failed")
+                Result.failure(it)
+            }
+        )
+    }
+
     // ─── Star/Favorite API ───────────────────────────────────────────────
 
     /**

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -92,6 +92,8 @@ import com.theveloper.pixelplay.presentation.viewmodel.ColorSchemePair
 import com.theveloper.pixelplay.shared.WearIntents
 import com.theveloper.pixelplay.utils.ArtworkTransportSanitizer
 import com.theveloper.pixelplay.utils.MediaItemBuilder
+import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
+import com.theveloper.pixelplay.di.AppScope
 import kotlin.math.abs
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
@@ -134,6 +136,11 @@ class MusicService : MediaLibraryService() {
     lateinit var wearStatePublisher: WearStatePublisher
     @Inject
     lateinit var replayGainManager: com.theveloper.pixelplay.data.media.ReplayGainManager
+    @Inject
+    lateinit var navidromeRepository: NavidromeRepository
+    @Inject
+    @AppScope
+    lateinit var appScope: CoroutineScope
 
     private var replayGainEnabled = false
     private var replayGainUseAlbumGain = false
@@ -1002,6 +1009,59 @@ class MusicService : MediaLibraryService() {
         return startCommandResult
     }
 
+    private fun getNavidromeId(mediaItem: MediaItem?): String? {
+        if (mediaItem == null) return null
+        return mediaItem.mediaMetadata.extras?.getString(MediaItemBuilder.EXTERNAL_EXTRA_NAVIDROME_ID)
+            ?: mediaItem.mediaId.let { if (it.startsWith("navidrome_")) it.substringAfter("navidrome_") else null }
+            ?: mediaItem.mediaMetadata.extras?.getString(MediaItemBuilder.EXTERNAL_EXTRA_CONTENT_URI)?.let {
+                if (it.startsWith("navidrome://")) it.substringAfter("navidrome://") else null
+            }
+    }
+
+    private fun isNavidromeMediaItem(mediaItem: MediaItem?): Boolean {
+        return getNavidromeId(mediaItem) != null
+    }
+
+    private fun reportNavidromePlayback(state: String) {
+        val player = engine.masterPlayer
+        // Ensure we capture player state on main thread to avoid IllegalStateException
+        val mediaItem = player.currentMediaItem ?: return
+        val navidromeId = getNavidromeId(mediaItem) ?: return
+
+        val positionMs = player.currentPosition
+        val playbackRate = player.playbackParameters.speed
+
+        // Use appScope for the network call so it survives if serviceScope is cancelled
+        appScope.launch(Dispatchers.IO) {
+            navidromeRepository.reportPlayback(
+                navidromeId = navidromeId,
+                positionMs = positionMs,
+                state = state,
+                playbackRate = playbackRate
+            )
+        }
+    }
+
+    private var navidromePlaybackReportJob: Job? = null
+
+    private fun startNavidromePlaybackReporting() {
+        navidromePlaybackReportJob?.cancel()
+        navidromePlaybackReportJob = serviceScope.launch {
+            while (true) {
+                delay(30_000) // Report every 30 seconds
+                val player = engine.masterPlayer
+                if (player.isPlaying && isNavidromeMediaItem(player.currentMediaItem)) {
+                    reportNavidromePlayback("playing")
+                }
+            }
+        }
+    }
+
+    private fun stopNavidromePlaybackReporting() {
+        navidromePlaybackReportJob?.cancel()
+        navidromePlaybackReportJob = null
+    }
+
     private val playerListener = object : Player.Listener {
         override fun onVolumeChanged(volume: Float) {
             if (engine.isTransitionRunning()) return
@@ -1017,6 +1077,16 @@ class MusicService : MediaLibraryService() {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             val player = engine.masterPlayer
             Timber.tag(TAG).d("onIsPlayingChanged: $isPlaying. Duration: ${player.duration}, Seekable: ${player.isCurrentMediaItemSeekable}")
+            
+            if (isPlaying) {
+                reportNavidromePlayback("playing")
+                startNavidromePlaybackReporting()
+            } else {
+                val state = if (player.playbackState == Player.STATE_ENDED) "stopped" else "paused"
+                reportNavidromePlayback(state)
+                stopNavidromePlaybackReporting()
+            }
+
             // Re-apply the last known RG volume immediately when resuming playback.
             // After a pause, ExoPlayer may reset the audio track volume internally,
             // causing a brief full-volume spike before the IO coroutine finishes.
@@ -1055,7 +1125,16 @@ class MusicService : MediaLibraryService() {
         override fun onPlaybackStateChanged(playbackState: Int) {
             Timber.tag(TAG).d("Playback state changed: $playbackState")
             if (playbackState == Player.STATE_ENDED) {
+                val mediaItem = engine.masterPlayer.currentMediaItem
+                getNavidromeId(mediaItem)?.let { navidromeId ->
+                    appScope.launch(Dispatchers.IO) {
+                        navidromeRepository.scrobble(navidromeId, submission = true)
+                    }
+                }
+
                 endOfTrackTimerSongId = null
+                reportNavidromePlayback("stopped")
+                stopNavidromePlaybackReporting()
             }
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist(immediate = playbackState == Player.STATE_IDLE)
@@ -1077,6 +1156,10 @@ class MusicService : MediaLibraryService() {
             newPosition: Player.PositionInfo,
             reason: Int
         ) {
+            if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+                val state = if (engine.masterPlayer.isPlaying) "playing" else "paused"
+                reportNavidromePlayback(state)
+            }
             if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION ||
                 reason == Player.DISCONTINUITY_REASON_SEEK
             ) {
@@ -1097,6 +1180,15 @@ class MusicService : MediaLibraryService() {
         }
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            if (isNavidromeMediaItem(mediaItem)) {
+                reportNavidromePlayback("starting")
+                if (engine.masterPlayer.isPlaying) {
+                    startNavidromePlaybackReporting()
+                }
+            } else {
+                stopNavidromePlaybackReporting()
+            }
+
             val eotTargetSongId = endOfTrackTimerSongId
             if (!eotTargetSongId.isNullOrBlank()) {
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
@@ -1443,6 +1535,8 @@ class MusicService : MediaLibraryService() {
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaSession
 
     override fun onDestroy() {
+        reportNavidromePlayback("stopped")
+        stopNavidromePlaybackReporting()
         playbackSnapshotPersistJob?.cancel()
         mediaSessionButtonRefreshJob?.cancel()
         followUpMediaSessionUiRefreshJob?.cancel()

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
@@ -92,6 +92,7 @@ object MediaItemBuilder {
     const val EXTERNAL_EXTRA_BITRATE = EXTERNAL_EXTRA_PREFIX + "BITRATE"
     const val EXTERNAL_EXTRA_SAMPLE_RATE = EXTERNAL_EXTRA_PREFIX + "SAMPLE_RATE"
     const val EXTERNAL_EXTRA_FILE_PATH = EXTERNAL_EXTRA_PREFIX + "FILE_PATH"
+    const val EXTERNAL_EXTRA_NAVIDROME_ID = EXTERNAL_EXTRA_PREFIX + "NAVIDROME_ID"
 
     fun build(song: Song): MediaItem {
         return MediaItem.Builder()
@@ -287,6 +288,7 @@ object MediaItemBuilder {
             putInt(EXTERNAL_EXTRA_BITRATE, song.bitrate ?: 0)
             putInt(EXTERNAL_EXTRA_SAMPLE_RATE, song.sampleRate ?: 0)
             putString(EXTERNAL_EXTRA_FILE_PATH, song.path)
+            song.navidromeId?.let { putString(EXTERNAL_EXTRA_NAVIDROME_ID, it) }
         }
 
         metadataBuilder.setExtras(extras)


### PR DESCRIPTION
This partly fixes #1890 and implements both [`reportPlayback`](https://opensubsonic.netlify.app/docs/endpoints/reportplayback/) and [`scrobble`](https://opensubsonic.netlify.app/docs/endpoints/scrobble/) according to the Opensubsonic spec.

Normally, we don’t need the `scrobble` API when using `reportPlayback`, as the server should automatically handle scrobbling based on the received data. However, since the latest release of Navidrome does not yet support `reportPlayback` API as it was only recently implemented (see: https://github.com/navidrome/navidrome/pull/5442), So we need the `scrobble` API as a fallback. Therefore, i have added both of them.

Tested on my Navidrome server (v0.61.2) with Last.fm scrobbling enabled. The server can now detect which song is being played, increment the play count, and also perform scrobbling to third party extensions such as Last.fm and ListenBrainz.