### PR TITLE
Fix UnifiedPlayerSheetV2 expand/collapse lag after play→pause

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -627,16 +627,14 @@ fun UnifiedPlayerSheetV2(
                                 alpha = miniReadyAlpha
                                 transformOrigin = TransformOrigin(0.5f, 1f)
                             }
-                            .then(
-                                if (visualCardShadowElevation > 0.dp) {
-                                    Modifier.shadow(
-                                        elevation = visualCardShadowElevation,
-                                        shape = sheetInteractionState.playerShadowShape,
-                                        clip = false
-                                    )
-                                } else {
-                                    Modifier
-                                }
+                            // Always keep Modifier.shadow attached. It is a no-op at 0.dp
+                            // and avoids restructuring the modifier subtree (and re-attaching
+                            // the layout node) every time elevation crosses the visibility
+                            // threshold during an expand/collapse animation.
+                            .shadow(
+                                elevation = visualCardShadowElevation,
+                                shape = sheetInteractionState.playerShadowShape,
+                                clip = false
                             )
                             .background(
                                 color = playerAreaBackground,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
@@ -3,10 +3,8 @@ package com.theveloper.pixelplay.presentation.components.player
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -163,10 +161,7 @@ fun AnimatedPlaybackControls(
             )
             val playCorner by animateDpAsState(
                 targetValue = if (!playPauseVisualState) playPauseCornerPlaying else playPauseCornerPaused,
-                animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioNoBouncy,
-                    stiffness = Spring.StiffnessMedium
-                ),
+                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
                 label = "playCorner"
             )
             val playShape = AbsoluteSmoothCornerShape(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt
@@ -161,7 +161,7 @@ fun AnimatedPlaybackControls(
             )
             val playCorner by animateDpAsState(
                 targetValue = if (!playPauseVisualState) playPauseCornerPlaying else playPauseCornerPaused,
-                animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+                animationSpec = PauseRestDpSpec,
                 label = "playCorner"
             )
             val playShape = AbsoluteSmoothCornerShape(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1011,12 +1011,13 @@ private fun FullPlayerAlbumCoverSection(
 ) {
     val shouldDelay = loadingTweaks.delayAll || loadingTweaks.delayAlbumCarousel
     val shouldApplyPausedScale = !isPlayingProvider() && !playWhenReadyProvider()
+    // tween instead of Spring.StiffnessLow (~1.5s settle) so the pause "rest"
+    // animation finishes before the user can plausibly start an expand/collapse —
+    // otherwise the carousel keeps invalidating its graphicsLayer.scale during
+    // the sheet gesture and drops frames.
     val albumArtScale by animateFloatAsState(
         targetValue = if (shouldApplyPausedScale) 0.95f else 1f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioNoBouncy,
-            stiffness = Spring.StiffnessLow
-        ),
+        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
         label = "AlbumArtScale"
     )
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1011,13 +1011,9 @@ private fun FullPlayerAlbumCoverSection(
 ) {
     val shouldDelay = loadingTweaks.delayAll || loadingTweaks.delayAlbumCarousel
     val shouldApplyPausedScale = !isPlayingProvider() && !playWhenReadyProvider()
-    // tween instead of Spring.StiffnessLow (~1.5s settle) so the pause "rest"
-    // animation finishes before the user can plausibly start an expand/collapse —
-    // otherwise the carousel keeps invalidating its graphicsLayer.scale during
-    // the sheet gesture and drops frames.
     val albumArtScale by animateFloatAsState(
         targetValue = if (shouldApplyPausedScale) 0.95f else 1f,
-        animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+        animationSpec = PauseRestFloatSpec,
         label = "AlbumArtScale"
     )
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerAnimSpecs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerAnimSpecs.kt
@@ -1,0 +1,15 @@
+package com.theveloper.pixelplay.presentation.components.player
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.unit.Dp
+
+// Shared spec for "rest pose" transitions that fire when playback pauses
+// (album-art shrink, play-button corner morph). The duration is short enough
+// that the animation finishes before a user can plausibly start a sheet
+// expand/collapse gesture — otherwise the still-animating graphicsLayer
+// invalidates draw layers mid-gesture and drops frames.
+private const val PAUSE_REST_DURATION_MS = 220
+
+internal val PauseRestFloatSpec = tween<Float>(durationMillis = PAUSE_REST_DURATION_MS, easing = FastOutSlowInEasing)
+internal val PauseRestDpSpec = tween<Dp>(durationMillis = PAUSE_REST_DURATION_MS, easing = FastOutSlowInEasing)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/ComposeLoader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/ComposeLoader.kt
@@ -62,11 +62,15 @@ fun rememberSmoothProgress(
 
     val latestPositionProvider by rememberUpdatedState(newValue = currentPositionProvider)
     val latestIsPlayingProvider by rememberUpdatedState(newValue = isPlayingProvider)
+    // isVisible is read inside the loop (not as a LaunchedEffect key) so visibility
+    // transitions during expand/collapse don't cancel & restart this coroutine
+    // mid-gesture. The sampler simply idles while hidden.
+    val latestIsVisible by rememberUpdatedState(newValue = isVisible)
 
     val safeUpperBound = totalDuration.coerceAtLeast(0L)
     val safeDuration = totalDuration.coerceAtLeast(1L)
 
-    LaunchedEffect(totalDuration, sampleWhilePlayingMs, sampleWhilePausedMs, isVisible) {
+    LaunchedEffect(totalDuration, sampleWhilePlayingMs, sampleWhilePausedMs) {
         fun sampleNow() {
             val rawPosition = latestPositionProvider()
             val clampedPosition = rawPosition.coerceIn(0L, safeUpperBound)
@@ -75,9 +79,12 @@ fun rememberSmoothProgress(
         }
 
         sampleNow()
-        if (!isVisible) return@LaunchedEffect
 
         while (isActive) {
+            if (!latestIsVisible) {
+                delay(200L)
+                continue
+            }
             val isPlaying = latestIsPlayingProvider()
             val delayMillis = if (isPlaying) sampleWhilePlayingMs else sampleWhilePausedMs
             delay(delayMillis.coerceAtLeast(1L))

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/ComposeLoader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/ComposeLoader.kt
@@ -82,7 +82,9 @@ fun rememberSmoothProgress(
 
         while (isActive) {
             if (!latestIsVisible) {
-                delay(200L)
+                // Hidden sampler does no work; the longer poll just bounds how
+                // soon we resume after becoming visible again.
+                delay(600L)
                 continue
             }
             val isPlaying = latestIsPlayingProvider()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/FullPlayerCompositionPolicy.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/FullPlayerCompositionPolicy.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerSheetState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 
 internal data class FullPlayerCompositionPolicy(
     val shouldRenderFullPlayer: Boolean
@@ -50,16 +51,16 @@ internal fun rememberFullPlayerCompositionPolicy(
         }
     }
 
-    // Monitor expansion fraction via snapshotFlow instead of using it as a
-    // LaunchedEffect key. The old approach relaunched the effect on every frame.
+    // Wait for the first expansion past the threshold and then exit. The old
+    // version used .collect { } which kept this coroutine receiving every frame
+    // of the expansion animation for the life of the song, long after the flag
+    // had already flipped.
     LaunchedEffect(currentSongId) {
         if (currentSongId == null) return@LaunchedEffect
+        if (keepFullPlayerComposed) return@LaunchedEffect
         snapshotFlow { expansionFraction.value }
-            .collect { fraction ->
-                if (fraction > 0.12f && !keepFullPlayerComposed) {
-                    keepFullPlayerComposed = true
-                }
-            }
+            .first { it > 0.12f }
+        keepFullPlayerComposed = true
     }
 
     // Read expansion fraction inside derivedStateOf so that changes only trigger

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetVisualState.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetVisualState.kt
@@ -141,12 +141,16 @@ internal fun rememberSheetVisualState(
         }
     }
 
+    // isPlaying and hasCurrentSong are read inside the lambda but kept out of the
+    // remember key set so play/pause toggles don't invalidate this provider's
+    // identity (which would cascade into a new playerShadowShape and re-outline
+    // the sheet's background/shadow modifiers).
+    val isPlayingState = rememberUpdatedState(isPlaying)
+    val hasCurrentSongState = rememberUpdatedState(hasCurrentSong)
     val playerContentActualBottomRadiusProvider: () -> Dp = remember(
         navBarStyle,
         showPlayerContentArea,
         playerContentExpansionFraction,
-        isPlaying,
-        hasCurrentSong,
         predictiveBackCollapseProgress,
         currentSheetContentState,
         swipeDismissProgress,
@@ -176,7 +180,7 @@ internal fun rememberSheetVisualState(
                                 lerp(26.dp, 0.dp, ((fraction - 0.2f) / 0.8f).coerceIn(0f, 1f))
                             }
                         } else {
-                            if (!isPlaying || !hasCurrentSong) {
+                            if (!isPlayingState.value || !hasCurrentSongState.value) {
                                 if (isNavBarHidden) 32.dp else navBarCornerRadiusDp
                             } else {
                                 if (isNavBarHidden) 32.dp else 12.dp

--- a/baselineprofile/src/main/java/com/theveloper/pixelplay/baselineprofile/PlayerSheetAnimationBenchmarks.kt
+++ b/baselineprofile/src/main/java/com/theveloper/pixelplay/baselineprofile/PlayerSheetAnimationBenchmarks.kt
@@ -35,34 +35,59 @@ class PlayerSheetAnimationBenchmarks {
             ),
             iterations = 6,
             startupMode = StartupMode.WARM,
-            setupBlock = {
-                val shouldRebuildLibrary = !libraryRebuiltForThisRun
-                setupBenchmarkPermissions(packageName)
-                pressHome()
-                killProcess()
-                startActivityAndWait { intent ->
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-                    intent.putExtra(BENCHMARK_EXTRA, true)
-                    intent.putExtra(BENCHMARK_REBUILD_DATABASE_EXTRA, shouldRebuildLibrary)
-                }
-                waitForTargetPackageVisible(packageName)
-                waitForAppForeground("Player sheet benchmark setup", packageName)
-                device.waitForIdle(IDLE_WAIT_MS)
-                assertDeviceMediaStoreHasAudio()
-                dismissBenchmarkBlockingDialogs()
-                if (shouldRebuildLibrary) {
-                    Thread.sleep(BENCHMARK_REBUILD_WAIT_MS)
-                    dismissBenchmarkBlockingDialogs()
-                }
-                ensureSongIsReady()
-                libraryRebuiltForThisRun = true
-                openHomeTab()
-                waitForSheetState(SHEET_COLLAPSED_PATTERN, "setup after opening Home")
-                device.waitForIdle(IDLE_WAIT_MS)
-            }
+            setupBlock = { setupPlayerSheetBenchmark(packageName) }
         ) {
             runPlayerSheetAnimationSequence()
         }
+    }
+
+    // Reproduces the specific lag fixed by the "Fix UnifiedPlayerSheetV2
+    // expand/collapse lag after play→pause" PR: toggle play then pause from the
+    // mini-player and immediately expand/collapse the sheet. Pre-fix this hit
+    // slow Spring.StiffnessLow rest animations and re-keyed shape providers,
+    // causing dropped frames during the gesture.
+    @Test
+    fun playerSheetExpandAfterPauseGestures() {
+        val packageName = benchmarkTargetPackageName()
+
+        benchmarkRule.measureRepeated(
+            packageName = packageName,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = CompilationMode.Partial(
+                baselineProfileMode = BaselineProfileMode.UseIfAvailable
+            ),
+            iterations = 6,
+            startupMode = StartupMode.WARM,
+            setupBlock = { setupPlayerSheetBenchmark(packageName) }
+        ) {
+            runPlayPauseExpandSequence()
+        }
+    }
+
+    private fun androidx.benchmark.macro.MacrobenchmarkScope.setupPlayerSheetBenchmark(packageName: String) {
+        val shouldRebuildLibrary = !libraryRebuiltForThisRun
+        setupBenchmarkPermissions(packageName)
+        pressHome()
+        killProcess()
+        startActivityAndWait { intent ->
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.putExtra(BENCHMARK_EXTRA, true)
+            intent.putExtra(BENCHMARK_REBUILD_DATABASE_EXTRA, shouldRebuildLibrary)
+        }
+        waitForTargetPackageVisible(packageName)
+        waitForAppForeground("Player sheet benchmark setup", packageName)
+        device.waitForIdle(IDLE_WAIT_MS)
+        assertDeviceMediaStoreHasAudio()
+        dismissBenchmarkBlockingDialogs()
+        if (shouldRebuildLibrary) {
+            Thread.sleep(BENCHMARK_REBUILD_WAIT_MS)
+            dismissBenchmarkBlockingDialogs()
+        }
+        ensureSongIsReady()
+        libraryRebuiltForThisRun = true
+        openHomeTab()
+        waitForSheetState(SHEET_COLLAPSED_PATTERN, "setup after opening Home")
+        device.waitForIdle(IDLE_WAIT_MS)
     }
 
     private fun androidx.benchmark.macro.MacrobenchmarkScope.assertDeviceMediaStoreHasAudio() {
@@ -146,6 +171,37 @@ class PlayerSheetAnimationBenchmarks {
             collapseExpandedPlayer()
             waitForSheetState(SHEET_COLLAPSED_PATTERN, "repeated tap close $it")
         }
+    }
+
+    private fun androidx.benchmark.macro.MacrobenchmarkScope.runPlayPauseExpandSequence() {
+        val midX = device.displayWidth / 2
+        val collapsedY = (device.displayHeight * 0.86f).toInt()
+        val fullTopY = (device.displayHeight * 0.12f).toInt()
+        val fullBottomY = (device.displayHeight * 0.88f).toInt()
+
+        repeat(3) { iteration ->
+            tapMiniPlayerPlayPause("play, iter $iteration")
+            // Give the play→pause-style rest animations time to actually start
+            // running so we capture frames produced while they're in flight,
+            // which is when the pre-fix code dropped them.
+            Thread.sleep(PLAY_PAUSE_SETTLE_MS)
+            tapMiniPlayerPlayPause("pause, iter $iteration")
+
+            swipeOpenFromCollapsed(midX, collapsedY, fullTopY, steps = 12)
+            waitForSheetState(SHEET_EXPANDED_PATTERN, "post-pause expand $iteration")
+            swipe(midX, fullTopY, midX, fullBottomY, steps = 8)
+            waitForSheetState(SHEET_COLLAPSED_PATTERN, "post-pause collapse $iteration")
+        }
+    }
+
+    private fun androidx.benchmark.macro.MacrobenchmarkScope.tapMiniPlayerPlayPause(context: String) {
+        val button = findByTextOrDescription(MINI_PLAYER_PLAY_PAUSE_PATTERN, SHORT_WAIT_MS)
+            ?: throw IllegalStateException(
+                "Mini-player play/pause button not found for $context. " +
+                    "Visible UI: ${visibleUiSnapshot()}"
+            )
+        click(button)
+        Thread.sleep(DEFAULT_WAIT_MS)
     }
 
     private fun androidx.benchmark.macro.MacrobenchmarkScope.openCollapsedPlayerByTap(fallbackY: Int) {
@@ -374,6 +430,7 @@ class PlayerSheetAnimationBenchmarks {
         private const val BENCHMARK_REBUILD_WAIT_MS = 20_000L
         private const val ANIMATION_WAIT_MS = 360L
         private const val SHEET_STATE_WAIT_MS = 3_000L
+        private const val PLAY_PAUSE_SETTLE_MS = 900L
 
         private var libraryRebuiltForThisRun = false
         private const val BENCHMARK_REBUILD_DATABASE_EXTRA = "benchmark_rebuild_database"
@@ -389,6 +446,9 @@ class PlayerSheetAnimationBenchmarks {
         private val BACK_PATTERN = exactPattern("Back|Atr[aá]s")
         private val LIBRARY_TAB_PATTERN = pattern("Library|Biblioteca")
         private val COLLAPSE_PLAYER_PATTERN = exactPattern("Collapse player|Contraer reproductor")
+        // Matches the hardcoded contentDescription on the mini-player's
+        // play/pause button (see UnifiedPlayerSheetShared.kt).
+        private val MINI_PLAYER_PLAY_PAUSE_PATTERN = exactPattern("Pausar|Reproducir|Pause|Play")
         private val DISMISS_DIALOG_PATTERN = exactPattern("Got it|Entendido|Aceptar|OK")
         private val EMPTY_LIBRARY_PATTERN = pattern(
             "No songs|No valid songs|Sin canciones|No se encontraron canciones|Empty"


### PR DESCRIPTION
## Summary

- Pausing kicked off several long-running spring animations (album-art rest scale on `Spring.StiffnessLow` ~1.5 s, play-button corner morph on `Spring.StiffnessMedium`, wave amplitude collapse) that kept invalidating draw layers while the user tried to expand/collapse the sheet right after.
- `isPlaying` was a `remember(...)` key for `SheetVisualState.playerContentActualBottomRadiusProvider`, so every play/pause toggle swapped the `playerShadowShape` and forced the sheet's `Modifier.background(shape=…)` / `Modifier.shadow(shape=…)` to re-outline — even though the `isPlaying` branch is only reachable when `!showPlayerContentArea`.
- Three smaller items compounded the cost: the shadow modifier was conditionally inserted via `.then(if (…) shadow else Modifier)`, `rememberSmoothProgress` restarted its sampler whenever `isVisible` flipped a threshold during a gesture, and `FullPlayerCompositionPolicy`'s `snapshotFlow` collector kept receiving every frame for the rest of the song after its only side-effect had already fired.

## Changes

- [`SheetVisualState.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetVisualState.kt) — read `isPlaying` / `hasCurrentSong` via `rememberUpdatedState` inside the bottom-radius provider lambda; remove them from its `remember` keys.
- [`UnifiedPlayerSheetV2.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt) — always attach `Modifier.shadow` (no-op at 0.dp) instead of toggling it on/off in the modifier chain.
- [`FullPlayerContent.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt) — swap `albumArtScale`'s `Spring.StiffnessLow` for a 220 ms tween so the pause-rest pose settles before a gesture can start.
- [`AnimatedPlaybackControls.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/player/AnimatedPlaybackControls.kt) — same swap for `playCorner`; drop the now-unused `Spring`/`spring` imports.
- [`ComposeLoader.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/ComposeLoader.kt) — move `isVisible` out of `rememberSmoothProgress`'s `LaunchedEffect` key set and read it via `rememberUpdatedState` inside the loop.
- [`FullPlayerCompositionPolicy.kt`](app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/FullPlayerCompositionPolicy.kt) — replace the `snapshotFlow.collect { … }` with `snapshotFlow.first { … }` so the coroutine exits once the threshold has fired.

No visual behavior changes — the carousel still shrinks to 0.95 on pause and the play button still morphs corners, just on a tween instead of a slow spring.

## Test plan

- [ ] Cold-paused: open the app with a queued but never-played song, expand/collapse the sheet a few times → smooth.
- [ ] Repro the original lag: press play, wait ~1 s, press pause, then immediately expand and collapse the sheet — repeat several times. Each cycle should feel identical to the cold-paused case.
- [ ] Sanity-check during playback: expand/collapse while the song is playing → no regression.
- [ ] Predictive back gesture (Android 14+) still collapses the sheet smoothly.
- [ ] Queue sheet, cast sheet, and mini-player horizontal-dismiss gestures still respond as before.
- [ ] Visual: album art still visibly "rests" (5% shrink) when paused, just reaches the target faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)