### PR TITLE
ci: add nightly APK build workflow

### DIFF
--- a/.github/workflows/nightly-apk.yml
+++ b/.github/workflows/nightly-apk.yml
@@ -1,0 +1,142 @@
+name: Build Nightly APK
+
+on:
+  schedule:
+    # Runs at 02:17 America/Buenos_Aires.
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: nightly-apk-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      current-sha: ${{ steps.nightly-changes.outputs.current-sha }}
+      previous-sha: ${{ steps.nightly-changes.outputs.previous-sha }}
+      should-build: ${{ steps.nightly-changes.outputs.should-build }}
+      short-sha: ${{ steps.nightly-changes.outputs.short-sha }}
+
+    steps:
+      - name: Check for new master changes
+        id: nightly-changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflow_id = 'nightly-apk.yml';
+            const currentSha = context.sha;
+            const shortSha = currentSha.slice(0, 7);
+
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('current-sha', currentSha);
+              core.setOutput('previous-sha', '');
+              core.setOutput('short-sha', shortSha);
+              core.setOutput('should-build', 'true');
+              await core.summary
+                .addHeading('Nightly APK')
+                .addRaw(`Manual run requested for ${currentSha}. Building APKs.`)
+                .write();
+              return;
+            }
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id,
+              branch: 'master',
+              status: 'success',
+              per_page: 20,
+            });
+
+            const previousRun = runs.find((run) => run.id !== context.runId);
+            const previousSha = previousRun?.head_sha ?? '';
+            const shouldBuild = previousSha !== currentSha;
+
+            core.setOutput('current-sha', currentSha);
+            core.setOutput('previous-sha', previousSha);
+            core.setOutput('short-sha', shortSha);
+            core.setOutput('should-build', shouldBuild ? 'true' : 'false');
+
+            const summary = core.summary.addHeading('Nightly APK');
+            if (shouldBuild) {
+              summary.addRaw(
+                previousSha
+                  ? `master moved from ${previousSha} to ${currentSha}. Building APKs.`
+                  : `No previous successful nightly was found. Building APKs for ${currentSha}.`
+              );
+            } else {
+              summary.addRaw(`master is still at ${currentSha}. Skipping APK build.`);
+            }
+            await summary.write();
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.should-build == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Cache nightly keystore
+        id: cache-keystore
+        uses: actions/cache@v5
+        with:
+          path: vz-pixelplay.jks
+          key: ${{ runner.os }}-nightly-keystore-vz-pixelplay
+
+      - name: Generate nightly keystore if not cached
+        if: steps.cache-keystore.outputs.cache-hit != 'true'
+        run: |
+          keytool -genkey -v -keystore vz-pixelplay.jks -alias pixelplay-nightly-key -keyalg RSA -keysize 4096 -validity 10000 \
+            -storepass 994273 -keypass 994273 \
+            -dname "CN=PixelPlay Nightly, OU=Dev, O=PixelPlay, L=World, S=World, C=US"
+
+      - name: Create keystore.properties
+        run: |
+          echo "storePassword=994273" > keystore.properties
+          echo "keyAlias=pixelplay-nightly-key" >> keystore.properties
+          echo "keyPassword=994273" >> keystore.properties
+
+      - name: Build Phone nightly release APKs
+        run: gradle :app:assembleRelease -Ppixelplay.enableAbiSplits=true
+
+      - name: Verify Phone nightly split APKs
+        run: |
+          BUILD_TOOLS_VERSION="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)"
+          for apk in \
+            app/build/outputs/apk/release/app-arm64-v8a-release.apk \
+            app/build/outputs/apk/release/app-armeabi-v7a-release.apk
+          do
+            "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/aapt2" dump badging "$apk" >/dev/null
+            "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner" verify --verbose "$apk"
+          done
+
+      - name: Upload Phone nightly split APK artifacts
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: PixelPlay-phone-nightly-${{ needs.changes.outputs.short-sha }}
+          path: |
+            app/build/outputs/apk/release/app-arm64-v8a-release.apk
+            app/build/outputs/apk/release/app-armeabi-v7a-release.apk
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically build and sign release APKs on a nightly schedule.

- Triggers daily at 05:17 UTC or manually via `workflow_dispatch`.
- Includes a logic check to only build if new commits are detected on the master branch since the last successful run.
- Configures a build environment with JDK 21 and Gradle.
- Generates and caches a dedicated keystore for nightly builds.
- Builds ABI-split release APKs for `arm64-v8a` and `armeabi-v7a`.
- Verifies APK integrity using `aapt2` and `apksigner`.
- Uploads signed APKs as artifacts with a 14-day retention policy.