### PR TITLE
feat: implement empty state placeholder for "Your Mix" on Home screen

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -16,23 +16,29 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeExtendedFloatingActionButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -63,6 +69,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -105,11 +112,14 @@ import com.theveloper.pixelplay.presentation.viewmodel.StatsViewModel
 import com.theveloper.pixelplay.ui.theme.ExpTitleTypography
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
+
+private const val HomeLoadingPlaceholderMinDurationMillis = 1200L
 
 // Modern HomeScreen with collapsible top bar and staggered grid layout
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -149,6 +159,22 @@ fun HomeScreen(
             else -> homeMixPreviewSongs
         }
     }
+    var homePlaceholderRefreshGeneration by rememberSaveable { mutableIntStateOf(0) }
+    var hasHomeLoadingMinimumElapsed by rememberSaveable(homePlaceholderRefreshGeneration) {
+        mutableStateOf(false)
+    }
+
+    LaunchedEffect(homePlaceholderRefreshGeneration, yourMixSongs.isEmpty()) {
+        if (yourMixSongs.isEmpty()) {
+            hasHomeLoadingMinimumElapsed = false
+            delay(HomeLoadingPlaceholderMinDurationMillis)
+            hasHomeLoadingMinimumElapsed = true
+        } else {
+            hasHomeLoadingMinimumElapsed = true
+        }
+    }
+
+    val shouldShowYourMixLoadingPlaceholder = yourMixSongs.isEmpty() && !hasHomeLoadingMinimumElapsed
     val recentSongIds = remember(playbackHistory) {
         collectRecentlyPlayedSongIds(
             playbackHistory = playbackHistory,
@@ -198,7 +224,7 @@ fun HomeScreen(
     }
 
     ReportDrawnWhen {
-        yourMixSongs.isNotEmpty() || isBenchmarkMode
+        yourMixSongs.isNotEmpty() || hasHomeLoadingMinimumElapsed || isBenchmarkMode
     }
 
     val yourMixSong: String = "Today's Mix for you"
@@ -283,10 +309,20 @@ fun HomeScreen(
             ) {
                 if (yourMixSongs.isEmpty()) {
                     item(
-                        key = "your_mix_loading_placeholder",
-                        contentType = "your_mix_loading_placeholder"
+                        key = "your_mix_placeholder",
+                        contentType = "your_mix_placeholder"
                     ) {
-                        YourMixLoadingPlaceholder()
+                        if (shouldShowYourMixLoadingPlaceholder) {
+                            YourMixLoadingPlaceholder()
+                        } else {
+                            YourMixEmptyPlaceholder(
+                                onRefresh = {
+                                    homePlaceholderRefreshGeneration++
+                                    settingsViewModel.refreshLibrary()
+                                    playerViewModel.forceUpdateDailyMix()
+                                }
+                            )
+                        }
                     }
                 } else {
                     item(
@@ -525,6 +561,92 @@ private fun YourMixLoadingPlaceholder() {
             modifier = Modifier.size(128.dp),
             color = MaterialTheme.colorScheme.primary
         )
+    }
+}
+
+@Composable
+private fun YourMixEmptyPlaceholder(
+    onRefresh: () -> Unit
+) {
+    val colors = MaterialTheme.colorScheme
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 256.dp)
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Surface(
+                modifier = Modifier.size(76.dp),
+                shape = AbsoluteSmoothCornerShape(
+                    cornerRadiusTL = 28.dp,
+                    smoothnessAsPercentTR = 60,
+                    cornerRadiusBR = 28.dp,
+                    smoothnessAsPercentTL = 60,
+                    cornerRadiusBL = 28.dp,
+                    smoothnessAsPercentBR = 60,
+                    cornerRadiusTR = 28.dp,
+                    smoothnessAsPercentBL = 60,
+                ),
+                color = colors.secondaryContainer,
+                contentColor = colors.onSecondaryContainer
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Rounded.MusicNote,
+                        contentDescription = null,
+                        modifier = Modifier.size(34.dp)
+                    )
+                }
+            }
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                Text(
+                    text = stringResource(R.string.home_empty_placeholder_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = colors.onSurface,
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = stringResource(R.string.home_empty_placeholder_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colors.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            FilledTonalButton(
+                onClick = onRefresh,
+                shape = AbsoluteSmoothCornerShape(
+                    cornerRadiusTL = 22.dp,
+                    smoothnessAsPercentTR = 60,
+                    cornerRadiusBR = 22.dp,
+                    smoothnessAsPercentTL = 60,
+                    cornerRadiusBL = 22.dp,
+                    smoothnessAsPercentBR = 60,
+                    cornerRadiusTR = 22.dp,
+                    smoothnessAsPercentBL = 60,
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(R.string.home_empty_placeholder_refresh))
+            }
+        }
     }
 }
 

--- a/app/src/main/res/values-es/strings_screens.xml
+++ b/app/src/main/res/values-es/strings_screens.xml
@@ -129,6 +129,9 @@
     <string name="dialog_delete_song_message">\"%1$s\" de %2$s\n\nEsta canción se eliminará permanentemente del dispositivo y no podrá recuperarse.</string>
 
     <string name="home_your_mix_title">Tu\nMix</string>
+    <string name="home_empty_placeholder_title">Aun no hay datos para mostrar</string>
+    <string name="home_empty_placeholder_subtitle">Tu mix aparecera aqui cuando PixelPlayer encuentre canciones o sincronice una fuente.</string>
+    <string name="home_empty_placeholder_refresh">Actualizar</string>
     <string name="cd_shuffle_play">Reproducción aleatoria</string>
     <string name="cd_album_art_for_title">Carátula de %1$s</string>
     <string name="cd_options">Opciones</string>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -131,6 +131,9 @@
 
     <!-- Home / detail shared -->
     <string name="home_your_mix_title">Your\nMix</string>
+    <string name="home_empty_placeholder_title">No data to show yet</string>
+    <string name="home_empty_placeholder_subtitle">Your mix will appear here when PixelPlayer finds songs or syncs a source.</string>
+    <string name="home_empty_placeholder_refresh">Refresh</string>
     <string name="cd_shuffle_play">Shuffle Play</string>
     <string name="cd_album_art_for_title">Album art for %1$s</string>
     <string name="cd_options">Options</string>


### PR DESCRIPTION
Introduces a dedicated empty state for the "Your Mix" section when no songs are available. This includes a refresh action and a minimum loading duration to improve UI stability and prevent flickering.

- Adds new string resources for the empty state title, subtitle, and refresh action in English and Spanish.
- Implements `YourMixEmptyPlaceholder` composable featuring a branded icon and a refresh button that triggers library and daily mix updates.
- Updates `HomeScreen` to manage transitions between loading and empty states using a 1.2-second minimum delay.
- Refactors the "Your Mix" section in the main `LazyColumn` to conditionally display `YourMixLoadingPlaceholder` or `YourMixEmptyPlaceholder` based on data availability and the loading timer.