### PR TITLE
Implement MIDI support and refactor audio decoder selection policy

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -230,6 +230,7 @@ dependencies {
     implementation(libs.androidx.media3.ui)
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.exoplayer.ffmpeg)
+    implementation(libs.androidx.media3.exoplayer.midi)
     implementation(libs.androidx.media3.transformer)
     implementation(libs.androidx.mediarouter)
     implementation(libs.androidx.media)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,6 +50,13 @@
 -keep class androidx.media3.decoder.ffmpeg.** { *; }
 -keep class androidx.media3.exoplayer.ffmpeg.** { *; }
 
+# ExoPlayer MIDI extension and JSyn synthesizer
+-keep class androidx.media3.decoder.midi.** { *; }
+-keep class com.jsyn.** { *; }
+-keep class com.softsynth.** { *; }
+-dontwarn com.jsyn.**
+-dontwarn com.softsynth.**
+
 # Mantener clases de datos y sus miembros para evitar que R8 Full elimine campos
 -keepclassmembers class com.theveloper.pixelplay.data.model.** { *; }
 -keepclassmembers class com.theveloper.pixelplay.domain.model.** { *; }

--- a/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveConstants.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveConstants.kt
@@ -12,6 +12,7 @@ object GDriveConstants {
         "audio/mpeg", "audio/mp3", "audio/flac", "audio/wav", "audio/x-wav",
         "audio/mp4", "audio/x-m4a", "audio/aac", "audio/ogg",
         "audio/opus", "audio/x-aiff", "audio/alac", "audio/aiff",
-        "audio/x-flac", "audio/vnd.wave"
+        "audio/x-flac", "audio/vnd.wave", "audio/midi", "audio/x-midi",
+        "audio/sp-midi", "audio/x-mid"
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/AudioDecoderPolicy.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/AudioDecoderPolicy.kt
@@ -1,0 +1,50 @@
+package com.theveloper.pixelplay.data.service.player
+
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.util.UnstableApi
+import java.util.Locale
+
+@UnstableApi
+internal object AudioDecoderPolicy {
+    private const val AUDIO_MIDI = "audio/midi"
+    private val extensionOnlyMimeTypes = setOf(
+        MimeTypes.AUDIO_ALAC,
+        MimeTypes.AUDIO_EXOPLAYER_MIDI,
+        AUDIO_MIDI
+    )
+
+    fun shouldUseExtensionRenderer(mimeType: String): Boolean {
+        return extensionOnlyMimeTypes.any { it.equals(mimeType, ignoreCase = true) }
+    }
+
+    fun <T> selectPlatformDecoders(mimeType: String, decoderInfos: List<T>): List<T> {
+        return if (shouldUseExtensionRenderer(mimeType)) {
+            emptyList()
+        } else {
+            decoderInfos
+        }
+    }
+
+    fun isLikelyHardwareDecoder(decoderName: String): Boolean {
+        val normalized = decoderName.lowercase(Locale.US)
+        val knownSoftwareTokens = listOf(
+            "omx.google.",
+            "c2.android.",
+            "ffmpeg",
+            "midi",
+            "jsyn",
+            "libgav1",
+            "dav1d"
+        )
+        if (knownSoftwareTokens.any(normalized::contains)) return false
+
+        return normalized.startsWith("omx.") ||
+            normalized.startsWith("c2.") ||
+            normalized.contains(".qti.") ||
+            normalized.contains(".qcom.") ||
+            normalized.contains(".sec.") ||
+            normalized.contains(".mtk.") ||
+            normalized.contains(".exynos.") ||
+            normalized.contains(".dolby.")
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -12,7 +12,6 @@ import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes as Media3AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MimeTypes
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
@@ -29,7 +28,6 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.AudioSink
 import androidx.media3.exoplayer.audio.DefaultAudioSink
-import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.extractor.DefaultExtractorsFactory
@@ -52,7 +50,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
-import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.resume
@@ -197,13 +194,7 @@ class DualPlayerEngine @Inject constructor(
             initializedTimestampMs: Long,
             initializationDurationMs: Long
         ) {
-            val isSamsung = Build.MANUFACTURER.lowercase(Locale.US) == "samsung"
-            // Heuristic to check if decoder is hardware based on name and manufacturer-specific quirks.
-            // On Samsung, c2.sec.* are high-perf hardware paths.
-            val isHardware = decoderName.startsWith("omx.google.", ignoreCase = true).not() &&
-                decoderName.startsWith("c2.android.", ignoreCase = true).not() &&
-                (decoderName.startsWith("c2.sec.", ignoreCase = true) || !isSamsung)
-            
+            val isHardware = AudioDecoderPolicy.isLikelyHardwareDecoder(decoderName)
             _activeDecoderInfo.value = ActiveDecoderInfo(decoderName, isHardware)
             Timber.tag("DualPlayerEngine").d("Audio decoder initialized: %s (Hardware: %b)", decoderName, isHardware)
         }
@@ -523,34 +514,7 @@ class DualPlayerEngine @Inject constructor(
                 requiresTunnelingDecoder
             )
 
-            val samsungPreferred = if (Build.MANUFACTURER.lowercase(Locale.US) == "samsung") {
-                val (secCodecs, otherCodecs) = decoderInfos.partition { it.name.startsWith("c2.sec.") }
-                val secCodecsForced = secCodecs.map { info ->
-                    if (!info.hardwareAccelerated) {
-                        MediaCodecInfo.newInstance(
-                            info.name,
-                            info.mimeType,
-                            info.codecMimeType,
-                            info.capabilities,
-                            true, // hardwareAccelerated = true
-                            info.softwareOnly,
-                            info.vendor,
-                            false,
-                            false
-                        )
-                    } else info
-                }
-                secCodecsForced + otherCodecs
-            } else {
-                decoderInfos
-            }
-
-            if (mimeType.equals(MimeTypes.AUDIO_ALAC, ignoreCase = true)) {
-                val softwareDecoders = samsungPreferred.filterNot { it.hardwareAccelerated }
-                softwareDecoders.ifEmpty { emptyList() }
-            } else {
-                samsungPreferred.sortedByDescending { it.hardwareAccelerated }
-            }
+            AudioDecoderPolicy.selectPlatformDecoders(mimeType, decoderInfos)
         }
         val renderersFactory = object : DefaultRenderersFactory(context) {
             override fun buildAudioSink(

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AudioMetaUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AudioMetaUtils.kt
@@ -145,6 +145,11 @@ object AudioMetaUtils {
             normalized == "audio/vnd.dts" ||
                 normalized == "audio/vnd.dts.hd" -> "dts"
 
+            normalized == "audio/midi" ||
+                normalized == "audio/x-midi" ||
+                normalized == "audio/sp-midi" ||
+                normalized == "audio/x-mid" -> "midi"
+
             normalized.contains("mp4a") -> "m4a"
             normalized.contains("flac") -> "flac"
             normalized.contains("opus") -> "opus"
@@ -158,6 +163,7 @@ object AudioMetaUtils {
             normalized.contains("wma") -> "wma"
             normalized.contains("dts") -> "dts"
             normalized.contains("eac3") || normalized.contains("ac3") -> "ac3"
+            normalized.contains("midi") || normalized.contains("x-mid") -> "midi"
             normalized.startsWith("audio/") -> normalized.substringAfter("audio/").ifBlank { "-" }
             else -> "-"
         }

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtils.kt
@@ -2,19 +2,43 @@ package com.theveloper.pixelplay.utils
 
 import android.provider.MediaStore
 
+private val MIDI_MIME_SELECTION_ARGS = arrayOf(
+    "audio/midi",
+    "audio/x-midi",
+    "audio/sp-midi",
+    "audio/x-mid"
+)
+private val MIDI_EXTENSION_SELECTION_ARGS = arrayOf(
+    "%.mid",
+    "%.midi"
+)
+
 /**
  * Builds the baseline MediaStore selection for user-facing local audio.
  *
  * We intentionally do not rely on [MediaStore.Audio.Media.IS_MUSIC] here because some devices
  * and scanners leave valid songs flagged as non-music, which makes library sync and folder
  * browsing appear to "cap out" below the real file count for specific users.
+ *
+ * MIDI files may be indexed with incomplete duration metadata, so explicit MIDI MIME/path
+ * matches bypass the duration floor and are left to playback capability checks.
  */
 fun buildLocalAudioSelection(minDurationMs: Int): Pair<String, Array<String>> {
     val clampedMinDurationMs = minDurationMs.coerceAtLeast(0)
+    val midiMimePlaceholders = MIDI_MIME_SELECTION_ARGS.joinToString(",") { "?" }
+    val midiExtensionSelection = MIDI_EXTENSION_SELECTION_ARGS.joinToString(" OR ") {
+        "LOWER(${MediaStore.Audio.Media.DATA}) LIKE ?"
+    }
     val selection = buildString {
+        append("(")
         append("${MediaStore.Audio.Media.DURATION} >= ?")
+        append(" OR LOWER(COALESCE(${MediaStore.Audio.Media.MIME_TYPE}, '')) IN ($midiMimePlaceholders)")
+        append(" OR $midiExtensionSelection")
+        append(")")
         append(" AND COALESCE(${MediaStore.Audio.Media.TITLE}, '') != ''")
         append(" AND ${MediaStore.Audio.Media.DATA} IS NOT NULL")
     }
-    return selection to arrayOf(clampedMinDurationMs.toString())
+    return selection to arrayOf(clampedMinDurationMs.toString()) +
+        MIDI_MIME_SELECTION_ARGS +
+        MIDI_EXTENSION_SELECTION_ARGS
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/player/AudioDecoderPolicyTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/player/AudioDecoderPolicyTest.kt
@@ -1,0 +1,51 @@
+package com.theveloper.pixelplay.data.service.player
+
+import androidx.media3.common.MimeTypes
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class AudioDecoderPolicyTest {
+
+    @Test
+    fun selectPlatformDecoders_routesAlacToExtensionRenderer() {
+        val decoders = listOf("c2.qti.alac.decoder", "c2.android.alac.decoder")
+
+        val selected = AudioDecoderPolicy.selectPlatformDecoders(MimeTypes.AUDIO_ALAC, decoders)
+
+        assertThat(selected).isEmpty()
+    }
+
+    @Test
+    fun selectPlatformDecoders_routesMidiToExtensionRenderer() {
+        val decoders = listOf("platform-midi-decoder")
+
+        val selected = AudioDecoderPolicy.selectPlatformDecoders(MimeTypes.AUDIO_EXOPLAYER_MIDI, decoders)
+
+        assertThat(selected).isEmpty()
+    }
+
+    @Test
+    fun selectPlatformDecoders_preservesMedia3OrderForCoreFormats() {
+        val decoders = listOf("c2.android.aac.decoder", "c2.qti.aac.decoder")
+
+        val selected = AudioDecoderPolicy.selectPlatformDecoders(MimeTypes.AUDIO_AAC, decoders)
+
+        assertThat(selected).containsExactlyElementsIn(decoders).inOrder()
+    }
+
+    @Test
+    fun isLikelyHardwareDecoder_marksSoftwareRenderersAsSoftware() {
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("OMX.google.aac.decoder")).isFalse()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("c2.android.aac.decoder")).isFalse()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("ffmpegAudioRenderer")).isFalse()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("MidiRenderer(JSyn)")).isFalse()
+    }
+
+    @Test
+    fun isLikelyHardwareDecoder_marksVendorCodecsAsHardware() {
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("c2.qti.aac.decoder")).isTrue()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("c2.qti.flac.decoder")).isTrue()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("OMX.qcom.audio.decoder.aac")).isTrue()
+        assertThat(AudioDecoderPolicy.isLikelyHardwareDecoder("c2.sec.aac.decoder")).isTrue()
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaStoreSelectionUtilsTest.kt
@@ -15,13 +15,26 @@ class MediaStoreSelectionUtilsTest {
         assertFalse(selection.contains(MediaStore.Audio.Media.IS_MUSIC))
         assertTrue(selection.contains(MediaStore.Audio.Media.DURATION))
         assertTrue(selection.contains(MediaStore.Audio.Media.TITLE))
-        assertArrayEquals(arrayOf("10000"), selectionArgs)
+        assertArrayEquals(
+            arrayOf("10000", "audio/midi", "audio/x-midi", "audio/sp-midi", "audio/x-mid", "%.mid", "%.midi"),
+            selectionArgs
+        )
     }
 
     @Test
     fun `buildLocalAudioSelection clamps negative durations`() {
         val (_, selectionArgs) = buildLocalAudioSelection(-250)
 
-        assertArrayEquals(arrayOf("0"), selectionArgs)
+        assertTrue(selectionArgs.isNotEmpty())
+        assertArrayEquals(arrayOf("0"), selectionArgs.take(1).toTypedArray())
+    }
+
+    @Test
+    fun `buildLocalAudioSelection includes midi duration bypass`() {
+        val (selection, _) = buildLocalAudioSelection(10_000)
+
+        assertTrue(selection.contains(MediaStore.Audio.Media.MIME_TYPE))
+        assertTrue(selection.contains("audio_media._data") || selection.contains(MediaStore.Audio.Media.DATA))
+        assertTrue(selection.contains("LIKE"))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,6 +143,7 @@ androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltNa
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "composeMaterialIcons" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMaterialIcons" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Session" }
+androidx-media3-exoplayer-midi = { module = "androidx.media3:media3-exoplayer-midi", version.ref = "media3Session" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3Session" }
 androidx-media3-transformer = { module = "androidx.media3:media3-transformer", version.ref = "media3Transformer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Session" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ dependencyResolutionManagement {
         maven("https://jitpack.io") {
             content {
                 includeGroup("com.github.FaceOnLive")
+                includeGroup("com.github.philburk")
                 includeGroup("com.github.racra")
                 includeGroup("com.github.tdlibx")
             }


### PR DESCRIPTION
This change introduces support for MIDI playback using the Media3 MIDI extension and centralizes decoder selection logic.

- Adds `androidx.media3:media3-exoplayer-midi` dependency and necessary ProGuard rules for MIDI and JSyn.
- Introduces `AudioDecoderPolicy` to manage decoder routing, ensuring formats like ALAC and MIDI are handled by extension renderers rather than platform decoders.
- Refactors hardware decoder detection in `DualPlayerEngine` to use the new policy, removing device-specific hardcoding.
- Updates `MediaStoreSelectionUtils` to include MIDI files in media queries by MIME type and file extension, bypassing standard duration filters as MIDI files often lack duration metadata.
- Updates `GDriveConstants` and `AudioMetaUtils` to recognize MIDI MIME types.
- Adds unit tests for `AudioDecoderPolicy` and updates `MediaStoreSelectionUtilsTest`.