### PR TITLE
refactor: restrict local album art to embedded tags and bump cache to v3

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
@@ -16,7 +16,7 @@ import java.io.FileInputStream
 import java.io.InputStream
 
 object AlbumArtUtils {
-    private const val CACHE_VERSION_SUFFIX = "_v2"
+    private const val CACHE_VERSION_SUFFIX = "_v3"
 
     // P2-1: Dedicated app-level scope to replace GlobalScope.
     // SupervisorJob ensures child failures don't cancel sibling coroutines.
@@ -39,11 +39,23 @@ object AlbumArtUtils {
         "music",
         "songs",
         "audio",
-        "telegram audio"
+        "telegram audio",
+        "studio",
+        "gallery",
+        "pictures",
+        "photos",
+        "images",
+        "dcim",
+        "camera",
+        "screenshots"
     )
 
     /**
-     * Main function to get album art - tries multiple methods
+     * Main function to get album art for local songs.
+     *
+     * Local artwork is intentionally embedded-only. Falling back to folder images such as
+     * cover.jpg/thumb.jpg can pick unrelated Gallery files when music is stored in mixed
+     * directories, and can duplicate the same image across unrelated tracks.
      */
     fun getAlbumArtUri(
         appContext: Context,
@@ -123,13 +135,6 @@ object AlbumArtUtils {
             return cachedFile.takeIf { it.exists() && it.length() > 0 }
         }
 
-        getExternalAlbumArtUri(resolvedPath)?.let { externalUri ->
-            if (copyUriToCache(appContext, externalUri, cachedFile) != null) {
-                noArtFile.delete()
-                return cachedFile
-            }
-        }
-
         cachedFile.delete()
         noArtFile.createNewFile()
         return null
@@ -190,18 +195,16 @@ object AlbumArtUtils {
             return true
         }
 
-        if (getExternalAlbumArtUri(filePath) != null) {
-            noArtFile.delete()
-            return true
-        }
-
         cachedFile.delete()
         noArtFile.createNewFile()
         return false
     }
 
     /**
-     * Look for external album art files in the same directory
+     * Look for external album art files in the same directory.
+     *
+     * This is kept for explicit, controlled callers only. The default local-song artwork path
+     * must remain embedded-only so the app does not pull unrelated personal Gallery files.
      */
     fun getExternalAlbumArtUri(filePath: String): Uri? {
         return runCatching {
@@ -263,10 +266,14 @@ object AlbumArtUtils {
      * Delete both the cached artwork and the "no art" marker for a specific song.
      */
     fun clearCacheForSong(appContext: Context, songId: Long) {
-        getCachedAlbumArtFile(appContext, songId).delete()
-        noArtMarkerFile(appContext, songId).delete()
-        legacyCachedAlbumArtFile(appContext, songId).delete()
-        legacyNoArtMarkerFile(appContext, songId).delete()
+        listOf(
+            getCachedAlbumArtFile(appContext, songId),
+            noArtMarkerFile(appContext, songId),
+            legacyCachedAlbumArtFile(appContext, songId, "_v2"),
+            legacyNoArtMarkerFile(appContext, songId, "_v2"),
+            legacyCachedAlbumArtFile(appContext, songId),
+            legacyNoArtMarkerFile(appContext, songId)
+        ).forEach { it.delete() }
     }
 
     // Album art lives in filesDir (persistent) instead of cacheDir, because Android can
@@ -333,12 +340,20 @@ object AlbumArtUtils {
         return File(getAlbumArtDir(appContext), "song_art_${songId}${CACHE_VERSION_SUFFIX}_no.jpg")
     }
 
-    private fun legacyCachedAlbumArtFile(appContext: Context, songId: Long): File {
-        return File(getAlbumArtDir(appContext), "song_art_${songId}.jpg")
+    private fun legacyCachedAlbumArtFile(
+        appContext: Context,
+        songId: Long,
+        versionSuffix: String = ""
+    ): File {
+        return File(getAlbumArtDir(appContext), "song_art_${songId}${versionSuffix}.jpg")
     }
 
-    private fun legacyNoArtMarkerFile(appContext: Context, songId: Long): File {
-        return File(getAlbumArtDir(appContext), "song_art_${songId}_no.jpg")
+    private fun legacyNoArtMarkerFile(
+        appContext: Context,
+        songId: Long,
+        versionSuffix: String = ""
+    ): File {
+        return File(getAlbumArtDir(appContext), "song_art_${songId}${versionSuffix}_no.jpg")
     }
 
     private data class MediaStoreSongInfo(
@@ -399,24 +414,6 @@ object AlbumArtUtils {
 
         return runCatching {
             AudioMetadataReader.read(File(filePath))?.artwork?.bytes?.takeIf { it.isNotEmpty() }
-        }.getOrNull()
-    }
-
-    private fun copyUriToCache(
-        appContext: Context,
-        sourceUri: Uri,
-        targetFile: File
-    ): File? {
-        return runCatching {
-            openArtworkInputStream(appContext, sourceUri)?.use { input ->
-                targetFile.outputStream().use { output -> input.copyTo(output) }
-            } ?: return null
-
-            appScope.launch {
-                AlbumArtCacheManager.cleanCacheIfNeeded(appContext, AlbumArtCacheManager.configuredCacheLimitMb)
-            }
-
-            targetFile
         }.getOrNull()
     }
 

--- a/app/src/test/java/com/theveloper/pixelplay/utils/AlbumArtUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/AlbumArtUtilsTest.kt
@@ -2,7 +2,7 @@ package com.theveloper.pixelplay.utils
 
 import com.google.common.truth.Truth.assertThat
 import kotlin.io.path.createTempDirectory
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AlbumArtUtilsTest {
 
@@ -38,6 +38,19 @@ class AlbumArtUtilsTest {
         val downloadsDir = root.resolve("Downloads").apply { mkdirs() }
         val songFile = downloadsDir.resolve("Fresh Track.mp3").apply { writeBytes(byteArrayOf(1, 2, 3)) }
         downloadsDir.resolve("cover.jpg").writeBytes(ByteArray(2048) { 5 })
+
+        val resolved = AlbumArtUtils.findExternalAlbumArtFile(songFile.absolutePath)
+
+        assertThat(resolved).isNull()
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun findExternalAlbumArtFile_ignoresStudioGalleryFolder() {
+        val root = createTempDirectory("album-art-test").toFile()
+        val studioDir = root.resolve("Studio").apply { mkdirs() }
+        val songFile = studioDir.resolve("Voice Note.mp3").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        studioDir.resolve("cover.jpg").writeBytes(ByteArray(2048) { 5 })
 
         val resolved = AlbumArtUtils.findExternalAlbumArtFile(songFile.absolutePath)
 


### PR DESCRIPTION
Restricts local song artwork to embedded metadata only to prevent the app from picking up unrelated images (e.g., from Gallery or DCIM folders) as album art.

- Updates `CACHE_VERSION_SUFFIX` to `_v3` and refactors `clearCacheForSong` to clean up legacy `_v2` and original cache files.
- Expands the list of ignored directories to include common media folders like "dcim", "camera", "screenshots", and "gallery".
- Removes automatic external artwork resolution from the primary `getAlbumArtUri` and `hasAlbumArt` flows.
- Migrates `AlbumArtUtilsTest` to JUnit 5 and adds a test case to verify directory exclusion logic.
- Removes unused `copyUriToCache` function.