### PR TITLE
Fix 0kbps bitrate reporting for cloud sources (Navidrome/Jellyfin)

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/JellyfinSongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/JellyfinSongEntity.kt
@@ -49,7 +49,7 @@ fun JellyfinSongEntity.toSong(): Song {
         duration = duration,
         genre = genre,
         mimeType = mimeType,
-        bitrate = bitRate,
+        bitrate = bitRate?.let { it * 1000 },
         sampleRate = null,
         year = year,
         trackNumber = trackNumber,

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeSongEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/NavidromeSongEntity.kt
@@ -77,7 +77,7 @@ fun NavidromeSongEntity.toSong(): Song {
         duration = duration,
         genre = genre,
         mimeType = mimeType,
-        bitrate = bitRate,
+        bitrate = bitRate?.let { it * 1000 },
         sampleRate = null,
         year = year,
         trackNumber = trackNumber,

--- a/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/JellyfinRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/JellyfinRepository.kt
@@ -547,7 +547,7 @@ class JellyfinRepository @Inject constructor(
                     dateAdded = jellyfinSong.dateAdded.takeIf { it > 0 }
                         ?: System.currentTimeMillis(),
                     mimeType = jellyfinSong.mimeType,
-                    bitrate = jellyfinSong.bitRate,
+                    bitrate = jellyfinSong.bitRate?.let { it * 1000 },
                     sampleRate = null,
                     telegramChatId = null,
                     telegramFileId = null,
@@ -649,7 +649,7 @@ class JellyfinRepository @Inject constructor(
             duration = duration,
             genre = genre,
             mimeType = resolvedMimeType,
-            bitrate = bitRate,
+            bitrate = bitRate?.let { it * 1000 },
             sampleRate = null,
             year = year,
             trackNumber = trackNumber,

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
@@ -60,7 +60,7 @@ object AudioMetadataReader {
                 // Get audio properties for duration
                 val audioProperties = TagLib.getAudioProperties(fd.dup().detachFd())
                 val durationMs = audioProperties?.length?.takeIf { it > 0 }?.let { it * 1000L }
-                val bitrate = audioProperties?.bitrate?.takeIf { it > 0 }
+                val bitrate = audioProperties?.bitrate?.takeIf { it > 0 }?.let { it * 1000 }
                 val sampleRate = audioProperties?.sampleRate?.takeIf { it > 0 }
 
                 // Get metadata
@@ -175,7 +175,7 @@ object AudioMetadataReader {
                 ?.take(4)?.toIntOrNull()
 
             val durationMs = header?.trackLength?.takeIf { it > 0 }?.let { it * 1000L }
-            val bitrate = header?.bitRateAsNumber?.takeIf { it > 0 }?.toInt()
+            val bitrate = header?.bitRateAsNumber?.takeIf { it > 0 }?.toInt()?.let { it * 1000 }
             val sampleRate = header?.sampleRateAsNumber?.takeIf { it > 0 }
 
             // Try to get artwork from JAudioTagger

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -708,7 +708,7 @@ class NavidromeRepository @Inject constructor(
                     dateAdded = navidromeSong.dateAdded.takeIf { it > 0 }
                         ?: System.currentTimeMillis(),
                     mimeType = navidromeSong.mimeType,
-                    bitrate = navidromeSong.bitRate,
+                    bitrate = navidromeSong.bitRate?.let { it * 1000 },
                     sampleRate = null,
                     telegramChatId = null,
                     telegramFileId = null,
@@ -877,7 +877,7 @@ fun NavidromeSong.toSong(): Song {
         duration = duration,
         genre = genre,
         mimeType = resolvedMimeType,
-        bitrate = bitRate,
+        bitrate = bitRate?.let { it * 1000 },
         sampleRate = null,
         year = year,
         trackNumber = trackNumber,


### PR DESCRIPTION
The issue was caused by a unit mismatch in remote sources. While the app's internal Song model and UI expect the bitrate in bits per second (bps), several data sources, including Navidrome, Jellyfin, and the fallback metadata readers (TagLib/JAudioTagger), were providing it in kilobits per second (kbps). When a bitrate like 128 (meaning 128 kbps) was passed to the UI, the display logic divided it by 1000, resulting in '0 kbps' (128 / 1000 = 0).

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/cd688e34-f0a8-489e-99e5-ae4d4fa9d5b8" width="800" /> | <img src="https://github.com/user-attachments/assets/77e7b240-f076-47aa-865f-7c2c92eb9ef2" width="800" /> |
