### PR TITLE
fix: wait for player collapse before closing delay gate

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -133,6 +133,7 @@ import com.theveloper.pixelplay.utils.ValidatedLyricsImport
 import com.theveloper.pixelplay.utils.formatDuration
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import timber.log.Timber
@@ -1988,7 +1989,13 @@ private fun DelayedContent(
                 return@LaunchedEffect
             }
 
-            isDelayGateOpen = isExpandedOverride
+            if (isExpandedOverride) {
+                isDelayGateOpen = true
+            } else {
+                snapshotFlow { expansionFractionProvider().coerceIn(0f, 1f) }
+                    .first { fraction -> fraction <= 0.001f }
+                isDelayGateOpen = false
+            }
             return@LaunchedEffect
         }
 


### PR DESCRIPTION
Updates `FullPlayerContent` to ensure `isDelayGateOpen` is only set to false after the expansion fraction reaches near-zero. This prevents premature state updates while the player is still animating to a collapsed state.