### PR TITLE
Fix typo in README for AI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 
 ### ⚙️ Advanced Features
 - **Tag Editor** - Edit metadata with TagLib (MP3, FLAC, M4A support)
-- **AI Playlists** - Generate playlists with AI (Supports Gemini, Deepseek, OpenIA, etc.)
+- **AI Playlists** - Generate playlists with AI (Supports Gemini, Deepseek, OpenAI, etc.)
 
 ---
 


### PR DESCRIPTION
Corrected the spelling of 'OpenIA' to 'OpenAI' in the README.