### PR TITLE
feat: Navidrome library sync speed and reliability improvements

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -59,7 +59,8 @@ class NavidromeRepository @Inject constructor(
     private val playlistPreferencesRepository: PlaylistPreferencesRepository,
     @ApplicationContext private val context: Context
 ) {
-    private companion object {
+    companion object {
+        const val SYNC_THRESHOLD_MS = 24 * 60 * 60 * 1000L // 24 hours
         private const val TAG = "NavidromeRepo"
         private const val PREFS_NAME = "navidrome_prefs"
         private const val KEY_SERVER_URL = "server_url"

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/NavidromeRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.database.AlbumEntity
 import com.theveloper.pixelplay.data.database.ArtistEntity
 import com.theveloper.pixelplay.data.database.MusicDao
@@ -25,18 +26,25 @@ import com.theveloper.pixelplay.data.stream.BulkSyncResult
 import com.theveloper.pixelplay.data.stream.CloudMusicUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.absoluteValue
+import androidx.core.content.edit
 
 /**
  * Repository for Navidrome/Subsonic music service.
@@ -57,6 +65,7 @@ class NavidromeRepository @Inject constructor(
         private const val KEY_SERVER_URL = "server_url"
         private const val KEY_USERNAME = "username"
         private const val KEY_PASSWORD = "password"
+        private const val KEY_LAST_FULL_SYNC = "last_full_sync"
 
         // ID offsets for unified library (following Netease: 3-5, QQ: 6-8)
         // Using negative offsets to prevent collisions with MediaStore IDs
@@ -135,6 +144,10 @@ class NavidromeRepository @Inject constructor(
     val username: String?
         get() = prefs.getString(KEY_USERNAME, null)
 
+    var lastFullSyncTime: Long
+        get() = prefs.getLong(KEY_LAST_FULL_SYNC, 0L)
+        set(value) = prefs.edit { putLong(KEY_LAST_FULL_SYNC, value) }
+
     /**
      * Login to Navidrome server with credentials.
      *
@@ -166,11 +179,11 @@ class NavidromeRepository @Inject constructor(
                 }
 
                 // Save credentials
-                prefs.edit()
-                    .putString(KEY_SERVER_URL, credentials.normalizedServerUrl)
-                    .putString(KEY_USERNAME, username)
-                    .putString(KEY_PASSWORD, password)
-                    .apply()
+                prefs.edit {
+                    putString(KEY_SERVER_URL, credentials.normalizedServerUrl)
+                        .putString(KEY_USERNAME, username)
+                        .putString(KEY_PASSWORD, password)
+                }
 
                 _isLoggedInFlow.value = true
                 Timber.d("$TAG: Login successful for $username@$serverUrl")
@@ -190,7 +203,7 @@ class NavidromeRepository @Inject constructor(
     suspend fun logout() {
         Timber.d("$TAG: Logging out")
         api.clearCredentials()
-        prefs.edit().clear().apply()
+        prefs.edit { clear() }
 
         // Delete all Navidrome playlists from database
         val playlistsToDelete = dao.getAllPlaylistsList()
@@ -363,7 +376,9 @@ class NavidromeRepository @Inject constructor(
     /**
      * Sync all songs from the server library by fetching all albums.
      */
-    suspend fun syncLibrarySongs(): Result<Int> {
+    suspend fun syncLibrarySongs(
+        onProgress: ((Float, String) -> Unit)? = null
+    ): Result<Int> {
         if (!isLoggedIn) {
             return Result.failure(Exception("Not logged in"))
         }
@@ -373,30 +388,59 @@ class NavidromeRepository @Inject constructor(
                 Timber.d("$TAG: Syncing library songs from server")
                 val allSongs = mutableListOf<NavidromeSong>()
                 val pageSize = 500
+                
+                onProgress?.invoke(0.1f, context.getString(R.string.dash_status_fetching_albums))
                 val fetchedAlbums = fetchAllAlbums(pageSize)
 
-                // Fetch songs for each album
-                for (albumJson in fetchedAlbums) {
-                    val albumId = albumJson.optString("id", "")
-                    if (albumId.isBlank()) continue
+                // Fetch songs for each album in parallel
+                val totalAlbums = fetchedAlbums.size
+                val concurrencyLimit = 5
+                val semaphore = Semaphore(concurrencyLimit)
+                val processedCount = AtomicInteger(0)
 
-                    val songsResult = api.getAlbum(albumId)
-                    songsResult.fold(
-                        onSuccess = { songJsons ->
-                            val songs = NavidromeResponseParser.parseSongs(songJsons)
-                            allSongs.addAll(songs)
-                        },
-                        onFailure = {
-                            Timber.w(it, "$TAG: Failed to fetch songs for album $albumId")
+                val albumSongLists = coroutineScope {
+                    fetchedAlbums.map { albumJson ->
+                        async {
+                            semaphore.withPermit {
+                                val albumId = albumJson.optString("id", "")
+                                val albumTitle = albumJson.optString("title", "Unknown Album")
+                                if (albumId.isBlank()) return@withPermit emptyList()
+
+                                val songsResult = api.getAlbum(albumId)
+                                val currentProcessed = processedCount.incrementAndGet()
+                                
+                                val progress = 0.1f + (currentProcessed.toFloat() / totalAlbums.coerceAtLeast(1) * 0.8f)
+                                onProgress?.invoke(
+                                    progress, 
+                                    context.getString(R.string.dash_status_fetching_songs_from_format, albumTitle)
+                                )
+
+                                songsResult.fold(
+                                    onSuccess = { songJsons ->
+                                        NavidromeResponseParser.parseSongs(songJsons)
+                                    },
+                                    onFailure = {
+                                        Timber.w(it, "$TAG: Failed to fetch songs for album $albumId")
+                                        emptyList()
+                                    }
+                                )
+                            }
                         }
-                    )
+                    }.awaitAll()
                 }
+
+                allSongs.addAll(albumSongLists.flatten())
 
                 if (allSongs.isEmpty()) {
                     Timber.d("$TAG: No library songs found on server")
+                    onProgress?.invoke(1f, context.getString(R.string.dash_status_no_songs_found))
                     return@withContext Result.success(0)
                 }
 
+                onProgress?.invoke(
+                    0.95f, 
+                    context.getString(R.string.dash_status_saving_songs_format, allSongs.size)
+                )
                 // Deduplicate by song ID
                 val uniqueSongs = allSongs.distinctBy { it.id }
 
@@ -409,6 +453,7 @@ class NavidromeRepository @Inject constructor(
                 dao.insertSongs(entities)
 
                 Timber.d("$TAG: Synced ${entities.size} library songs from ${fetchedAlbums.size} albums")
+                onProgress?.invoke(1f, context.getString(R.string.dash_status_library_sync_complete))
                 Result.success(entities.size)
             } catch (e: Exception) {
                 Timber.e(e, "$TAG: Failed to sync library songs")
@@ -445,18 +490,25 @@ class NavidromeRepository @Inject constructor(
     /**
      * Sync all playlists and their songs, plus library songs.
      */
-    suspend fun syncAllPlaylistsAndSongs(): Result<BulkSyncResult> {
+    suspend fun syncAllPlaylistsAndSongs(
+        onProgress: ((Float, String) -> Unit)? = null
+    ): Result<BulkSyncResult> {
         return withContext(Dispatchers.IO) {
             var syncedSongCount = 0
             var failedPlaylistCount = 0
 
+            onProgress?.invoke(0.05f, context.getString(R.string.dash_status_syncing_library))
             // Sync library songs (all albums)
-            val libResult = syncLibrarySongs()
+            val libResult = syncLibrarySongs { progress, message ->
+                // Map library sync progress (0-1) to 0.05-0.4 range
+                onProgress?.invoke(0.05f + (progress * 0.35f), message)
+            }
             libResult.fold(
                 onSuccess = { count -> syncedSongCount += count },
                 onFailure = { Timber.w(it, "$TAG: Failed syncing library songs") }
             )
 
+            onProgress?.invoke(0.4f, context.getString(R.string.dash_status_fetching_playlists))
             // Sync playlists
             val playlistResult = syncPlaylists().getOrElse {
                 // Playlists failed but library songs may have synced
@@ -474,7 +526,17 @@ class NavidromeRepository @Inject constructor(
                 )
             }
 
-            playlistResult.forEach { playlist ->
+            val totalPlaylists = playlistResult.size
+            playlistResult.forEachIndexed { index, playlist ->
+                val progressBase = 0.4f
+                val progressStep = 0.5f / totalPlaylists.coerceAtLeast(1)
+                val currentProgress = progressBase + (index * progressStep)
+                
+                onProgress?.invoke(
+                    currentProgress, 
+                    context.getString(R.string.dash_status_syncing_playlist_format, playlist.name)
+                )
+                
                 val songSyncResult = syncPlaylistSongs(playlist.id)
                 songSyncResult.fold(
                     onSuccess = { count -> syncedSongCount += count },
@@ -485,11 +547,18 @@ class NavidromeRepository @Inject constructor(
                 )
             }
 
+            onProgress?.invoke(0.95f, context.getString(R.string.dash_status_updating_local))
             // Sync to unified library once after everything is synced
             try {
                 syncUnifiedLibrarySongsFromNavidrome()
             } catch (e: Exception) {
                 Timber.e(e, "$TAG: Failed to sync unified library")
+            }
+
+            onProgress?.invoke(1f, context.getString(R.string.dash_status_sync_complete))
+
+            if (failedPlaylistCount == 0) {
+                lastFullSyncTime = System.currentTimeMillis()
             }
 
             Result.success(
@@ -758,7 +827,7 @@ class NavidromeRepository @Inject constructor(
 
     // ─── App Playlist Management ───────────────────────────────────────────
 
-    private suspend fun getAppPlaylistIdForNavidrome(navidromePlaylistId: String): String {
+    private fun getAppPlaylistIdForNavidrome(navidromePlaylistId: String): String {
         return "$NAVIDROME_PLAYLIST_PREFIX$navidromePlaylistId"
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/NavidromeSyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/NavidromeSyncWorker.kt
@@ -1,0 +1,81 @@
+package com.theveloper.pixelplay.data.worker
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import timber.log.Timber
+
+@HiltWorker
+class NavidromeSyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val repository: NavidromeRepository
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val syncType = inputData.getString(KEY_SYNC_TYPE) ?: SYNC_TYPE_ALL
+        val playlistId = inputData.getString(KEY_PLAYLIST_ID)
+
+        Timber.d("NavidromeSyncWorker: Starting sync (type=$syncType, playlistId=$playlistId)")
+
+        return try {
+            when (syncType) {
+                SYNC_TYPE_ALL -> {
+                    repository.syncAllPlaylistsAndSongs { progress, message ->
+                        setProgressAsync(
+                            workDataOf(
+                                PROGRESS_VALUE to progress,
+                                PROGRESS_MESSAGE to message
+                            )
+                        )
+                    }
+                }
+                SYNC_TYPE_PLAYLISTS -> {
+                    repository.syncPlaylists()
+                }
+                SYNC_TYPE_PLAYLIST_SONGS -> {
+                    if (playlistId != null) {
+                        repository.syncPlaylistSongs(playlistId)
+                        repository.syncUnifiedLibrarySongsFromNavidrome()
+                    }
+                }
+            }
+            Result.success()
+        } catch (e: Exception) {
+            Timber.e(e, "NavidromeSyncWorker: Sync failed")
+            Result.failure(workDataOf(ERROR_MESSAGE to e.message))
+        }
+    }
+
+    companion object {
+        const val KEY_SYNC_TYPE = "sync_type"
+        const val KEY_PLAYLIST_ID = "playlist_id"
+        
+        const val SYNC_TYPE_ALL = "all"
+        const val SYNC_TYPE_PLAYLISTS = "playlists"
+        const val SYNC_TYPE_PLAYLIST_SONGS = "playlist_songs"
+
+        const val PROGRESS_VALUE = "progress_value"
+        const val PROGRESS_MESSAGE = "progress_message"
+        const val ERROR_MESSAGE = "error_message"
+
+        fun startAllSync() = OneTimeWorkRequestBuilder<NavidromeSyncWorker>()
+            .setInputData(workDataOf(KEY_SYNC_TYPE to SYNC_TYPE_ALL))
+            .build()
+            
+        fun startPlaylistSync(playlistId: String) = OneTimeWorkRequestBuilder<NavidromeSyncWorker>()
+            .setInputData(
+                workDataOf(
+                    KEY_SYNC_TYPE to SYNC_TYPE_PLAYLIST_SONGS,
+                    KEY_PLAYLIST_ID to playlistId
+                )
+            )
+            .build()
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -1760,9 +1760,8 @@ constructor(
         // since the last successful Navidrome sync. This prevents slow app startups.
         val lastSync = navidromeRepository.lastFullSyncTime
         val currentTime = System.currentTimeMillis()
-        val threshold = 24 * 60 * 60 * 1000L // 24 hours
 
-        if (currentTime - lastSync < threshold) {
+        if (currentTime - lastSync < NavidromeRepository.SYNC_THRESHOLD_MS) {
             Log.d(TAG, "Skipping Navidrome sync during main library sync - last sync was recent.")
             // Still sync unified library from local cache to be safe
             navidromeRepository.syncUnifiedLibrarySongsFromNavidrome()

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -377,10 +377,15 @@ constructor(
                     // the user hasn't configured that cloud provider.
                     val hasTelegramChannels = telegramDao.getAllChannels().first().isNotEmpty()
                     val neteaseCount = neteaseDao.getNeteaseCount()
-                    val needsCloudSync = hasTelegramChannels ||
+                    // For Navidrome, we only do network sync if SYNC_THRESHOLD_MS (24h) threshold has passed.
+                    val navidromeNeedsNetworkSync = navidromeRepository.isLoggedIn && 
+                        (System.currentTimeMillis() - navidromeRepository.lastFullSyncTime >= NavidromeRepository.SYNC_THRESHOLD_MS)
+                    
+                    val needsActiveCloudSync = hasTelegramChannels ||
                         neteaseCount > 0 ||
-                        navidromeRepository.isLoggedIn
-                    if (needsCloudSync) {
+                        navidromeNeedsNetworkSync
+
+                    if (needsActiveCloudSync) {
                         setProgress(
                             workDataOf(
                                 PROGRESS_PHASE to SyncProgress.SyncPhase.SYNCING_CLOUD.ordinal
@@ -1756,11 +1761,10 @@ constructor(
     private suspend fun syncNavidromeData() {
         if (!navidromeRepository.isLoggedIn) return
 
-        // Only auto-sync Navidrome during main library sync if it's been more than 24 hours
-        // since the last successful Navidrome sync. This prevents slow app startups.
         val lastSync = navidromeRepository.lastFullSyncTime
         val currentTime = System.currentTimeMillis()
 
+        // Only auto-sync Navidrome during main library sync if it's been more than SYNC_THRESHOLD_MS (24h)
         if (currentTime - lastSync < NavidromeRepository.SYNC_THRESHOLD_MS) {
             Log.d(TAG, "Skipping Navidrome sync during main library sync - last sync was recent.")
             // Still sync unified library from local cache to be safe

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -284,14 +284,19 @@ constructor(
                         // Clear the rescan required flag
                         userPreferencesRepository.clearArtistSettingsRescanRequired()
 
-                        val endTime = System.currentTimeMillis()
-                        Timber.tag(TAG)
-                            .i("Synchronization finished successfully in ${endTime - startTime}ms.")
-                        userPreferencesRepository.setLastSyncTimestamp(System.currentTimeMillis())
                         userPreferencesRepository.markDirectoryRulesVersionApplied(
                             directoryRulesVersion
                         )
                     }
+
+                    // Always update last sync timestamp if we reached this point successfully,
+                    // even if no new songs were found in MediaStore. This prevents the sync
+                    // from being re-triggered on every app launch when the library is already up to date.
+                    userPreferencesRepository.setLastSyncTimestamp(System.currentTimeMillis())
+
+                    val endTime = System.currentTimeMillis()
+                    Timber.tag(TAG)
+                        .i("Synchronization finished successfully in ${endTime - startTime}ms.")
 
                     // Count total songs for the output
                     val totalSongs = musicDao.getSongCount().first()
@@ -1749,6 +1754,21 @@ constructor(
     }
 
     private suspend fun syncNavidromeData() {
+        if (!navidromeRepository.isLoggedIn) return
+
+        // Only auto-sync Navidrome during main library sync if it's been more than 24 hours
+        // since the last successful Navidrome sync. This prevents slow app startups.
+        val lastSync = navidromeRepository.lastFullSyncTime
+        val currentTime = System.currentTimeMillis()
+        val threshold = 24 * 60 * 60 * 1000L // 24 hours
+
+        if (currentTime - lastSync < threshold) {
+            Log.d(TAG, "Skipping Navidrome sync during main library sync - last sync was recent.")
+            // Still sync unified library from local cache to be safe
+            navidromeRepository.syncUnifiedLibrarySongsFromNavidrome()
+            return
+        }
+
         Log.i(TAG, "Syncing Navidrome data from server...")
         try {
             // Fetch playlists and songs from the Navidrome server, then sync to unified library

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -11,6 +11,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
@@ -110,6 +111,12 @@ object AppModule {
     @AppScope
     fun provideAppCoroutineScope(): CoroutineScope {
         return CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+
+    @Singleton
+    @Provides
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
+        return WorkManager.getInstance(context)
     }
 
     @Singleton

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
@@ -38,6 +38,7 @@ import com.theveloper.pixelplay.data.database.NavidromePlaylistEntity
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.presentation.components.SmartImage
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import com.theveloper.pixelplay.utils.formatTimeAgo
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.res.stringResource
@@ -50,6 +51,7 @@ fun NavidromeDashboardScreen(
 ) {
     val playlists by viewModel.playlists.collectAsStateWithLifecycle()
     val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()
+    val syncProgress by viewModel.syncProgress.collectAsStateWithLifecycle()
     val syncMessage by viewModel.syncMessage.collectAsStateWithLifecycle()
 
     val cardShape = AbsoluteSmoothCornerShape(
@@ -93,8 +95,10 @@ fun NavidromeDashboardScreen(
         DashboardContent(
             playlists = playlists,
             isSyncing = isSyncing,
+            syncProgress = syncProgress,
             syncMessage = syncMessage,
             username = viewModel.username,
+            lastSyncTime = viewModel.lastSyncTime,
             onSyncAll = { viewModel.syncAllPlaylistsAndSongs() },
             onSyncPlaylist = { viewModel.syncPlaylistSongs(it) },
             onDeletePlaylist = { viewModel.deletePlaylist(it) },
@@ -113,8 +117,10 @@ fun NavidromeDashboardScreen(
 private fun DashboardContent(
     playlists: List<NavidromePlaylistEntity>,
     isSyncing: Boolean,
+    syncProgress: Float?,
     syncMessage: String?,
     username: String?,
+    lastSyncTime: Long,
     onSyncAll: () -> Unit,
     onSyncPlaylist: (String) -> Unit,
     onDeletePlaylist: (String) -> Unit,
@@ -149,23 +155,47 @@ private fun DashboardContent(
                             MaterialTheme.colorScheme.primaryContainer
                     )
                 ) {
-                    Row(
-                        modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (isSyncing) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(20.dp),
-                                strokeWidth = 2.dp,
-                                color = MaterialTheme.colorScheme.primary
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (isSyncing && syncProgress == null) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                                Spacer(Modifier.width(12.dp))
+                            }
+                            Text(
+                                text = message,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontFamily = GoogleSansRounded,
+                                modifier = Modifier.weight(1f)
                             )
-                            Spacer(Modifier.width(12.dp))
+                            if (isSyncing && syncProgress != null) {
+                                Text(
+                                    text = "${(syncProgress * 100).toInt()}%",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontFamily = GoogleSansRounded,
+                                    fontWeight = FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
                         }
-                        Text(
-                            text = message,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontFamily = GoogleSansRounded
-                        )
+                        
+                        if (isSyncing && syncProgress != null) {
+                            Spacer(Modifier.height(12.dp))
+                            LinearProgressIndicator(
+                                progress = { syncProgress!! },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(8.dp)
+                                    .clip(CircleShape),
+                                color = MaterialTheme.colorScheme.primary,
+                                trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                            )
+                        }
                     }
                 }
             }
@@ -215,6 +245,12 @@ private fun DashboardContent(
                             style = MaterialTheme.typography.bodySmall,
                             fontFamily = GoogleSansRounded,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Last synced: ${formatTimeAgo(lastSyncTime)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = GoogleSansRounded,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                         )
                     }
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -49,7 +49,7 @@ class NavidromeDashboardViewModel @Inject constructor(
         // Auto sync full library (songs + playlists) if it's been more than 24 hours
         val lastSync = repository.lastFullSyncTime
         val currentTime = System.currentTimeMillis()
-        if (currentTime - lastSync > SYNC_THRESHOLD_MS) {
+        if (currentTime - lastSync > NavidromeRepository.SYNC_THRESHOLD_MS) {
             syncAllPlaylistsAndSongs()
         }
     }
@@ -126,6 +126,5 @@ class NavidromeDashboardViewModel @Inject constructor(
 
     companion object {
         private const val WORK_NAME_SYNC_ALL = "navidrome_sync_all"
-        private const val SYNC_THRESHOLD_MS = 24 * 60 * 60 * 1000L // 24 hours
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardViewModel.kt
@@ -2,12 +2,14 @@ package com.theveloper.pixelplay.presentation.navidrome.dashboard
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.ExistingWorkPolicy
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.theveloper.pixelplay.data.database.NavidromePlaylistEntity
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
+import com.theveloper.pixelplay.data.worker.NavidromeSyncWorker
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Job
-import timber.log.Timber
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +20,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NavidromeDashboardViewModel @Inject constructor(
-    private val repository: NavidromeRepository
+    private val repository: NavidromeRepository,
+    private val workManager: WorkManager
 ) : ViewModel() {
 
     val playlists: StateFlow<List<NavidromePlaylistEntity>> = repository.getPlaylists()
@@ -26,6 +29,9 @@ class NavidromeDashboardViewModel @Inject constructor(
 
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
+
+    private val _syncProgress = MutableStateFlow<Float?>(null)
+    val syncProgress: StateFlow<Float?> = _syncProgress.asStateFlow()
 
     private val _syncMessage = MutableStateFlow<String?>(null)
     val syncMessage: StateFlow<String?> = _syncMessage.asStateFlow()
@@ -36,62 +42,62 @@ class NavidromeDashboardViewModel @Inject constructor(
     val username: String? get() = repository.username
     val serverUrl: String? get() = repository.serverUrl
     val isLoggedIn: StateFlow<Boolean> = repository.isLoggedInFlow
+    val lastSyncTime: Long get() = repository.lastFullSyncTime
 
     init {
-        // Auto-sync full library (songs + playlists) when dashboard opens
-        syncAllPlaylistsAndSongs()
+        observeSyncWorker()
+        // Auto sync full library (songs + playlists) if it's been more than 24 hours
+        val lastSync = repository.lastFullSyncTime
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - lastSync > SYNC_THRESHOLD_MS) {
+            syncAllPlaylistsAndSongs()
+        }
+    }
+
+    private fun observeSyncWorker() {
+        viewModelScope.launch {
+            workManager.getWorkInfosForUniqueWorkFlow(WORK_NAME_SYNC_ALL).collect { workInfos ->
+                val workInfo = workInfos.firstOrNull() ?: return@collect
+                
+                when (workInfo.state) {
+                    WorkInfo.State.RUNNING -> {
+                        _isSyncing.value = true
+                        val progress = workInfo.progress.getFloat(NavidromeSyncWorker.PROGRESS_VALUE, 0f)
+                        _syncProgress.value = if (progress > 0f) progress else null
+                        _syncMessage.value = workInfo.progress.getString(NavidromeSyncWorker.PROGRESS_MESSAGE)
+                    }
+                    WorkInfo.State.SUCCEEDED -> {
+                        _isSyncing.value = false
+                        _syncProgress.value = null
+                    }
+                    WorkInfo.State.FAILED -> {
+                        _isSyncing.value = false
+                        _syncProgress.value = null
+                        _syncMessage.value = workInfo.outputData.getString(NavidromeSyncWorker.ERROR_MESSAGE) ?: "Sync failed"
+                    }
+                    else -> {
+                        _isSyncing.value = false
+                        _syncProgress.value = null
+                    }
+                }
+            }
+        }
     }
 
     fun syncAllPlaylistsAndSongs() {
-        viewModelScope.launch {
-            _isSyncing.value = true
-            _syncMessage.value = "Syncing all playlists and songs..."
-            val result = repository.syncAllPlaylistsAndSongs()
-            result.fold(
-                onSuccess = { summary ->
-                    _syncMessage.value = if (summary.failedPlaylistCount == 0) {
-                        "Synced ${summary.playlistCount} playlists, ${summary.syncedSongCount} songs"
-                    } else {
-                        "Synced ${summary.playlistCount} playlists, ${summary.syncedSongCount} songs (${summary.failedPlaylistCount} failed)"
-                    }
-                },
-                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
-            )
-            _isSyncing.value = false
-        }
-    }
-
-    fun syncPlaylists() {
-        viewModelScope.launch {
-            _isSyncing.value = true
-            _syncMessage.value = "Syncing playlists..."
-            val result = repository.syncPlaylists()
-            result.fold(
-                onSuccess = { _syncMessage.value = "Synced ${it.size} playlists" },
-                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
-            )
-            _isSyncing.value = false
-        }
+        workManager.enqueueUniqueWork(
+            WORK_NAME_SYNC_ALL,
+            ExistingWorkPolicy.KEEP,
+            NavidromeSyncWorker.startAllSync()
+        )
     }
 
     fun syncPlaylistSongs(playlistId: String) {
-        viewModelScope.launch {
-            _isSyncing.value = true
-            _syncMessage.value = "Syncing songs..."
-            val result = repository.syncPlaylistSongs(playlistId)
-            result.fold(
-                onSuccess = { count ->
-                    try {
-                        repository.syncUnifiedLibrarySongsFromNavidrome()
-                    } catch (e: Exception) {
-                        Timber.e(e, "Failed to sync unified library after playlist sync")
-                    }
-                    _syncMessage.value = "Synced $count songs"
-                },
-                onFailure = { _syncMessage.value = "Sync failed: ${it.message}" }
-            )
-            _isSyncing.value = false
-        }
+        workManager.enqueueUniqueWork(
+            "navidrome_sync_playlist_$playlistId",
+            ExistingWorkPolicy.REPLACE,
+            NavidromeSyncWorker.startPlaylistSync(playlistId)
+        )
     }
 
     fun loadPlaylistSongs(playlistId: String) {
@@ -116,5 +122,10 @@ class NavidromeDashboardViewModel @Inject constructor(
         viewModelScope.launch {
             repository.logout()
         }
+    }
+
+    companion object {
+        private const val WORK_NAME_SYNC_ALL = "navidrome_sync_all"
+        private const val SYNC_THRESHOLD_MS = 24 * 60 * 60 * 1000L // 24 hours
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/utils/Formats.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/Formats.kt
@@ -58,3 +58,19 @@ fun formatListeningDurationCompact(milliseconds: Long): String {
 fun formatSongCount(count: Int): String {
     return if (count <= 1) "$count Song" else "$count Songs"
 }
+
+fun formatTimeAgo(timestamp: Long): String {
+    if (timestamp <= 0) return "Never"
+    val diff = System.currentTimeMillis() - timestamp
+    val seconds = diff / 1000
+    val minutes = seconds / 60
+    val hours = minutes / 60
+    val days = hours / 24
+
+    return when {
+        days > 0 -> if (days == 1L) "1 day ago" else "$days days ago"
+        hours > 0 -> if (hours == 1L) "1 hour ago" else "$hours hours ago"
+        minutes > 0 -> if (minutes == 1L) "1 minute ago" else "$minutes minutes ago"
+        else -> "Just now"
+    }
+}

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -213,6 +213,16 @@
     <string name="dash_status_syncing">Syncing</string>
     <string name="dash_action_sync_library">Sync library</string>
     <string name="dash_action_disconnect">Disconnect</string>
+    <string name="dash_status_syncing_library">Syncing library…</string>
+    <string name="dash_status_fetching_playlists">Fetching playlists…</string>
+    <string name="dash_status_syncing_playlist_format">Syncing playlist: %1$s</string>
+    <string name="dash_status_updating_local">Updating local library…</string>
+    <string name="dash_status_sync_complete">Sync complete</string>
+    <string name="dash_status_fetching_albums">Fetching album list…</string>
+    <string name="dash_status_fetching_songs_from_format">Fetching songs from %1$s…</string>
+    <string name="dash_status_saving_songs_format">Saving %1$d songs to database…</string>
+    <string name="dash_status_no_songs_found">No library songs found</string>
+    <string name="dash_status_library_sync_complete">Library sync complete</string>
     <string name="dash_song_count">%1$d songs</string>
     <string name="cd_sync">Sync</string>
     <string name="cd_sync_all">Sync all</string>


### PR DESCRIPTION
- Implemented parallel album song fetching using kotlin async/await to increase sync speed.
- Moved library sync execution to WorkManager for reliable background syncing when the user navigates to a different screen or puts the app in the background and switches to another app.
- Added a progress bar and live sync status to the Navidrome dashboard page so user can see the current sync progress.
- Added a 24 hour cooldown threshold for auto sync when opening navidrome dashboard

#### Some screenshots of progress bar/status

Closes #1947 

| | |
|---|---|
| <img src="https://github.com/user-attachments/assets/ec10ec3e-e377-4422-a334-85221d395a26" width="600"/> | <img src="https://github.com/user-attachments/assets/e763d3c5-d078-4e9e-b9c2-353116a3b09f" width="600"/> |
| <img src="https://github.com/user-attachments/assets/c4cded28-954e-4e9b-9ac6-7ec1ee74d3d3" width="600"/> | <img src="https://github.com/user-attachments/assets/ff3cb5f2-2053-4ade-b25f-76a223c5440c" width="600"/> |
| <img src="https://github.com/user-attachments/assets/65328241-59c8-482a-bb36-d9065bc84bf2" width="600"/> |  |
