### PR TITLE
Refactor listening stats tracking to MusicService

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -95,6 +95,7 @@ import com.theveloper.pixelplay.utils.ArtworkTransportSanitizer
 import com.theveloper.pixelplay.utils.MediaItemBuilder
 import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
 import com.theveloper.pixelplay.di.AppScope
+import com.theveloper.pixelplay.presentation.viewmodel.ListeningStatsTracker
 import kotlin.math.abs
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
@@ -140,6 +141,8 @@ class MusicService : MediaLibraryService() {
     @Inject
     lateinit var navidromeRepository: NavidromeRepository
     @Inject
+    lateinit var listeningStatsTracker: ListeningStatsTracker
+    @Inject
     @AppScope
     lateinit var appScope: CoroutineScope
 
@@ -179,6 +182,7 @@ class MusicService : MediaLibraryService() {
     private var castSessionManagerListener: SessionManagerListener<CastSession>? = null
     private var castRemoteClientCallback: RemoteMediaClient.Callback? = null
     private var observedCastSession: CastSession? = null
+    private var activeCastStatsOccurrenceId: String? = null
     private var playbackSnapshotPersistJob: Job? = null
     private var isRestoringPlaybackSnapshot = false
     private var isPlaybackUnloadInProgress = false
@@ -292,6 +296,7 @@ class MusicService : MediaLibraryService() {
         }
 
         Timber.tag("MusicService").d(logMessage)
+        syncLocalListeningStatsFromPlayer(player)
         requestWidgetFullUpdate(force = true)
         refreshMediaSessionUi(session)
     }
@@ -310,6 +315,48 @@ class MusicService : MediaLibraryService() {
             engine.incomingTrackReplayGainVolume = cachedVolume
         }
         applyReplayGain(incomingItem)
+    }
+
+    private fun syncLocalListeningStatsFromPlayer(
+        player: Player = engine.masterPlayer,
+        forceNewSession: Boolean = false
+    ) {
+        val mediaItem = player.currentMediaItem
+        val songId = mediaItem?.mediaId?.takeIf { it.isNotBlank() }
+        if (songId == null) {
+            if (
+                player.mediaItemCount == 0 ||
+                player.playbackState == Player.STATE_IDLE ||
+                player.playbackState == Player.STATE_ENDED
+            ) {
+                listeningStatsTracker.onPlaybackStopped()
+            }
+            return
+        }
+
+        val positionMs = player.currentPosition.coerceAtLeast(0L)
+        val durationMs = player.duration
+        val fallbackDurationMs = mediaItem.mediaMetadata.extras
+            ?.getLong(MediaItemBuilder.EXTERNAL_EXTRA_DURATION, 0L)
+            ?: 0L
+
+        if (forceNewSession) {
+            listeningStatsTracker.onTrackChanged(
+                songId = songId,
+                positionMs = positionMs,
+                durationMs = durationMs,
+                fallbackDurationMs = fallbackDurationMs,
+                isPlaying = player.isPlaying
+            )
+        } else {
+            listeningStatsTracker.ensureSession(
+                songId = songId,
+                positionMs = positionMs,
+                durationMs = durationMs,
+                fallbackDurationMs = fallbackDurationMs,
+                isPlaying = player.isPlaying
+            )
+        }
     }
 
     override fun onCreate() {
@@ -342,10 +389,12 @@ class MusicService : MediaLibraryService() {
         }
 
         super.onCreate()
+        listeningStatsTracker.initialize(appScope)
         
         // Ensure engine is ready (re-initialize if service was restarted)
         engine.initialize()
         userSelectedVolume = engine.masterPlayer.volume.coerceIn(0f, 1f)
+        syncLocalListeningStatsFromPlayer(engine.masterPlayer)
 
         engine.masterPlayer.addListener(playerListener)
 
@@ -1102,8 +1151,9 @@ class MusicService : MediaLibraryService() {
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            val player = engine.masterPlayer
+            val player = mediaSession?.player ?: engine.masterPlayer
             Timber.tag(TAG).d("onIsPlayingChanged: $isPlaying. Duration: ${player.duration}, Seekable: ${player.isCurrentMediaItemSeekable}")
+            syncLocalListeningStatsFromPlayer(player)
             
             if (isPlaying) {
                 reportNavidromePlayback("playing")
@@ -1152,7 +1202,8 @@ class MusicService : MediaLibraryService() {
         override fun onPlaybackStateChanged(playbackState: Int) {
             Timber.tag(TAG).d("Playback state changed: $playbackState")
             if (playbackState == Player.STATE_ENDED) {
-                val mediaItem = engine.masterPlayer.currentMediaItem
+                listeningStatsTracker.finalizeCurrentSession()
+                val mediaItem = (mediaSession?.player ?: engine.masterPlayer).currentMediaItem
                 getNavidromeId(mediaItem)?.let { navidromeId ->
                     appScope.launch(Dispatchers.IO) {
                         navidromeRepository.scrobble(navidromeId, submission = true)
@@ -1162,6 +1213,8 @@ class MusicService : MediaLibraryService() {
                 endOfTrackTimerSongId = null
                 reportNavidromePlayback("stopped")
                 stopNavidromePlaybackReporting()
+            } else {
+                syncLocalListeningStatsFromPlayer(mediaSession?.player ?: engine.masterPlayer)
             }
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist(immediate = playbackState == Player.STATE_IDLE)
@@ -1221,6 +1274,7 @@ class MusicService : MediaLibraryService() {
         }
 
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            syncLocalListeningStatsFromPlayer(mediaSession?.player ?: engine.masterPlayer, forceNewSession = true)
             if (isNavidromeMediaItem(mediaItem)) {
                 reportNavidromePlayback("starting")
                 if (engine.masterPlayer.isPlaying) {
@@ -1457,14 +1511,17 @@ class MusicService : MediaLibraryService() {
 
         val remoteCallback = object : RemoteMediaClient.Callback() {
             override fun onStatusUpdated() {
+                syncCastListeningStatsFromRemote()
                 requestWidgetFullUpdate(force = false)
             }
 
             override fun onMetadataUpdated() {
+                syncCastListeningStatsFromRemote()
                 requestWidgetFullUpdate(force = false)
             }
 
             override fun onQueueStatusUpdated() {
+                syncCastListeningStatsFromRemote()
                 requestWidgetFullUpdate(force = false)
             }
 
@@ -1523,6 +1580,10 @@ class MusicService : MediaLibraryService() {
                 runCatching { remoteClient.registerCallback(callback) }
             }
             remoteClient.requestStatus()
+            syncCastListeningStatsFromRemote()
+        } ?: run {
+            activeCastStatsOccurrenceId = null
+            listeningStatsTracker.onPlaybackStopped()
         }
         requestWidgetFullUpdate(force = true)
     }
@@ -1571,6 +1632,7 @@ class MusicService : MediaLibraryService() {
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaSession
 
     override fun onDestroy() {
+        listeningStatsTracker.finalizeCurrentSession(forceSynchronousPersistence = true)
         reportNavidromePlayback("stopped")
         stopNavidromePlaybackReporting()
         playbackSnapshotPersistJob?.cancel()
@@ -1964,6 +2026,7 @@ class MusicService : MediaLibraryService() {
     }
 
     private data class RemotePlaybackSnapshot(
+        val occurrenceId: String,
         val songId: String?,
         val title: String,
         val artist: String,
@@ -1974,6 +2037,34 @@ class MusicService : MediaLibraryService() {
         val repeatMode: Int,
         val isShuffleEnabled: Boolean,
     )
+
+    private fun syncCastListeningStatsFromRemote() {
+        val snapshot = resolveCastRemoteSnapshot() ?: return
+        val songId = snapshot.songId?.takeIf { it.isNotBlank() }
+        if (songId == null) {
+            activeCastStatsOccurrenceId = null
+            listeningStatsTracker.onPlaybackStopped()
+            return
+        }
+
+        if (activeCastStatsOccurrenceId != snapshot.occurrenceId) {
+            activeCastStatsOccurrenceId = snapshot.occurrenceId
+            listeningStatsTracker.onTrackChanged(
+                songId = songId,
+                positionMs = snapshot.currentPositionMs,
+                durationMs = snapshot.totalDurationMs,
+                isPlaying = snapshot.isPlaying
+            )
+            return
+        }
+
+        listeningStatsTracker.ensureSession(
+            songId = songId,
+            positionMs = snapshot.currentPositionMs,
+            durationMs = snapshot.totalDurationMs,
+            isPlaying = snapshot.isPlaying
+        )
+    }
 
     private fun resolveCastRemoteSnapshot(): RemotePlaybackSnapshot? {
         val remoteClient = observedCastSession?.remoteMediaClient
@@ -1996,6 +2087,13 @@ class MusicService : MediaLibraryService() {
             ?.customData
             ?.optString("songId")
             ?.takeIf { it.isNotBlank() }
+        val occurrenceId = currentItem
+            ?.itemId
+            ?.takeIf { it > 0 }
+            ?.toString()
+            ?: songId
+            ?: mediaInfo?.contentId
+            ?: return null
 
         val durationHintMs = currentItem
             ?.customData
@@ -2019,6 +2117,7 @@ class MusicService : MediaLibraryService() {
         }
 
         return RemotePlaybackSnapshot(
+            occurrenceId = occurrenceId,
             songId = songId,
             title = metadata?.getString(CastMediaMetadata.KEY_TITLE).orEmpty(),
             artist = metadata?.getString(CastMediaMetadata.KEY_ARTIST).orEmpty(),
@@ -2794,6 +2893,8 @@ class MusicService : MediaLibraryService() {
         } else {
             clearPlaybackSnapshotBlocking()
         }
+
+        listeningStatsTracker.finalizeCurrentSession(forceSynchronousPersistence = true)
 
         player.playWhenReady = false
         player.stop()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
@@ -50,8 +50,7 @@ class CastTransferStateHolder @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val castStateHolder: CastStateHolder,
     private val playbackStateHolder: PlaybackStateHolder,
-    private val dualPlayerEngine: DualPlayerEngine, // For local player control during transfer
-    private val listeningStatsTracker: ListeningStatsTracker
+    private val dualPlayerEngine: DualPlayerEngine // For local player control during transfer
 ) {
     private val CAST_LOG_TAG = "PlayerCastTransfer"
 
@@ -163,7 +162,6 @@ class CastTransferStateHolder @Inject constructor(
                 }
                 castStateHolder.setRemotePosition(progress)
                 lastRemoteStreamPosition = progress
-                listeningStatsTracker.onProgress(progress, lastKnownRemoteIsPlaying)
             }
         }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ListeningStatsTracker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ListeningStatsTracker.kt
@@ -44,14 +44,18 @@ class ListeningStatsTracker @Inject constructor(
      * Must be called to set the coroutine scope for async operations.
      */
     fun initialize(coroutineScope: CoroutineScope) {
-        scope = coroutineScope
-        scope?.launch(Dispatchers.IO) {
+        val activeScope = scope
+        if (activeScope == null || activeScope.coroutineContext[Job]?.isActive != true) {
+            scope = coroutineScope
+        }
+        coroutineScope.launch(Dispatchers.IO) {
             _playbackHistory.value = playbackStatsRepository.loadPlaybackHistory(
                 limit = MAX_INTERNAL_PLAYBACK_HISTORY_ITEMS
             )
         }
     }
 
+    @Synchronized
     fun onVoluntarySelection(songId: String) {
         pendingVoluntarySongId = songId
     }
@@ -62,21 +66,51 @@ class ListeningStatsTracker @Inject constructor(
         durationMs: Long,
         isPlaying: Boolean
     ) {
+        onTrackChanged(
+            songId = song?.id,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            fallbackDurationMs = song?.duration ?: 0L,
+            isPlaying = isPlaying
+        )
+    }
+
+    @Synchronized
+    fun onTrackChanged(
+        songId: String?,
+        positionMs: Long,
+        durationMs: Long,
+        isPlaying: Boolean
+    ) {
+        onTrackChanged(
+            songId = songId,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            fallbackDurationMs = 0L,
+            isPlaying = isPlaying
+        )
+    }
+
+    @Synchronized
+    fun onTrackChanged(
+        songId: String?,
+        positionMs: Long,
+        durationMs: Long,
+        fallbackDurationMs: Long,
+        isPlaying: Boolean
+    ) {
         finalizeCurrentSession()
-        if (song == null) {
+        val safeSongId = songId?.takeIf { it.isNotBlank() }
+        if (safeSongId == null) {
             return
         }
 
         val nowRealtime = SystemClock.elapsedRealtime()
         val nowEpoch = System.currentTimeMillis()
-        val normalizedDuration = when {
-            durationMs > 0 && durationMs != C.TIME_UNSET -> durationMs
-            song.duration > 0 -> song.duration
-            else -> 0L
-        }
+        val normalizedDuration = normalizeDuration(durationMs, fallbackDurationMs)
 
         currentSession = ActiveSession(
-            songId = song.id,
+            songId = safeSongId,
             totalDurationMs = normalizedDuration,
             startedAtEpochMs = nowEpoch,
             lastKnownPositionMs = positionMs.coerceAtLeast(0L),
@@ -84,13 +118,14 @@ class ListeningStatsTracker @Inject constructor(
             lastRealtimeMs = nowRealtime,
             lastUpdateEpochMs = nowEpoch,
             isPlaying = isPlaying,
-            isVoluntary = pendingVoluntarySongId == song.id
+            isVoluntary = pendingVoluntarySongId == safeSongId
         )
-        if (pendingVoluntarySongId == song.id) {
+        if (pendingVoluntarySongId == safeSongId) {
             pendingVoluntarySongId = null
         }
     }
 
+    @Synchronized
     fun onPlayStateChanged(isPlaying: Boolean, positionMs: Long) {
         val session = currentSession ?: return
         val nowRealtime = SystemClock.elapsedRealtime()
@@ -101,6 +136,7 @@ class ListeningStatsTracker @Inject constructor(
         session.lastUpdateEpochMs = System.currentTimeMillis()
     }
 
+    @Synchronized
     fun onProgress(positionMs: Long, isPlaying: Boolean) {
         val session = currentSession ?: return
         val nowRealtime = SystemClock.elapsedRealtime()
@@ -117,13 +153,47 @@ class ListeningStatsTracker @Inject constructor(
         durationMs: Long,
         isPlaying: Boolean
     ) {
-        if (song == null) {
+        ensureSession(
+            songId = song?.id,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            fallbackDurationMs = song?.duration ?: 0L,
+            isPlaying = isPlaying
+        )
+    }
+
+    @Synchronized
+    fun ensureSession(
+        songId: String?,
+        positionMs: Long,
+        durationMs: Long,
+        isPlaying: Boolean
+    ) {
+        ensureSession(
+            songId = songId,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            fallbackDurationMs = 0L,
+            isPlaying = isPlaying
+        )
+    }
+
+    @Synchronized
+    fun ensureSession(
+        songId: String?,
+        positionMs: Long,
+        durationMs: Long,
+        fallbackDurationMs: Long,
+        isPlaying: Boolean
+    ) {
+        val safeSongId = songId?.takeIf { it.isNotBlank() }
+        if (safeSongId == null) {
             finalizeCurrentSession()
             return
         }
         val existing = currentSession
-        if (existing?.songId == song.id) {
-            updateDuration(durationMs)
+        if (existing?.songId == safeSongId) {
+            updateDuration(normalizeDuration(durationMs, fallbackDurationMs))
             val nowRealtime = SystemClock.elapsedRealtime()
             accumulateRealtimeListening(existing, nowRealtime)
             existing.isPlaying = isPlaying
@@ -132,9 +202,16 @@ class ListeningStatsTracker @Inject constructor(
             existing.lastUpdateEpochMs = System.currentTimeMillis()
             return
         }
-        onSongChanged(song, positionMs, durationMs, isPlaying)
+        onTrackChanged(
+            songId = safeSongId,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            fallbackDurationMs = fallbackDurationMs,
+            isPlaying = isPlaying
+        )
     }
 
+    @Synchronized
     fun updateDuration(durationMs: Long) {
         val session = currentSession ?: return
         if (durationMs > 0 && durationMs != C.TIME_UNSET) {
@@ -142,6 +219,7 @@ class ListeningStatsTracker @Inject constructor(
         }
     }
 
+    @Synchronized
     fun finalizeCurrentSession(forceSynchronousPersistence: Boolean = false) {
         val session = currentSession ?: return
         val nowRealtime = SystemClock.elapsedRealtime()
@@ -178,28 +256,24 @@ class ListeningStatsTracker @Inject constructor(
         }
     }
 
+    @Synchronized
     fun onPlaybackStopped() {
         finalizeCurrentSession()
     }
 
+    @Synchronized
     fun onCleared() {
         finalizeCurrentSession(forceSynchronousPersistence = true)
         scope = null
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun persistPlayback(
         songId: String,
         listened: Long,
         timestamp: Long,
         forceSynchronous: Boolean
     ) {
-        val coroutineScope = scope
-        if (!forceSynchronous && coroutineScope != null && coroutineScope.coroutineContext[Job]?.isActive == true) {
-            coroutineScope.launch(Dispatchers.IO) {
-                persistPlaybackInternal(songId = songId, listened = listened, timestamp = timestamp)
-            }
-            return
-        }
         persistenceScope.launch {
             runCatching {
                 persistPlaybackInternal(songId = songId, listened = listened, timestamp = timestamp)
@@ -230,9 +304,12 @@ class ListeningStatsTracker @Inject constructor(
         }
     }
 
-    private fun CoroutineScope?.isActive(): Boolean {
-        val job = this?.coroutineContext?.get(Job)
-        return job?.isActive == true
+    private fun normalizeDuration(durationMs: Long, fallbackDurationMs: Long): Long {
+        return when {
+            durationMs > 0 && durationMs != C.TIME_UNSET -> durationMs
+            fallbackDurationMs > 0 && fallbackDurationMs != C.TIME_UNSET -> fallbackDurationMs
+            else -> 0L
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -36,7 +36,6 @@ class PlaybackStateHolder @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val castStateHolder: CastStateHolder,
     private val queueStateHolder: QueueStateHolder,
-    private val listeningStatsTracker: ListeningStatsTracker,
     @param:ApplicationContext private val appContext: Context
 ) {
     companion object {
@@ -522,7 +521,6 @@ class PlaybackStateHolder @Inject constructor(
                             castStateHolder.setRemotePosition(currentPosition)
                         }
 
-                        listeningStatsTracker.onProgress(currentPosition, isRemotePlaying)
                         val nextPosition = if (isRemotelySeeking) _currentPosition.value else currentPosition
                         if (_currentPosition.value != nextPosition) {
                             _currentPosition.value = nextPosition
@@ -564,28 +562,27 @@ class PlaybackStateHolder @Inject constructor(
                             continue
                         }
 
-                         val currentPosition = controller.currentPosition.coerceAtLeast(0L)
-                         val songDurationHint = visibleSong?.duration ?: 0L
-                         val duration = resolveEffectiveDuration(
-                             reportedDurationMs = controller.duration,
-                             songDurationHintMs = songDurationHint,
-                             currentPositionMs = currentPosition
-                         )
-                         
-                         listeningStatsTracker.onProgress(currentPosition, true)
-                         val resolvedPosition = resolveUiPosition(currentMediaId, currentPosition)
-                         if (_currentPosition.value != resolvedPosition) {
-                             _currentPosition.value = resolvedPosition
+                          val currentPosition = controller.currentPosition.coerceAtLeast(0L)
+                          val songDurationHint = visibleSong?.duration ?: 0L
+                          val duration = resolveEffectiveDuration(
+                              reportedDurationMs = controller.duration,
+                              songDurationHintMs = songDurationHint,
+                              currentPositionMs = currentPosition
+                          )
+
+                          val resolvedPosition = resolveUiPosition(currentMediaId, currentPosition)
+                          if (_currentPosition.value != resolvedPosition) {
+                              _currentPosition.value = resolvedPosition
+                          }
+
+                          _stablePlayerState.update { state ->
+                              if (state.totalDuration == duration) {
+                                  state
+                              } else {
+                                  state.copy(totalDuration = duration)
+                              }
                          }
-                         
-                         _stablePlayerState.update { state ->
-                             if (state.totalDuration == duration) {
-                                 state
-                             } else {
-                                 state.copy(totalDuration = duration)
-                             }
-                        }
-                     }
+                      }
                 }
                 delay(tickMs)
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2718,12 +2718,6 @@ class PlayerViewModel @Inject constructor(
                     val currentUri = playbackStateHolder.stablePlayerState.value.currentSong?.albumArtUriString
                     themeStateHolder.extractAndGenerateColorScheme(uri, currentUri)
                 }
-                listeningStatsTracker.onSongChanged(
-                    song = song,
-                    positionMs = initialPosition,
-                    durationMs = resolvedDuration,
-                    isPlaying = playerCtrl.isPlaying
-                )
                 loadLyricsForCurrentSong()
                 if (playerCtrl.isPlaying) {
                     _isSheetVisible.value = true
@@ -2757,10 +2751,6 @@ class PlayerViewModel @Inject constructor(
                         playWhenReady = playerCtrl.playWhenReady
                     )
                 }
-                listeningStatsTracker.onPlayStateChanged(
-                    isPlaying = isPlaying,
-                    positionMs = playerCtrl.currentPosition.coerceAtLeast(0L)
-                )
                 if (isPlaying) {
                     _isSheetVisible.value = true
                     clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
@@ -2805,7 +2795,6 @@ class PlayerViewModel @Inject constructor(
                     }
 
                     mediaItem?.let { transitionedItem ->
-                        listeningStatsTracker.finalizeCurrentSession()
                         val song = resolveSongFromMediaItem(transitionedItem)
                         
                         // Offline check for Telegram songs
@@ -2850,12 +2839,6 @@ class PlayerViewModel @Inject constructor(
                         )
 
                         song?.let { currentSongValue ->
-                            listeningStatsTracker.onSongChanged(
-                                song = currentSongValue,
-                                positionMs = transitionPosition,
-                                durationMs = resolvedDuration,
-                                isPlaying = playerCtrl.isPlaying
-                            )
                             viewModelScope.launch {
                                 val uri = currentSongValue.albumArtUriString?.toUri()
                                 val currentUri = playbackStateHolder.stablePlayerState.value.currentSong?.albumArtUriString
@@ -2915,16 +2898,11 @@ class PlayerViewModel @Inject constructor(
                     )
                     syncPlaybackPositionFromPlayer(playerCtrl.currentMediaItem?.mediaId, readyPosition)
                     playbackStateHolder.updateStablePlayerState { it.copy(totalDuration = resolvedDuration) }
-                    listeningStatsTracker.updateDuration(resolvedDuration)
                     startProgressUpdates()
-                }
-                if (playbackState == Player.STATE_ENDED) {
-                    listeningStatsTracker.finalizeCurrentSession()
                 }
                 if (playbackState == Player.STATE_IDLE && playerCtrl.mediaItemCount == 0) {
                     clearPreparingSongIfMatching()
                     if (!isCastConnecting.value && !isRemotePlaybackActive.value) {
-                        listeningStatsTracker.onPlaybackStopped()
                         lyricsStateHolder.cancelLoading()
                         playbackStateHolder.updateStablePlayerState {
                             it.copy(
@@ -4340,7 +4318,6 @@ class PlayerViewModel @Inject constructor(
         remoteQueueLoadJob?.cancel()
         castSongUiSyncJob?.cancel()
         stopProgressUpdates()
-        listeningStatsTracker.onCleared()
         castTransferStateHolder.onCleared()
         castStateHolder.onCleared()
         searchStateHolder.onCleared()

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolderTest.kt
@@ -25,7 +25,6 @@ class PlaybackStateHolderTest {
     private val userPreferencesRepository: UserPreferencesRepository = mockk(relaxed = true)
     private val castStateHolder: CastStateHolder = mockk(relaxed = true)
     private val queueStateHolder: QueueStateHolder = mockk(relaxed = true)
-    private val listeningStatsTracker: ListeningStatsTracker = mockk(relaxed = true)
     private val appContext: Context = mockk(relaxed = true)
     private val powerManager: PowerManager = mockk(relaxed = true)
 
@@ -34,7 +33,6 @@ class PlaybackStateHolderTest {
         userPreferencesRepository = userPreferencesRepository,
         castStateHolder = castStateHolder,
         queueStateHolder = queueStateHolder,
-        listeningStatsTracker = listeningStatsTracker,
         appContext = appContext
     )
 


### PR DESCRIPTION
Moves the responsibility of tracking listening statistics from the `PlayerViewModel` and UI state holders to `MusicService`. This ensures more accurate tracking that persists independently of the UI lifecycle and centralizes logic for both local and remote (Cast) playback.

- Refactors `ListeningStatsTracker` to be thread-safe using `@Synchronized` and decouples it from the `Song` data model by using `songId`.
- Introduces `ensureSession` and `onTrackChanged` in `ListeningStatsTracker` to handle state synchronization more robustly.
- Implements `syncLocalListeningStatsFromPlayer` in `MusicService` to update tracking state based on Media3 `Player.Listener` events.
- Adds `syncCastListeningStatsFromRemote` to `MusicService` to support listening stats for Cast sessions via `RemoteMediaClient` callbacks.
- Removes `ListeningStatsTracker` dependencies and manual progress reporting from `PlayerViewModel`, `PlaybackStateHolder`, and `CastTransferStateHolder`.
- Ensures listening sessions are finalized in `MusicService.onDestroy`.