### PR TITLE
fix: swallow background-start denial in media button receiver

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/PixelPlayMediaButtonReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/PixelPlayMediaButtonReceiver.kt
@@ -19,6 +19,12 @@ class PixelPlayMediaButtonReceiver : MediaButtonReceiver() {
         MusicService.markPendingMediaButtonForegroundStart()
         try {
             super.onReceive(context, intent)
+        } catch (e: IllegalStateException) {
+            // androidx.media's MediaButtonReceiver only diverts ForegroundServiceStartNotAllowedException;
+            // its sibling BackgroundServiceStartNotAllowedException (thrown when the app is cached)
+            // falls through and rethrows. Nothing actionable here — the click can't be honored.
+            MusicService.unmarkPendingMediaButtonForegroundStart()
+            Timber.tag(TAG).w(e, "Media button start denied while app cached")
         } catch (throwable: Throwable) {
             MusicService.unmarkPendingMediaButtonForegroundStart()
             Timber.tag(TAG).w(throwable, "Media button dispatch failed before MusicService start")


### PR DESCRIPTION
## Summary

Crash on `PixelPlayMediaButtonReceiver.onReceive` after the app sat in the background long enough to be cached:

```
Exception: Not allowed to start service Intent { cmp=com.theveloper.pixelplay/.data.service.MusicService }:
  app is in background uid UidRecord{... CAC bg:+2m57s650ms idle change:cached|procstate|procadj ...}
```

**Cause.** A Bluetooth/headset key press hits `MediaButtonReceiver`, which calls `ContextCompat.startForegroundService(MusicService)`. The system refuses (cached state) and throws `BackgroundServiceStartNotAllowedException`. androidx.media 1.8.0's `MediaButtonReceiver.onReceive` catches `IllegalStateException` but only diverts to `onForegroundServiceStartNotAllowedException(...)` when the throwable is a `ForegroundServiceStartNotAllowedException` — the *background* variant is a sibling, so it falls through and rethrows. Our `PixelPlayMediaButtonReceiver` wrapper logged it and rethrew, killing the process via the BroadcastReceiver dispatch path.

**Fix.** Catch `IllegalStateException` (parent of both `ForegroundServiceStartNotAllowedException` and `BackgroundServiceStartNotAllowedException`) and swallow it. The media-button click can't be honored from a cached app — there's nothing to do but log. Other `Throwable`s still rethrow, and the pending-foreground-start counter is decremented in both branches so `MusicService`'s start path remains balanced.

The sibling start-from-background sites already absorb the same exception family (`SleepTimerReceiver`, `PlayerControlActionCallback`); this brings the media-button receiver in line.

## Test plan

- [ ] Build app: `./gradlew :app:assembleDebug`
- [ ] With app running, connect Bluetooth headset, play music briefly, leave app backgrounded for ~3+ minutes until the system marks it cached (`adb shell dumpsys activity processes | grep pixelplay` shows `CAC`/`cached`).
- [ ] Press the headset's play/pause key — verify no crash log on next launch (previously: `Not allowed to start service Intent { cmp=…MusicService }: app is in background …`).
- [ ] Verify logcat shows the new warning: `Media button start denied while app cached`.
- [ ] Sanity: media-button presses while the app is active still resume/pause as before.