### PR TITLE
Preserve artist image metadata during database updates

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -1554,9 +1554,9 @@ constructor(
             preferences[PreferencesKeys.ALBUM_ART_QUALITY]
                 ?.let {
                     try { AlbumArtQuality.valueOf(it) }
-                    catch (e: Exception) { AlbumArtQuality.ORIGINAL }
+                    catch (e: Exception) { AlbumArtQuality.MEDIUM }
                 }
-                ?: AlbumArtQuality.ORIGINAL
+                ?: AlbumArtQuality.MEDIUM
         }
 
     suspend fun setAlbumArtQuality(quality: AlbumArtQuality) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
@@ -66,7 +66,7 @@ fun AlbumCarouselSection(
 
     // Calculate target size based on quality
     val targetSize = remember(albumArtQuality) {
-        if (albumArtQuality.maxSize == 0) Size.ORIGINAL
+        if (albumArtQuality.maxSize == 0) SafeOriginalAlbumArtSize
         else Size(albumArtQuality.maxSize, albumArtQuality.maxSize)
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArt.kt
@@ -35,16 +35,22 @@ import coil.size.Size
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.utils.LocalArtworkUri
 
+internal const val MaxSafeAlbumArtDimensionPx = 2048
+internal val SafeOriginalAlbumArtSize = Size(MaxSafeAlbumArtDimensionPx, MaxSafeAlbumArtDimensionPx)
+
 @OptIn(ExperimentalCoilApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun OptimizedAlbumArt(
     uri: Any?,
     title: String,
     modifier: Modifier = Modifier,
-    targetSize: Size = Size.ORIGINAL,
+    targetSize: Size = SafeOriginalAlbumArtSize,
     placeholderModel: Any? = null
 ) {
     val context = LocalContext.current
+    val requestTargetSize = remember(targetSize) {
+        safeAlbumArtTargetSize(targetSize)
+    }
     val isStableLocalArtwork = remember(uri) {
         when (uri) {
             is String -> LocalArtworkUri.isLocalArtworkUri(uri)
@@ -67,8 +73,8 @@ fun OptimizedAlbumArt(
         return
     }
 
-    val memoryCacheKey = remember(uri, targetSize) {
-        albumArtMemoryCacheKey(uri, targetSize)
+    val memoryCacheKey = remember(uri, requestTargetSize) {
+        albumArtMemoryCacheKey(uri, requestTargetSize)
     }
     val placeholderMemoryCacheKey = remember(memoryCacheKey, uri) {
         when (uri) {
@@ -78,9 +84,10 @@ fun OptimizedAlbumArt(
             else -> memoryCacheKey?.let { MemoryCache.Key(it) }
         }
     }
-    val requestModel = remember(context, uri, targetSize) {
+    val requestModel = remember(context, uri, requestTargetSize) {
         when (uri) {
             is ImageRequest -> uri.newBuilder(context).apply {
+                size(requestTargetSize)
                 if (uri.memoryCacheKey == null) {
                     memoryCacheKey(memoryCacheKey)
                 }
@@ -90,7 +97,7 @@ fun OptimizedAlbumArt(
                 .data(uri)
                 .crossfade(350) // Use Coil's native crossfade
                 .error(R.drawable.ic_music_placeholder)
-                .size(targetSize)
+                .size(requestTargetSize)
                 .memoryCachePolicy(CachePolicy.ENABLED)
                 .diskCachePolicy(if (isStableLocalArtwork) CachePolicy.DISABLED else CachePolicy.ENABLED)
                 .apply {
@@ -212,6 +219,14 @@ private fun renderDirectAlbumArt(
             true
         }
         else -> false
+    }
+}
+
+internal fun safeAlbumArtTargetSize(targetSize: Size): Size {
+    return if (targetSize == Size.ORIGINAL) {
+        SafeOriginalAlbumArtSize
+    } else {
+        targetSize
     }
 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SmartImage.kt
@@ -64,6 +64,9 @@ fun SmartImage(
 ) {
     val context = LocalContext.current
     val clippedModifier = modifier.clip(shape)
+    val requestTargetSize = remember(targetSize) {
+        safeAlbumArtTargetSize(targetSize)
+    }
 
     // Handle direct models (Bitmap, Vector, etc) early to avoid ImageRequest overhead
     if (model == null || model is ImageVector || model is Painter || model is ImageBitmap || model is Bitmap) {
@@ -96,10 +99,12 @@ fun SmartImage(
         useDiskCache,
         useMemoryCache,
         allowHardware,
-        targetSize
+        requestTargetSize
     ) {
         if (model is ImageRequest) {
-            model
+            model.newBuilder(context)
+                .size(requestTargetSize)
+                .build()
         } else {
             ImageRequest.Builder(context)
                 .data(model)
@@ -107,7 +112,7 @@ fun SmartImage(
                 .diskCachePolicy(if (useDiskCache) CachePolicy.ENABLED else CachePolicy.DISABLED)
                 .memoryCachePolicy(if (useMemoryCache) CachePolicy.ENABLED else CachePolicy.DISABLED)
                 .allowHardware(allowHardware)
-                .size(targetSize)
+                .size(requestTargetSize)
                 .build()
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/external/ExternalPlayerOverlay.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/external/ExternalPlayerOverlay.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.util.UnstableApi
+import coil.size.Size
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.presentation.components.OptimizedAlbumArt
 import com.theveloper.pixelplay.presentation.components.WavyMusicSlider
@@ -221,7 +222,8 @@ fun ExternalPlayerOverlay(
                                     title = currentSong.title,
                                     modifier = Modifier
                                         .size(96.dp)
-                                        .clip(RoundedCornerShape(18.dp))
+                                        .clip(RoundedCornerShape(18.dp)),
+                                    targetSize = Size(192, 192)
                                 )
                             }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PrefetchAlbumNeighbors.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/PrefetchAlbumNeighbors.kt
@@ -7,12 +7,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
-import coil.Coil
 import coil.request.CachePolicy
-import coil.request.ImageRequest
 import coil.size.Size
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.presentation.components.albumArtMemoryCacheKey
+import com.theveloper.pixelplay.presentation.components.safeAlbumArtTargetSize
 import com.theveloper.pixelplay.utils.LocalArtworkUri
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -34,7 +33,8 @@ fun PrefetchAlbumNeighborsImg(
             if (i == index) continue
             queue[i].albumArtUriString?.let { data ->
                 val diskPolicy = if (LocalArtworkUri.isLocalArtworkUri(data)) CachePolicy.DISABLED else CachePolicy.ENABLED
-                val memoryCacheKey = albumArtMemoryCacheKey(data, Size.ORIGINAL)
+                val targetSize = safeAlbumArtTargetSize(Size.ORIGINAL)
+                val memoryCacheKey = albumArtMemoryCacheKey(data, targetSize)
                 val req = coil.request.ImageRequest.Builder(context)
                     .data(data)
                     .apply {
@@ -44,7 +44,7 @@ fun PrefetchAlbumNeighborsImg(
                     }
                     .diskCacheKey(if (diskPolicy == CachePolicy.DISABLED) null else memoryCacheKey)
                     .diskCachePolicy(diskPolicy)
-                    .size(coil.size.Size.ORIGINAL)
+                    .size(targetSize)
                     .build()
                 loader.enqueue(req)
             }
@@ -65,8 +65,11 @@ fun PrefetchAlbumNeighbors(
     if (!isActive || queue.isEmpty()) return
     val context = LocalContext.current
     val imageLoader = coil.Coil.imageLoader(context)
+    val requestTargetSize = remember(targetSize) {
+        safeAlbumArtTargetSize(targetSize)
+    }
 
-    LaunchedEffect(pagerState, queue, anchorIndex) {
+    LaunchedEffect(pagerState, queue, anchorIndex, requestTargetSize) {
         snapshotFlow { 
             // If the user is manually scrolling, follow the PagerState.
             // If the Pager is idle, prioritize the provided anchorIndex (which is tied to the current song)
@@ -81,10 +84,10 @@ fun PrefetchAlbumNeighbors(
                 indices.forEach { idx ->
                     queue[idx].albumArtUriString?.let { uri ->
                         val diskPolicy = if (LocalArtworkUri.isLocalArtworkUri(uri)) coil.request.CachePolicy.DISABLED else coil.request.CachePolicy.ENABLED
-                        val memoryCacheKey = albumArtMemoryCacheKey(uri, targetSize)
+                        val memoryCacheKey = albumArtMemoryCacheKey(uri, requestTargetSize)
                         val req = coil.request.ImageRequest.Builder(context)
                             .data(uri)
-                            .size(targetSize)
+                            .size(requestTargetSize)
                             .memoryCachePolicy(coil.request.CachePolicy.ENABLED)
                             .apply {
                                 if (memoryCacheKey != null) {

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArtTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/components/OptimizedAlbumArtTest.kt
@@ -1,0 +1,26 @@
+package com.theveloper.pixelplay.presentation.components
+
+import coil.size.Dimension
+import coil.size.Size
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class OptimizedAlbumArtTest {
+
+    @Test
+    fun safeAlbumArtTargetSize_clampsOriginalRequests() {
+        val targetSize = safeAlbumArtTargetSize(Size.ORIGINAL)
+
+        assertThat((targetSize.width as Dimension.Pixels).px)
+            .isEqualTo(MaxSafeAlbumArtDimensionPx)
+        assertThat((targetSize.height as Dimension.Pixels).px)
+            .isEqualTo(MaxSafeAlbumArtDimensionPx)
+    }
+
+    @Test
+    fun safeAlbumArtTargetSize_keepsBoundedRequests() {
+        val targetSize = Size(800, 600)
+
+        assertThat(safeAlbumArtTargetSize(targetSize)).isEqualTo(targetSize)
+    }
+}


### PR DESCRIPTION
- Add `getArtistsByIds` query to `MusicDao` to fetch existing artist entities.
- Update `upsertArtists` logic to merge incoming artist data with existing records.
- Ensure `imageUrl` and `customImageUri` are preserved if the incoming data contains null values for these fields.