### PR TITLE
Fix CodeQL alerts and remove green gradients

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseEncryption.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/network/netease/NeteaseEncryption.kt
@@ -50,14 +50,14 @@ object NeteaseEncryption {
         val cipher = when (mode.lowercase(Locale.ROOT)) {
             "cbc" -> {
                 // CBC with PKCS#7 is required for compatibility with the Netease API
-                // codeql[java/weak-cryptographic-algorithm]
+                // lgtm[java/weak-cryptographic-algorithm] Netease's public API requires this wire format.
                 Cipher.getInstance("AES/CBC/PKCS7Padding").apply {
                     init(Cipher.ENCRYPT_MODE, secretKey, IvParameterSpec(iv.toByteArray(StandardCharsets.UTF_8)))
                 }
             }
             "ecb" -> {
                 // ECB with PKCS#7 is required for compatibility with the Netease API
-                // codeql[java/weak-cryptographic-algorithm]
+                // lgtm[java/weak-cryptographic-algorithm] Netease's public API requires this wire format.
                 Cipher.getInstance("AES/ECB/PKCS7Padding").apply {
                     init(Cipher.ENCRYPT_MODE, secretKey)
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -876,7 +876,8 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun createSleepTimerPendingIntent(): PendingIntent {
-        val intent = Intent(this, SleepTimerReceiver::class.java).apply {
+        val intent = Intent(ACTION_SLEEP_TIMER_EXPIRED).apply {
+            component = ComponentName(this@MusicService, SleepTimerReceiver::class.java)
             setPackage(packageName)
         }
         return PendingIntent.getBroadcast(

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -876,8 +876,8 @@ class MusicService : MediaLibraryService() {
     }
 
     private fun createSleepTimerPendingIntent(): PendingIntent {
-        val intent = Intent(ACTION_SLEEP_TIMER_EXPIRED).apply {
-            component = ComponentName(this@MusicService, SleepTimerReceiver::class.java)
+        val intent = Intent(this, SleepTimerReceiver::class.java).apply {
+            action = ACTION_SLEEP_TIMER_EXPIRED
             setPackage(packageName)
         }
         return PendingIntent.getBroadcast(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
@@ -506,17 +505,7 @@ private fun AboutHeroCard(
         tonalElevation = 2.dp,
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    brush = Brush.linearGradient(
-                        listOf(
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.18f),
-                            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.14f),
-                            MaterialTheme.colorScheme.surfaceContainerLow,
-                        ),
-                    ),
-                ),
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/auth/TelegramLoginActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/auth/TelegramLoginActivity.kt
@@ -82,7 +82,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
@@ -189,11 +188,6 @@ fun TelegramLoginScreen(
         }
     }
 
-    val gradientColors = listOf(
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.55f),
-        MaterialTheme.colorScheme.surface
-    )
-
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         topBar = {
@@ -234,7 +228,7 @@ fun TelegramLoginScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Brush.verticalGradient(gradientColors))
+                .background(MaterialTheme.colorScheme.surface)
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp, vertical = 20.dp),

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
@@ -71,19 +71,18 @@ class SleepTimerStateHolder @Inject constructor(
     private var currentSongIdProvider: (() -> StateFlow<String?>)? = null
     private var songTitleResolver: ((String?) -> String)? = null
 
-    private fun sleepTimerIntent(): Intent =
-        Intent(context, SleepTimerReceiver::class.java).apply {
+    private fun sleepTimerPendingIntent(): PendingIntent {
+        val intent = Intent(context, SleepTimerReceiver::class.java).apply {
             action = SLEEP_TIMER_ACTION
             setPackage(context.packageName)
         }
-
-    private fun sleepTimerPendingIntent(): PendingIntent =
-        PendingIntent.getBroadcast(
+        return PendingIntent.getBroadcast(
             context,
             0,
-            sleepTimerIntent(),
+            intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+    }
 
     /**
      * Initialize with dependencies from ViewModel.

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
@@ -2,6 +2,7 @@ package com.theveloper.pixelplay.presentation.viewmodel
 
 import android.app.AlarmManager
 import android.app.PendingIntent
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -71,6 +72,20 @@ class SleepTimerStateHolder @Inject constructor(
     private var currentSongIdProvider: (() -> StateFlow<String?>)? = null
     private var songTitleResolver: ((String?) -> String)? = null
 
+    private fun sleepTimerIntent(): Intent =
+        Intent(SLEEP_TIMER_ACTION).apply {
+            component = ComponentName(context, SleepTimerReceiver::class.java)
+            setPackage(context.packageName)
+        }
+
+    private fun sleepTimerPendingIntent(): PendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            0,
+            sleepTimerIntent(),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
     /**
      * Initialize with dependencies from ViewModel.
      * Must be called before using timer functions.
@@ -113,15 +128,7 @@ class SleepTimerStateHolder @Inject constructor(
         )
 
         // Schedule alarm for reliable triggering
-        val intent = Intent(context, SleepTimerReceiver::class.java).apply {
-            setPackage(context.packageName)
-        }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val pendingIntent = sleepTimerPendingIntent()
 
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -257,15 +264,7 @@ class SleepTimerStateHolder @Inject constructor(
         val wasAnythingActive = _activeTimerValueDisplay.value != null
 
         // Cancel Alarm
-        val intent = Intent(context, SleepTimerReceiver::class.java).apply {
-            setPackage(context.packageName)
-        }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
+        val pendingIntent = sleepTimerPendingIntent()
         alarmManager.cancel(pendingIntent)
 
         // Cancel duration timer
@@ -303,5 +302,9 @@ class SleepTimerStateHolder @Inject constructor(
         mediaControllerProvider = null
         currentSongIdProvider = null
         songTitleResolver = null
+    }
+
+    private companion object {
+        const val SLEEP_TIMER_ACTION = "com.theveloper.pixelplay.action.SLEEP_TIMER_EXPIRED"
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SleepTimerStateHolder.kt
@@ -2,7 +2,6 @@ package com.theveloper.pixelplay.presentation.viewmodel
 
 import android.app.AlarmManager
 import android.app.PendingIntent
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -73,8 +72,8 @@ class SleepTimerStateHolder @Inject constructor(
     private var songTitleResolver: ((String?) -> String)? = null
 
     private fun sleepTimerIntent(): Intent =
-        Intent(SLEEP_TIMER_ACTION).apply {
-            component = ComponentName(context, SleepTimerReceiver::class.java)
+        Intent(context, SleepTimerReceiver::class.java).apply {
+            action = SLEEP_TIMER_ACTION
             setPackage(context.packageName)
         }
 


### PR DESCRIPTION
## Summary
- remove green gradient treatments from the About hero card and Telegram login background
- make sleep timer PendingIntent targets explicitly component-bound
- document and suppress Netease API-required weak crypto wire formats for CodeQL

## Verification
- git diff --check
- attempted ./gradlew :app:compileDebugKotlin, but JAVA_HOME/java is not configured in this environment