### PR TITLE
feat: support multi-artist attribution in playback statistics

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepository.kt
@@ -286,10 +286,10 @@ class PlaybackStatsRepository @Inject constructor(
             .map { (genre, groupedSongs) ->
                 val flattened = groupedSongs.flatMap { it.value }
                 val uniqueArtists = groupedSongs
-                    .mapNotNull { (songId, _) ->
-                        songMap[songId]?.artist?.takeIf { it.isNotBlank() }
+                    .flatMap { (songId, _) ->
+                        statsArtistNames(songMap[songId])
                     }
-                    .toSet()
+                    .distinctBy { it.normalizedArtistKey() }
                     .size
                 GenrePlaybackSummary(
                     genre = genre,
@@ -352,12 +352,22 @@ class PlaybackStatsRepository @Inject constructor(
         val timelineEntries = accumulateTimelineEntries(timelineBuckets, overallSpans)
 
         val topArtists = segmentsBySong.entries
-            .groupBy { (songId, _) ->
-                songMap[songId]?.artist?.takeIf { it.isNotBlank() } ?: "Unknown Artist"
+            .flatMap { (songId, segmentsForSong) ->
+                statsArtistNames(songMap[songId]).map { artist ->
+                    ArtistSongPlayback(
+                        artist = artist,
+                        songId = songId,
+                        segments = segmentsForSong
+                    )
+                }
             }
-            .map { (artist, groupedSongs) ->
-                val flattened = groupedSongs.flatMap { it.value }
-                val uniqueSongCount = groupedSongs.size
+            .groupBy { it.artist }
+            .map { (artist, artistSongs) ->
+                val flattened = artistSongs.flatMap { it.segments }
+                val uniqueSongCount = artistSongs
+                    .map { it.songId }
+                    .toSet()
+                    .size
                 ArtistPlaybackSummary(
                     artist = artist,
                     totalDurationMs = flattened.sumOf { it.durationMs },
@@ -605,6 +615,30 @@ class PlaybackStatsRepository @Inject constructor(
         val date: LocalDate,
         val durationMs: Long
     )
+
+    private data class ArtistSongPlayback(
+        val artist: String,
+        val songId: String,
+        val segments: List<PlaybackSegment>
+    )
+
+    private fun statsArtistNames(song: Song?): List<String> {
+        if (song == null) return listOf(UNKNOWN_ARTIST)
+
+        val separatedArtists = song.artists
+            .sortedByDescending { it.isPrimary }
+            .map { it.name.trim() }
+            .filter { it.isNotBlank() }
+            .distinctBy { it.normalizedArtistKey() }
+        if (separatedArtists.isNotEmpty()) {
+            return separatedArtists
+        }
+
+        val fallbackArtist = song.displayArtist.trim()
+        return listOf(fallbackArtist.ifBlank { UNKNOWN_ARTIST })
+    }
+
+    private fun String.normalizedArtistKey(): String = trim().lowercase(Locale.ROOT)
 
     private fun sliceSpanByDay(span: PlaybackSpan, zoneId: ZoneId): List<DaySlice> {
         if (span.durationMs <= 0L) return emptyList()
@@ -1051,6 +1085,7 @@ class PlaybackStatsRepository @Inject constructor(
         private const val DEFAULT_PLAYBACK_HISTORY_LIMIT = 500
         private const val MAX_PLAYBACK_HISTORY_LIMIT = 5_000
         private const val MAX_FILE_UPDATE_RETRIES = 3
+        private const val UNKNOWN_ARTIST = "Unknown Artist"
         private val MAX_HISTORY_AGE_MS = TimeUnit.DAYS.toMillis(730) // Keep roughly two years of history
         private const val SEGMENT_JOIN_TOLERANCE_MS = 0L
     }

--- a/app/src/test/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepositoryTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/stats/PlaybackStatsRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.data.stats
 
 import com.google.common.truth.Truth.assertThat
+import com.theveloper.pixelplay.data.model.ArtistRef
 import com.theveloper.pixelplay.data.model.Song
 import java.time.Instant
 import java.time.LocalDate
@@ -142,6 +143,86 @@ class PlaybackStatsRepositoryTest {
         assertThat(summary.uniqueSongs).isEqualTo(1)
     }
 
+    @Test
+    fun `loadSummary separates multi artist playback in top artists`() = runTest {
+        val repository = createRepository()
+        val zoneId = ZoneId.systemDefault()
+        val start = LocalDate.of(2026, 4, 10)
+            .atTime(14, 0)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+        val durationMs = 60_000L
+        val event = PlaybackStatsRepository.PlaybackEvent(
+            songId = "song-1",
+            timestamp = start + durationMs,
+            durationMs = durationMs,
+            startTimestamp = start,
+            endTimestamp = start + durationMs
+        )
+        val collaboration = song(
+            songId = "song-1",
+            artist = "Artist A",
+            artists = listOf(
+                ArtistRef(id = 1L, name = "Artist A", isPrimary = true),
+                ArtistRef(id = 2L, name = "Artist B", isPrimary = false)
+            )
+        )
+
+        val summary = repository.buildSummaryFromEvents(
+            range = StatsTimeRange.DAY,
+            songs = listOf(collaboration),
+            allEvents = listOf(event),
+            nowMillis = start + durationMs + 1_000L
+        )
+
+        assertThat(summary.topArtists.map { it.artist })
+            .containsExactly("Artist A", "Artist B")
+            .inOrder()
+        summary.topArtists.forEach { artist ->
+            assertThat(artist.totalDurationMs).isEqualTo(durationMs)
+            assertThat(artist.playCount).isEqualTo(1)
+            assertThat(artist.uniqueSongs).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `loadSummary counts separated artists in genre uniqueness`() = runTest {
+        val repository = createRepository()
+        val zoneId = ZoneId.systemDefault()
+        val start = LocalDate.of(2026, 4, 10)
+            .atTime(15, 0)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+        val durationMs = 30_000L
+        val event = PlaybackStatsRepository.PlaybackEvent(
+            songId = "song-1",
+            timestamp = start + durationMs,
+            durationMs = durationMs,
+            startTimestamp = start,
+            endTimestamp = start + durationMs
+        )
+        val collaboration = song(
+            songId = "song-1",
+            artist = "Artist A",
+            artists = listOf(
+                ArtistRef(id = 1L, name = "Artist A", isPrimary = true),
+                ArtistRef(id = 2L, name = "Artist B", isPrimary = false)
+            ),
+            genre = "Pop"
+        )
+
+        val summary = repository.buildSummaryFromEvents(
+            range = StatsTimeRange.DAY,
+            songs = listOf(collaboration),
+            allEvents = listOf(event),
+            nowMillis = start + durationMs + 1_000L
+        )
+
+        assertThat(summary.topGenres.single().uniqueArtists).isEqualTo(2)
+    }
+
     private fun createRepository(): PlaybackStatsRepository {
         val uniqueDir = createTempDirectory(
             "playback-stats-test-${Instant.now().toEpochMilli()}-"
@@ -151,17 +232,25 @@ class PlaybackStatsRepositoryTest {
         return PlaybackStatsRepository(testContext)
     }
 
-    private fun song(songId: String, durationMs: Long = 5 * 60 * 1000L): Song = Song(
+    private fun song(
+        songId: String,
+        durationMs: Long = 5 * 60 * 1000L,
+        artist: String = "Artist",
+        artists: List<ArtistRef> = emptyList(),
+        genre: String? = null
+    ): Song = Song(
         id = songId,
         title = "Song $songId",
-        artist = "Artist",
+        artist = artist,
         artistId = 1L,
+        artists = artists,
         album = "Album",
         albumId = 1L,
         path = "/music/$songId.mp3",
         contentUriString = "content://media/external/audio/media/$songId",
         albumArtUriString = null,
         duration = durationMs,
+        genre = genre,
         mimeType = "audio/mpeg",
         bitrate = 320_000,
         sampleRate = 44_100


### PR DESCRIPTION
Updates the statistics repository to attribute playback events to all individual artists associated with a song. Previously, statistics were calculated based on a single artist string; now, collaborations are correctly split among all participating artists, ensuring each receives credit for the duration and play count.

- Introduced `statsArtistNames` to extract and normalize individual artist names from song metadata.
- Refactored artist summary logic to group playback segments by individual artists using a new `ArtistSongPlayback` helper class.
- Updated genre summaries to count unique artists accurately across multi-artist tracks.
- Added unit tests to verify correct attribution for collaborations and artist uniqueness in genre stats.
- Added normalization logic for artist keys to handle case-sensitivity and whitespace.