### PR TITLE
Fix multiple UX issues + drop decorative gradients

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -843,28 +843,30 @@ private fun CastDevicesTabContent(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(bottom = 20.dp)
     ) {
-        item(key = "deviceSectionHeader") {
-            DeviceSectionHeader(
-                modifier = Modifier.fillMaxWidth(),
-                hasDevices = state.devices.isNotEmpty(),
-                    onRefresh = onRefresh
-            )
-        }
-
-        item(key = "refreshIndicator") {
-            AnimatedVisibility(
-                visible = state.isRefreshing,
-                enter = fadeIn(animationSpec = tween(200, easing = FastOutSlowInEasing)),
-                exit = fadeOut(animationSpec = tween(180)),
-                label = "refreshIndicator"
-            ) {
-                LinearProgressIndicator(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(18.dp)),
-                    color = colors.primary,
-                    trackColor = colors.primary.copy(alpha = 0.12f)
+        if (!allConnectivityOff) {
+            item(key = "deviceSectionHeader") {
+                DeviceSectionHeader(
+                    modifier = Modifier.fillMaxWidth(),
+                    hasDevices = state.devices.isNotEmpty(),
+                        onRefresh = onRefresh
                 )
+            }
+
+            item(key = "refreshIndicator") {
+                AnimatedVisibility(
+                    visible = state.isRefreshing,
+                    enter = fadeIn(animationSpec = tween(200, easing = FastOutSlowInEasing)),
+                    exit = fadeOut(animationSpec = tween(180)),
+                    label = "refreshIndicator"
+                ) {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(18.dp)),
+                        color = colors.primary,
+                        trackColor = colors.primary.copy(alpha = 0.12f)
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistCreationDialogs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistCreationDialogs.kt
@@ -87,7 +87,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -138,14 +137,6 @@ fun PlaylistCreationTypeDialog(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(
-                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.30f),
-                                MaterialTheme.colorScheme.surfaceContainerHigh
-                            )
-                        )
-                    )
                     .padding(20.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -175,6 +175,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.MoreHoriz
+import androidx.compose.material.icons.rounded.MyLocation
 import androidx.compose.material3.Button
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -303,6 +304,7 @@ fun QueueBottomSheet(
     }
 
     val listState = rememberLazyListState()
+    val queueCoroutineScope = rememberCoroutineScope()
     val displaySongCount = displaySongs.size
 
     // Local order used only while previewing a drag reorder.
@@ -979,6 +981,25 @@ fun QueueBottomSheet(
                             horizontalAlignment = Alignment.CenterHorizontally,
                             verticalArrangement = Arrangement.spacedBy(10.dp)
                         ) {
+                            if (currentSongDisplayIndex >= 0 && currentSongDisplayIndex < displaySongCount) {
+                                QueueToolbarMenuButton(
+                                    text = stringResource(R.string.presentation_batch_e_action_locate_current_song),
+                                    icon = Icons.Rounded.MyLocation,
+                                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                                    onClick = {
+                                        isFabExpanded = false
+                                        queueCoroutineScope.launch {
+                                            val firstVisible = listState.firstVisibleItemIndex
+                                            if (Math.abs(currentSongDisplayIndex - firstVisible) > 20) {
+                                                listState.scrollToItem(currentSongDisplayIndex)
+                                            } else {
+                                                listState.animateScrollToItem(currentSongDisplayIndex)
+                                            }
+                                        }
+                                    }
+                                )
+                            }
                             QueueToolbarMenuButton(
                                 text = stringResource(R.string.presentation_batch_e_action_clear_queue),
                                 icon = Icons.Filled.ClearAll,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
@@ -21,8 +21,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
@@ -160,7 +164,9 @@ fun SongPickerSelectionPane(
     playerViewModel: PlayerViewModel = hiltViewModel()
 ) {
     var searchQuery by remember { mutableStateOf("") }
+    var favoritesOnly by remember { mutableStateOf(false) }
     val pagedSongs = playerViewModel.playlistPickerSongs.collectAsLazyPagingItems()
+    val favoriteIds by playerViewModel.favoriteSongIds.collectAsStateWithLifecycle()
     val searchResultsInitialValue: List<Song>? = remember(searchQuery) {
         if (searchQuery.isBlank()) emptyList() else null
     }
@@ -191,23 +197,63 @@ fun SongPickerSelectionPane(
             onSearchQueryChange = { searchQuery = it }
         )
 
-        if (searchQuery.isBlank()) {
-            SongPickerPagingList(
-                pagedSongs = pagedSongs,
-                selectedSongIds = selectedSongIds,
-                albumShape = albumShape,
-                modifier = Modifier.weight(1f),
-                contentPadding = contentPadding
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            FilterChip(
+                selected = favoritesOnly,
+                onClick = { favoritesOnly = !favoritesOnly },
+                label = { Text(stringResource(R.string.song_picker_filter_favorites)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Rounded.Favorite,
+                        contentDescription = null,
+                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                    )
+                }
             )
-        } else {
-            SongPickerList(
-                filteredSongs = searchResults ?: emptyList(),
-                isLoading = searchResults == null,
-                selectedSongIds = selectedSongIds,
-                albumShape = albumShape,
-                modifier = Modifier.weight(1f),
-                contentPadding = contentPadding
-            )
+        }
+
+        when {
+            searchQuery.isNotBlank() -> {
+                val displayed = (searchResults ?: emptyList()).let { results ->
+                    if (favoritesOnly) results.filter { it.id in favoriteIds } else results
+                }
+                SongPickerList(
+                    filteredSongs = displayed,
+                    isLoading = searchResults == null,
+                    selectedSongIds = selectedSongIds,
+                    albumShape = albumShape,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = contentPadding
+                )
+            }
+            favoritesOnly -> {
+                val favoriteSongs = remember(pagedSongs.itemSnapshotList.items, favoriteIds) {
+                    pagedSongs.itemSnapshotList.items.filter { it.id in favoriteIds }
+                }
+                SongPickerList(
+                    filteredSongs = favoriteSongs,
+                    isLoading = pagedSongs.loadState.refresh is LoadState.Loading && pagedSongs.itemCount == 0,
+                    selectedSongIds = selectedSongIds,
+                    albumShape = albumShape,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = contentPadding
+                )
+            }
+            else -> {
+                SongPickerPagingList(
+                    pagedSongs = pagedSongs,
+                    selectedSongIds = selectedSongIds,
+                    albumShape = albumShape,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = contentPadding
+                )
+            }
         }
     }
 }
@@ -237,6 +283,9 @@ private fun SongPickerSearchField(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         shape = CircleShape,
         singleLine = true,
+        leadingIcon = {
+            Icon(Icons.Rounded.Search, contentDescription = null)
+        },
         trailingIcon = {
             if (searchQuery.isNotEmpty()) {
                 IconButton(onClick = { onSearchQueryChange("") }) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AccountsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AccountsScreen.kt
@@ -405,10 +405,10 @@ private fun ConnectedAccountCard(
     Column(modifier = Modifier.weight(1f)) {
         Text(
             text = account.title,
-            style = MaterialTheme.typography.titleLarge,
+            style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1,
+            maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
         Text(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -263,6 +263,40 @@ fun HomeScreen(
         derivedStateOf { listState.firstVisibleItemIndex > 0 || listState.firstVisibleItemScrollOffset > scrollThresholdPx }
     }
 
+    // Persist the scroll position across navigation away/back. The Stats card and other
+    // conditional sections can shift indices while data re-emits when returning, which
+    // would otherwise leave the list scrolled to the wrong place or jump to the top.
+    var savedScrollIndex by rememberSaveable { mutableIntStateOf(0) }
+    var savedScrollOffset by rememberSaveable { mutableIntStateOf(0) }
+    var needsScrollRestore by rememberSaveable { mutableStateOf(false) }
+
+    DisposableEffect(lifecycleOwner, listState) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE) {
+                savedScrollIndex = listState.firstVisibleItemIndex
+                savedScrollOffset = listState.firstVisibleItemScrollOffset
+                needsScrollRestore = true
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(
+        needsScrollRestore,
+        yourMixSongs.isNotEmpty(),
+        dailyMixSongs.isNotEmpty(),
+        recentlyPlayedSongs.size,
+        homeStatsOverview
+    ) {
+        if (!needsScrollRestore) return@LaunchedEffect
+        val totalItems = listState.layoutInfo.totalItemsCount
+        if (totalItems == 0) return@LaunchedEffect
+        val targetIndex = savedScrollIndex.coerceIn(0, (totalItems - 1).coerceAtLeast(0))
+        listState.scrollToItem(targetIndex, savedScrollOffset)
+        needsScrollRestore = false
+    }
+
     // Drawer state for sidebar
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val shouldShowCleanInstallDisclaimer =

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramChannelSearchSheet.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
@@ -337,12 +336,7 @@ fun TelegramChannelSearchSheet(
                                         .size(80.dp)
                                         .clip(CircleShape)
                                         .background(
-                                            brush = Brush.linearGradient(
-                                                colors = listOf(
-                                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-                                                    MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f)
-                                                )
-                                            )
+                                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
                                         ),
                                     contentAlignment = Alignment.Center
                                 ) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramSongItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/channel/TelegramSongItem.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -117,19 +116,12 @@ fun TelegramSongItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(14.dp)
         ) {
-            // Album Art with gradient fallback
+            // Album Art with solid fallback
             Box(
                 modifier = Modifier
                     .size(56.dp)
                     .clip(albumShape)
-                    .background(
-                        brush = Brush.linearGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.primaryContainer,
-                                MaterialTheme.colorScheme.tertiaryContainer
-                            )
-                        )
-                    ),
+                    .background(MaterialTheme.colorScheme.primaryContainer),
                 contentAlignment = Alignment.Center
             ) {
                 SmartImage(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
@@ -72,7 +72,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -123,11 +122,6 @@ fun TelegramDashboardScreen(
     val lazyListState = rememberLazyListState()
     val density = LocalDensity.current
     val coroutineScope = rememberCoroutineScope()
-
-    val gradientColors = listOf(
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-        Color.Transparent
-    )
 
     LaunchedEffect(statusMessage) {
         statusMessage?.let {
@@ -210,7 +204,6 @@ fun TelegramDashboardScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(gradientColors))
             .nestedScroll(nestedScrollConnection)
     ) {
         Crossfade(targetState = channels.isEmpty(), label = "telegramContentState") { isEmpty ->
@@ -396,14 +389,7 @@ private fun ExpressiveChannelItem(
                     modifier = Modifier
                         .size(62.dp)
                         .clip(imageShape)
-                        .background(
-                            brush = Brush.linearGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.tertiary
-                                )
-                            )
-                        ),
+                        .background(MaterialTheme.colorScheme.primary),
                     contentAlignment = Alignment.Center
                 ) {
                     if (!channel.photoPath.isNullOrEmpty()) {
@@ -881,14 +867,7 @@ private fun ExpressiveEmptyState(
             modifier = Modifier
                 .size(120.dp)
                 .clip(CircleShape)
-                .background(
-                    brush = Brush.linearGradient(
-                        colors = listOf(
-                            MaterialTheme.colorScheme.primaryContainer,
-                            MaterialTheme.colorScheme.tertiaryContainer
-                        )
-                    )
-                ),
+                .background(MaterialTheme.colorScheme.primaryContainer),
             contentAlignment = Alignment.Center
         ) {
             Icon(

--- a/app/src/main/res/values/strings_presentation_batch_c.xml
+++ b/app/src/main/res/values/strings_presentation_batch_c.xml
@@ -29,7 +29,8 @@
     <string name="song_picker_title">Add songs</string>
     <string name="cd_confirm_add_songs">Add selected songs</string>
     <string name="song_picker_action_add">Add</string>
-    <string name="song_picker_search_label">Search for songs…</string>
+    <string name="song_picker_search_label">Search or filter songs…</string>
+    <string name="song_picker_filter_favorites">Favorites only</string>
     <string name="song_picker_error_load_failed">Failed to load songs</string>
     <string name="song_picker_load_more">Load more</string>
 

--- a/app/src/main/res/values/strings_presentation_batch_e.xml
+++ b/app/src/main/res/values/strings_presentation_batch_e.xml
@@ -5,6 +5,7 @@
     <string name="presentation_batch_e_cd_queue_actions">Queue actions</string>
     <string name="presentation_batch_e_action_clear_queue">Clear queue</string>
     <string name="presentation_batch_e_action_save_as_playlist">Save as playlist</string>
+    <string name="presentation_batch_e_action_locate_current_song">Locate current song</string>
     <string name="presentation_batch_e_queue_named_suffix">%1$s queue</string>
     <string name="presentation_batch_e_queue_current">Current queue</string>
     <string name="presentation_batch_e_removed">removed</string>


### PR DESCRIPTION
## Summary
Seven separate commits, one per issue, that address the user-reported UX issues plus a follow-up gradient cleanup.

### Fixes
- **fix(accounts)** — Service title in connected-account card no longer truncates (titleLarge/maxLines=1 → titleMedium/maxLines=2). "NetEase Cloud Music" / "QQ Music" now fit alongside the Connected badge.
- **feat(queue)** — Adds a *Locate current song* entry to the queue sheet's expanded FAB menu; scrolls (instant or animated by distance) to the playing track. Hidden when the current song is not in the visible queue range.
- **fix(home)** — Saves Home's scroll position on `ON_PAUSE` and re-applies it via `LaunchedEffect` once data is ready, so returning from Listening Stats lands back at the same place even when conditional sections (Daily Mix, Recently Played, Stats card) shift indices during re-emit.
- **fix(cast)** — Skips the "Nearby devices" header + refresh indicator items when both wifi and bluetooth are off, leaving only the WifiOffIllustration instead of a dead empty card.
- **feat(song-picker)** — Adds a *Favorites only* `FilterChip` plus a leading Search icon to the song picker used in Create Playlist; favorites filter applies to both the paged list and search results.

### Style cleanup
- **style(playlist)** — Drops the `primaryContainer → surfaceContainerHigh` vertical gradient from `PlaylistCreationTypeDialog` background.
- **style(telegram)** — Removes 5 decorative gradients across the Telegram module (dashboard page background, channel avatar fallback, empty-state circle, channel-search idle icon, song-item album-art fallback). Each replaced with a solid container color; unused `Brush` imports dropped.

`./gradlew :app:compileDebugKotlin` passes after each change.

## Test plan
- [ ] Accounts → connect QQ Music / NetEase Cloud Music; title no longer ellipsized
- [ ] Queue sheet → open FAB menu, "Locate current song" present; tap it, list scrolls to current track
- [ ] Home → scroll down, open Listening Stats, press back; scroll position is restored
- [ ] Cast sheet → turn off wifi + bluetooth, open sheet; no "Nearby devices" header, only WifiOffIllustration
- [ ] Create Playlist → step 2 song picker shows search icon + "Favorites only" chip; chip filters results
- [ ] Create Playlist type-selection dialog → solid background, no gradient
- [ ] Telegram dashboard, channel search, song rows → solid backgrounds where gradients used to be