### PR TITLE
feat: conditionally hide cloud storage filter in song picker

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -486,6 +486,9 @@ interface MusicDao {
     @Query("SELECT COUNT(*) FROM songs")
     fun getSongCount(): Flow<Int>
 
+    @Query("SELECT COUNT(*) FROM songs WHERE source_type != 0")
+    fun getCloudSongCount(): Flow<Int>
+
     @Query("SELECT COUNT(*) FROM songs")
     suspend fun getSongCountOnce(): Int
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepository.kt
@@ -84,6 +84,11 @@ interface MusicRepository {
     fun getSongCountFlow(): Flow<Int>
 
     /**
+     * Returns the count of cloud songs in the library.
+     */
+    fun getCloudSongCountFlow(): Flow<Int>
+
+    /**
      * Returns a random selection of songs for efficient shuffle.
      * Uses database-level RANDOM() for performance.
      * @param limit Maximum number of songs to return.

--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/MusicRepositoryImpl.kt
@@ -295,6 +295,10 @@ class MusicRepositoryImpl @Inject constructor(
         return musicDao.getSongCount().distinctUntilChanged()
     }
 
+    override fun getCloudSongCountFlow(): Flow<Int> {
+        return musicDao.getCloudSongCount().distinctUntilChanged()
+    }
+
     override suspend fun getRandomSongs(limit: Int): List<Song> = withContext(Dispatchers.IO) {
         val filter = cachedDirFilter.value
         musicDao.getRandomSongs(limit, filter.allowedParentDirs, filter.applyFilter).map { it.toSong() }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LargeExtendedFloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -56,6 +57,7 @@ import androidx.compose.material3.TextFieldDefaults
 import com.theveloper.pixelplay.data.model.StorageFilter
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -126,6 +128,16 @@ fun SongPickerContent(
     onConfirm: (Set<String>) -> Unit,
     playerViewModel: PlayerViewModel = hiltViewModel()
 ) {
+    val storageFilter by playerViewModel.playlistPickerStorageFilter.collectAsStateWithLifecycle()
+    val hasCloudSongs by playerViewModel.hasCloudSongsFlow.collectAsStateWithLifecycle()
+    val showCloudFilter = hasCloudSongs != false
+
+    LaunchedEffect(hasCloudSongs, storageFilter) {
+        if (hasCloudSongs == false && storageFilter != StorageFilter.OFFLINE) {
+            playerViewModel.setPlaylistPickerStorageFilter(StorageFilter.OFFLINE)
+        }
+    }
+
     Scaffold(
         containerColor = Color.Transparent,
         topBar = {
@@ -144,83 +156,112 @@ fun SongPickerContent(
             }
         },
         bottomBar = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .padding(horizontal = 16.dp, vertical = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                val storageFilter by playerViewModel.playlistPickerStorageFilter.collectAsStateWithLifecycle()
-                val tabs = listOf(
-                    StorageFilter.OFFLINE to R.string.library_storage_filter_offline,
-                    StorageFilter.ONLINE to R.string.library_storage_filter_online
-                )
-                val selectedTabIndex = tabs.indexOfFirst { it.first == storageFilter }.coerceAtLeast(0)
-
-                PrimaryTabRow(
-                    selectedTabIndex = selectedTabIndex,
+            if (showCloudFilter) {
+                Row(
                     modifier = Modifier
-                        .weight(1f)
-                        .clip(CircleShape)
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                        .padding(5.dp),
-                    containerColor = Color.Transparent,
-                    divider = {},
-                    indicator = {}
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    tabs.forEachIndexed { index, (filter, labelRes) ->
-                        TabAnimation(
-                            index = index,
-                            title = stringResource(labelRes),
-                            selectedIndex = selectedTabIndex,
-                            onClick = { playerViewModel.setPlaylistPickerStorageFilter(filter) },
-                            transformOrigin = if (index == 0) TransformOrigin(0f, 0.5f) else TransformOrigin(1f, 0.5f)
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.Center
+                    val tabs = listOf(
+                        StorageFilter.OFFLINE to R.string.library_storage_filter_offline,
+                        StorageFilter.ONLINE to R.string.library_storage_filter_online
+                    )
+                    val selectedTabIndex = tabs.indexOfFirst { it.first == storageFilter }.coerceAtLeast(0)
+
+                    PrimaryTabRow(
+                        selectedTabIndex = selectedTabIndex,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                            .padding(5.dp),
+                        containerColor = Color.Transparent,
+                        divider = {},
+                        indicator = {}
+                    ) {
+                        tabs.forEachIndexed { index, (filter, labelRes) ->
+                            TabAnimation(
+                                index = index,
+                                title = stringResource(labelRes),
+                                selectedIndex = selectedTabIndex,
+                                onClick = { playerViewModel.setPlaylistPickerStorageFilter(filter) },
+                                transformOrigin = if (index == 0) TransformOrigin(0f, 0.5f) else TransformOrigin(1f, 0.5f)
                             ) {
-                                if (filter == StorageFilter.OFFLINE) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.ic_phonef),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp)
-                                    )
-                                } else {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Cloud,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp)
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.Center
+                                ) {
+                                    if (filter == StorageFilter.OFFLINE) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.ic_phonef),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Cloud,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        text = stringResource(labelRes),
+                                        fontFamily = GoogleSansRounded,
+                                        fontWeight = FontWeight.Bold,
+                                        modifier = Modifier.padding(end = 4.dp)
                                     )
                                 }
-                                Spacer(Modifier.width(8.dp))
-                                Text(
-                                    text = stringResource(labelRes),
-                                    fontFamily = GoogleSansRounded,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(end = 4.dp)
-                                )
                             }
                         }
                     }
-                }
 
-                FilledIconButton(
-                    onClick = { onConfirm(selectedSongIds.filterValues { it }.keys) },
-                    modifier = Modifier.size(56.dp),
-                    shape = RoundedCornerShape(16.dp),
-                    colors = IconButtonDefaults.filledIconButtonColors(
+                    FilledIconButton(
+                        onClick = { onConfirm(selectedSongIds.filterValues { it }.keys) },
+                        modifier = Modifier.size(56.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = IconButtonDefaults.filledIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+                        )
+                    ) {
+                        Icon(
+                            Icons.Rounded.Check,
+                            contentDescription = stringResource(R.string.cd_confirm_add_songs),
+                            modifier = Modifier.size(28.dp)
+                        )
+                    }
+                }
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 16.dp, vertical = 16.dp)
+                ) {
+                    LargeExtendedFloatingActionButton(
+                        onClick = { onConfirm(selectedSongIds.filterValues { it }.keys) },
+                        modifier = Modifier.align(Alignment.CenterEnd),
+                        shape = RoundedCornerShape(20.dp),
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                         contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
-                ) {
-                    Icon(
-                        Icons.Rounded.Check,
-                        contentDescription = stringResource(R.string.cd_confirm_add_songs),
-                        modifier = Modifier.size(28.dp)
-                    )
+                    ) {
+                        Icon(
+                            Icons.Rounded.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp)
+                        )
+                        Spacer(Modifier.width(10.dp))
+                        Text(
+                            text = stringResource(R.string.song_picker_action_add),
+                            fontFamily = GoogleSansRounded,
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
                 }
             }
         }
@@ -228,12 +269,14 @@ fun SongPickerContent(
         SongPickerSelectionPane(
             selectedSongIds = selectedSongIds,
             modifier = Modifier.fillMaxSize().padding(top = innerPadding.calculateTopPadding()),
-            contentPadding = PaddingValues(bottom = 120.dp, top = 8.dp),
+            contentPadding = PaddingValues(
+                bottom = if (showCloudFilter) 120.dp else 128.dp,
+                top = 8.dp
+            ),
             playerViewModel = playerViewModel
         )
     }
 }
-
 @OptIn(UnstableApi::class)
 @Composable
 fun SongPickerSelectionPane(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
@@ -278,7 +278,7 @@ fun EditPlaylistDialog(
 }
 
 @OptIn(UnstableApi::class)
-@androidx.compose.runtime.Composable
+@Composable
 private fun CreatePlaylistContent(
     onDismiss: () -> Unit,
     onGenerateClick: () -> Unit,
@@ -1197,27 +1197,27 @@ private fun PlaylistFormContent(
             }
 
             // AI Generation Button - only show in Create mode (not Edit mode)
-            if (onGenerateClick != null) {
-                androidx.compose.material3.FilledTonalButton(
-                    onClick = onGenerateClick,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 22.dp),
-                    shape = RoundedCornerShape(14.dp),
-                    colors = ButtonDefaults.filledTonalButtonColors(
-                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.AutoAwesome, // Use built-in icon
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(R.string.presentation_batch_f_generate_with_ai), fontWeight = FontWeight.SemiBold)
-                }
-            }
+//            if (onGenerateClick != null) {
+//                androidx.compose.material3.FilledTonalButton(
+//                    onClick = onGenerateClick,
+//                    modifier = Modifier
+//                        .fillMaxWidth()
+//                        .padding(horizontal = 22.dp),
+//                    shape = RoundedCornerShape(14.dp),
+//                    colors = ButtonDefaults.filledTonalButtonColors(
+//                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+//                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer
+//                    )
+//                ) {
+//                    Icon(
+//                        imageVector = Icons.Rounded.AutoAwesome, // Use built-in icon
+//                        contentDescription = null,
+//                        modifier = Modifier.size(18.dp)
+//                    )
+//                    Spacer(modifier = Modifier.width(8.dp))
+//                    Text(stringResource(R.string.presentation_batch_f_generate_with_ai), fontWeight = FontWeight.SemiBold)
+//                }
+//            }
 
             AnimatedVisibility(visible = creationMode == PlaylistCreationMode.SMART) {
                 Column(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1161,6 +1161,15 @@ class PlayerViewModel @Inject constructor(
             initialValue = 0
         )
 
+    val hasCloudSongsFlow: StateFlow<Boolean?> = musicRepository.getCloudSongCountFlow()
+        .map<Int, Boolean?> { it > 0 }
+        .distinctUntilChanged()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = null
+        )
+
     val albumsFlow: StateFlow<ImmutableList<Album>> = libraryStateHolder.albums
     val artistsFlow: StateFlow<ImmutableList<Artist>> = libraryStateHolder.artists
 


### PR DESCRIPTION
Updates the `SongPickerBottomSheet` to dynamically hide storage filter tabs if no cloud-based songs are present in the library. When cloud content is unavailable, the UI replaces the filter row with a simplified confirmation floating action button.

- Added `getCloudSongCountFlow` to `MusicDao` and `MusicRepository` to monitor cloud-sourced media.
- Implemented `hasCloudSongsFlow` in `PlayerViewModel` to expose the presence of cloud content as a `StateFlow`.
- Updated `SongPickerBottomSheet` to conditionally render the storage toggle and adjust layout padding based on cloud song availability.
- Added a `LaunchedEffect` to reset the storage filter to `OFFLINE` if cloud content is missing.
- Commented out the AI generation button in `CreatePlaylistScreen`.