### PR TITLE
Rename NetEase Cloud Music labels to NetEase Music

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -455,7 +455,7 @@ fun PlaylistItem(
                         Spacer(modifier = Modifier.width(8.dp))
                         Icon(
                             painter = painterResource(R.drawable.netease_cloud_music_logo_icon_206716__1_),
-                            contentDescription = "Netease Cloud Music",
+                            contentDescription = "Netease Music",
                             tint = MaterialTheme.colorScheme.tertiary,
                             modifier = Modifier.size(18.dp)
                         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/StreamingProviderSheet.kt
@@ -163,7 +163,7 @@ fun StreamingProviderSheet(
                     ProviderRow(
                         iconPainter = painterResource(R.drawable.netease_cloud_music_logo_icon_206716__1_),
                         iconTint = Color(0xFFE85959),
-                        title = "Netease Cloud Music",
+                        title = "Netease Music",
                         subtitle = if (isNeteaseLoggedIn) "Connected" else "Sign in to stream",
                         shape = providerSegmentItemShape,
                         isConnected = isNeteaseLoggedIn,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/AccountsViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/AccountsViewModel.kt
@@ -160,7 +160,7 @@ class AccountsViewModel @Inject constructor(
                 add(
                     ExternalAccountUiModel(
                         service = ExternalServiceAccount.NETEASE,
-                        title = "Netease Cloud Music",
+                        title = "Netease Music",
                         accountLabel = neteaseRepository.userNickname
                             ?.takeIf { it.isNotBlank() }
                             ?: "Netease account connected",

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
@@ -209,7 +209,7 @@ class SongInfoBottomSheetViewModel @Inject constructor(
     private fun getCloudProviderLabel(contentUriString: String): String? {
         return when {
             contentUriString.startsWith("telegram://") -> "Telegram"
-            contentUriString.startsWith("netease://") -> "Netease Cloud Music"
+            contentUriString.startsWith("netease://") -> "Netease Music"
             contentUriString.startsWith("qqmusic://") -> "QQ Music"
             contentUriString.startsWith("navidrome://") -> "Navidrome"
             contentUriString.startsWith("gdrive://") -> "Google Drive"

--- a/app/src/main/res/values-de/strings_screens.xml
+++ b/app/src/main/res/values-de/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Alle synchronisieren</string>
     <string name="cd_add_drive_folder">Ordner hinzufügen</string>
     <string name="cd_logout">Abmelden</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Alle Playlists synchronisieren</string>
     <string name="error_with_message_format">Fehler: %1$s</string>

--- a/app/src/main/res/values-es/strings_auth.xml
+++ b/app/src/main/res/values-es/strings_auth.xml
@@ -42,7 +42,7 @@
     <string name="auth_web_exit_confirm_body">Puedes volver más tarde. Al cerrar se descarta el estado de la página.</string>
     <string name="auth_exit">Salir</string>
     <string name="auth_stay">Permanecer</string>
-    <string name="auth_login_netease_title">Iniciar sesión en NetEase Cloud Music</string>
+    <string name="auth_login_netease_title">Iniciar sesión en NetEase Music</string>
     <string name="auth_login_qq_title">Iniciar sesión en QQ Music</string>
     <string name="auth_web_cd_web_back">Atrás en la web</string>
     <string name="auth_web_cd_web_forward">Adelante en la web</string>

--- a/app/src/main/res/values-es/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values-es/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">Conectar %1$s</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (próximamente)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">Ordenar canciones</string>

--- a/app/src/main/res/values-es/strings_screens.xml
+++ b/app/src/main/res/values-es/strings_screens.xml
@@ -214,7 +214,7 @@
     <string name="cd_sync_all">Sincronizar todo</string>
     <string name="cd_add_drive_folder">Añadir carpeta</string>
     <string name="cd_logout">Cerrar sesión</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Sincronizar todas las listas</string>
     <string name="error_with_message_format">Error: %1$s</string>

--- a/app/src/main/res/values-es/strings_settings.xml
+++ b/app/src/main/res/values-es/strings_settings.xml
@@ -3,7 +3,7 @@
     <!-- Main settings screen -->
     <string name="settings_top_bar_title">Ajustes</string>
     <string name="settings_accounts_row_title">Cuentas</string>
-    <string name="settings_accounts_row_subtitle">Gestiona Telegram, Google Drive, NetEase Cloud Music y otros servicios</string>
+    <string name="settings_accounts_row_subtitle">Gestiona Telegram, Google Drive, NetEase Music y otros servicios</string>
 
     <!-- SettingsCategory enum (grid) -->
     <string name="settings_category_library_title">Gestión de música</string>

--- a/app/src/main/res/values-fr/strings_auth.xml
+++ b/app/src/main/res/values-fr/strings_auth.xml
@@ -51,7 +51,7 @@
     <string name="auth_web_exit_confirm_body">Vous pourrez revenir plus tard. L\'état actuel de la page sera perdu lors de la fermeture.</string>
     <string name="auth_exit">Quitter</string>
     <string name="auth_stay">Rester</string>
-    <string name="auth_login_netease_title">Connexion à NetEase Cloud Music</string>
+    <string name="auth_login_netease_title">Connexion à NetEase Music</string>
     <string name="auth_login_qq_title">Connexion à QQ Music</string>
     <string name="auth_web_cd_web_back">Retour Web</string>
     <string name="auth_web_cd_web_forward">Avance Web</string>

--- a/app/src/main/res/values-fr/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values-fr/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">Connecter %1$s</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (Bientôt disponible)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">Trier les chansons</string>

--- a/app/src/main/res/values-fr/strings_presentation_batch_g.xml
+++ b/app/src/main/res/values-fr/strings_presentation_batch_g.xml
@@ -288,7 +288,7 @@
     <string name="presentation_batch_g_beta_sheet_expect_title">À attendre</string>
     <string name="presentation_batch_g_beta_sheet_expect_1">Utilisation quotidienne plus rapide : démarrage, navigation et interactions avec le lecteur plus fluides dans toute l\'application.</string>
     <string name="presentation_batch_g_beta_sheet_expect_2">Support d\'appareils plus large : Android Auto, améliorations Wear OS et fiabilité Cast renforcée.</string>
-    <string name="presentation_batch_g_beta_sheet_expect_3">Écosystème cloud élargi : playlists Telegram, sync NetEase Cloud Music, QQ Music et mises à jour du streaming Google Drive.</string>
+    <string name="presentation_batch_g_beta_sheet_expect_3">Écosystème cloud élargi : playlists Telegram, sync NetEase Music, QQ Music et mises à jour du streaming Google Drive.</string>
     <string name="presentation_batch_g_beta_sheet_expect_4">Grande passe de fiabilité : logique file d\'attente/aléatoire, comportement de lecture en arrière-plan et nombreuses corrections d\'interface.</string>
     <string name="presentation_batch_g_beta_sheet_report_title">Signaler un problème</string>
     <string name="presentation_batch_g_beta_sheet_report_body">Partagez les étapes de reproduction, le résultat attendu, le résultat actuel et les détails de votre appareil/OS. Une courte capture d\'écran est très utile.</string>

--- a/app/src/main/res/values-fr/strings_screens.xml
+++ b/app/src/main/res/values-fr/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Tout synchroniser</string>
     <string name="cd_add_drive_folder">Ajouter un dossier</string>
     <string name="cd_logout">Se déconnecter</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Synchroniser toutes les listes</string>
     <string name="error_with_message_format">Erreur : %1$s</string>

--- a/app/src/main/res/values-fr/strings_settings.xml
+++ b/app/src/main/res/values-fr/strings_settings.xml
@@ -3,7 +3,7 @@
     <!-- Main settings screen -->
     <string name="settings_top_bar_title">Paramètres</string>
     <string name="settings_accounts_row_title">Comptes</string>
-    <string name="settings_accounts_row_subtitle">Gérer Telegram, Google Drive, NetEase Cloud Music et d\'autres services</string>
+    <string name="settings_accounts_row_subtitle">Gérer Telegram, Google Drive, NetEase Music et d\'autres services</string>
 
     <!-- SettingsCategory enum (grid) -->
     <string name="settings_category_library_title">Gestion de la musique</string>

--- a/app/src/main/res/values-in/strings_auth.xml
+++ b/app/src/main/res/values-in/strings_auth.xml
@@ -51,7 +51,7 @@
     <string name="auth_web_exit_confirm_body">Anda dapat kembali lagi nanti. Status halaman saat ini akan dibuang saat menutup.</string>
     <string name="auth_exit">Keluar</string>
     <string name="auth_stay">Tetap di sini</string>
-    <string name="auth_login_netease_title">Login ke NetEase Cloud Music</string>
+    <string name="auth_login_netease_title">Login ke NetEase Music</string>
     <string name="auth_login_qq_title">Login ke QQ Music</string>
     <string name="auth_web_cd_web_back">Web kembali</string>
     <string name="auth_web_cd_web_forward">Web maju</string>

--- a/app/src/main/res/values-in/strings_screens.xml
+++ b/app/src/main/res/values-in/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Sinkronkan semua</string>
     <string name="cd_add_drive_folder">Tambah folder</string>
     <string name="cd_logout">Keluar</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Sinkronkan semua playlist</string>
     <string name="error_with_message_format">Kesalahan: %1$s</string>

--- a/app/src/main/res/values-it/strings_screens.xml
+++ b/app/src/main/res/values-it/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Sincronizza tutto</string>
     <string name="cd_add_drive_folder">Aggiungi cartella</string>
     <string name="cd_logout">Disconnetti</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Sincronizza tutte le playlist</string>
     <string name="error_with_message_format">Errore: %1$s</string>

--- a/app/src/main/res/values-ko/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values-ko/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">%1$s 연결</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (출시 예정)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">곡 정렬</string>

--- a/app/src/main/res/values-ko/strings_presentation_batch_c.xml
+++ b/app/src/main/res/values-ko/strings_presentation_batch_c.xml
@@ -56,7 +56,7 @@
     <string name="lib_empty_songs_offline_title">로컬 곡을 찾을 수 없음</string>
     <string name="lib_empty_songs_offline_subtitle">다른 소스 필터를 시도하거나 기기 라이브러리를 다시 스캔하세요.</string>
     <string name="lib_empty_songs_online_title">클라우드 곡을 찾을 수 없음</string>
-    <string name="lib_empty_songs_online_subtitle">Telegram 또는 NetEase Cloud Music 곡을 동기화하거나 로컬 소스로 전환하세요.</string>
+    <string name="lib_empty_songs_online_subtitle">Telegram 또는 NetEase Music 곡을 동기화하거나 로컬 소스로 전환하세요.</string>
     <string name="lib_empty_albums_all_title">사용 가능한 앨범 없음</string>
     <string name="lib_empty_albums_all_subtitle">라이브러리의 트랙이 그룹화되는 대로 앨범이 여기에 표시됩니다.</string>
     <string name="lib_empty_albums_offline_title">로컬 앨범을 찾을 수 없음</string>

--- a/app/src/main/res/values-ko/strings_screens.xml
+++ b/app/src/main/res/values-ko/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">모두 동기화</string>
     <string name="cd_add_drive_folder">폴더 추가</string>
     <string name="cd_logout">로그아웃</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">모든 플레이리스트 동기화</string>
     <string name="error_with_message_format">오류: %1$s</string>

--- a/app/src/main/res/values-ko/strings_settings.xml
+++ b/app/src/main/res/values-ko/strings_settings.xml
@@ -3,7 +3,7 @@
     <!-- Main settings screen -->
     <string name="settings_top_bar_title">설정</string>
     <string name="settings_accounts_row_title">계정</string>
-    <string name="settings_accounts_row_subtitle">Telegram, Google Drive, NetEase Cloud Music 및 기타 서비스 관리</string>
+    <string name="settings_accounts_row_subtitle">Telegram, Google Drive, NetEase Music 및 기타 서비스 관리</string>
 
     <!-- SettingsCategory enum (grid) -->
     <string name="settings_category_library_title">음악 관리</string>

--- a/app/src/main/res/values-nb/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values-nb/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">Koble til %1$s</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (Kommer snart)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">Sorter sanger</string>

--- a/app/src/main/res/values-nb/strings_screens.xml
+++ b/app/src/main/res/values-nb/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Synkroniser alle</string>
     <string name="cd_add_drive_folder">Legg til mappe</string>
     <string name="cd_logout">Logg ut</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Synkroniser alle spillelister</string>
     <string name="error_with_message_format">Feil: %1$s</string>

--- a/app/src/main/res/values-nb/strings_settings.xml
+++ b/app/src/main/res/values-nb/strings_settings.xml
@@ -3,7 +3,7 @@
     <!-- Main settings screen -->
     <string name="settings_top_bar_title">Innstillinger</string>
     <string name="settings_accounts_row_title">Kontoer</string>
-    <string name="settings_accounts_row_subtitle">Administrer Telegram, Google Drive, NetEase Cloud Music og andre tjenester</string>
+    <string name="settings_accounts_row_subtitle">Administrer Telegram, Google Drive, NetEase Music og andre tjenester</string>
 
     <!-- SettingsCategory enum (grid) -->
     <string name="settings_category_library_title">Musikkbehandling</string>

--- a/app/src/main/res/values-ru/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values-ru/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">Подключить %1$s</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (Скоро)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">Сортировать песни</string>

--- a/app/src/main/res/values-ru/strings_screens.xml
+++ b/app/src/main/res/values-ru/strings_screens.xml
@@ -218,7 +218,7 @@
     <string name="cd_sync_all">Синхронизировать всё</string>
     <string name="cd_add_drive_folder">Добавить папку</string>
     <string name="cd_logout">Выйти</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Синхронизировать все плейлисты</string>
     <string name="error_with_message_format">Ошибка: %1$s</string>

--- a/app/src/main/res/values-ru/strings_settings.xml
+++ b/app/src/main/res/values-ru/strings_settings.xml
@@ -3,7 +3,7 @@
     <!-- Main settings screen -->
     <string name="settings_top_bar_title">Настройки</string>
     <string name="settings_accounts_row_title">Аккаунты</string>
-    <string name="settings_accounts_row_subtitle">Управление Telegram, Google Drive, NetEase Cloud Music и другими сервисами</string>
+    <string name="settings_accounts_row_subtitle">Управление Telegram, Google Drive, NetEase Music и другими сервисами</string>
 
     <!-- SettingsCategory enum (grid) -->
     <string name="settings_category_library_title">Управление музыкой</string>

--- a/app/src/main/res/values/strings_auth.xml
+++ b/app/src/main/res/values/strings_auth.xml
@@ -51,7 +51,7 @@
     <string name="auth_web_exit_confirm_body">You can come back later. Current page state will be discarded when closing.</string>
     <string name="auth_exit">Exit</string>
     <string name="auth_stay">Stay</string>
-    <string name="auth_login_netease_title">Login to NetEase Cloud Music</string>
+    <string name="auth_login_netease_title">Login to NetEase Music</string>
     <string name="auth_login_qq_title">Login to QQ Music</string>
     <string name="auth_web_cd_web_back">Web back</string>
     <string name="auth_web_cd_web_forward">Web forward</string>

--- a/app/src/main/res/values/strings_presentation_batch_b.xml
+++ b/app/src/main/res/values/strings_presentation_batch_b.xml
@@ -16,7 +16,7 @@
     <string name="presentation_batch_b_accounts_connect_service">Connect %1$s</string>
     <string name="presentation_batch_b_accounts_service_paren_coming_soon">%1$s (Coming soon)</string>
     <string name="presentation_batch_b_service_telegram">Telegram</string>
-    <string name="presentation_batch_b_service_netease">NetEase Cloud Music</string>
+    <string name="presentation_batch_b_service_netease">NetEase Music</string>
 
     <!-- PlaylistDetailScreen -->
     <string name="presentation_batch_b_sort_songs">Sort Songs</string>

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -231,7 +231,7 @@
     <string name="cd_sync_all">Sync all</string>
     <string name="cd_add_drive_folder">Add folder</string>
     <string name="cd_logout">Log out</string>
-    <string name="screen_netease_dashboard_title">NetEase Cloud Music</string>
+    <string name="screen_netease_dashboard_title">NetEase Music</string>
     <string name="screen_qq_music_dashboard_title">QQ Music</string>
     <string name="cd_sync_all_playlists">Sync all playlists</string>
     <string name="error_with_message_format">Error: %1$s</string>


### PR DESCRIPTION
## Summary
- Renames every user-facing "NetEase Cloud Music" / "Netease Cloud Music" label to "NetEase Music" / "Netease Music"
- Updates provider row title, account card title, playlist icon contentDescription, and the cloud-provider label in the song info sheet
- Refreshes localized strings across 9 locales (en, de, it, nb, es, in, ko, ru, fr) — dashboard titles, login titles, accounts subtitle, service label, FR beta sheet bullet, KO empty-library subtitle

## Notes
- Internal code comments still reference "Netease Cloud Music" — left untouched since they aren't shown in the UI
- `values-zh-rCN` ("网易云音乐") left unchanged — official Chinese brand name

## Test plan
- [ ] Open the streaming provider sheet → row shows "Netease Music"
- [ ] Open Accounts screen with NetEase connected → card title shows "Netease Music"
- [ ] Open NetEase login screen → title shows "Login to NetEase Music" (and localized variants)
- [ ] Open NetEase dashboard → top bar shows "NetEase Music"
- [ ] Open a NetEase playlist → icon contentDescription reads "Netease Music"