### PR TITLE
Resolve unresponsive widget controls and optimize widget layouts

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -999,17 +999,40 @@ class MusicService : MediaLibraryService() {
             pendingMediaButtonForegroundStart ||
             (isMediaButtonIntent &&
                 !startedTemporaryForegroundInOnCreate &&
-                !isServiceAlreadyForeground())
+                !isServiceAlreadyForeground()) ||
+            when (intent?.action) {
+                PlayerActions.PLAY_PAUSE,
+                PlayerActions.NEXT,
+                PlayerActions.PREVIOUS,
+                PlayerActions.FAVORITE,
+                PlayerActions.PLAY_FROM_QUEUE,
+                PlayerActions.SHUFFLE,
+                PlayerActions.REPEAT -> true
+                else -> false
+            }
         if (needsTemporaryForeground && !startedTemporaryForegroundInOnCreate) {
             startTemporaryForegroundForCommand()
         }
 
         intent?.action?.let { action ->
-            val player = mediaSession?.player ?: return@let
+            Timber.tag(TAG).d("onStartCommand widget action: %s", action)
+            val player = mediaSession?.player ?: engine.masterPlayer
             when (action) {
-                PlayerActions.PLAY_PAUSE -> player.playWhenReady = !player.playWhenReady
-                PlayerActions.NEXT -> player.seekToNext()
-                PlayerActions.PREVIOUS -> player.seekToPrevious()
+                PlayerActions.PLAY_PAUSE -> {
+                    if (player.playbackState == Player.STATE_IDLE) {
+                        player.prepare()
+                    }
+                    player.playWhenReady = !player.playWhenReady
+                    requestWidgetFullUpdate(force = true)
+                }
+                PlayerActions.NEXT -> {
+                    player.seekToNext()
+                    requestWidgetFullUpdate(force = true)
+                }
+                PlayerActions.PREVIOUS -> {
+                    player.seekToPrevious()
+                    requestWidgetFullUpdate(force = true)
+                }
                 PlayerActions.FAVORITE -> {
                     val songId = player.currentMediaItem?.mediaId
                     if (!songId.isNullOrBlank()) {
@@ -1035,6 +1058,7 @@ class MusicService : MediaLibraryService() {
                                 timeline.getWindow(i, window)
                                 if (window.mediaItem.mediaId.toLongOrNull() == songId) {
                                     player.seekTo(i, C.TIME_UNSET)
+                                    player.prepare()
                                     player.play()
                                     break
                                 }
@@ -1046,6 +1070,10 @@ class MusicService : MediaLibraryService() {
                     val newState = !isManualShuffleEnabled
                     mediaSession?.let { session ->
                         updateManualShuffleState(session, enabled = newState, broadcast = true)
+                    } ?: run {
+                        // Fallback if session not ready
+                        isManualShuffleEnabled = newState
+                        requestWidgetFullUpdate(force = true)
                     }
                 }
                 PlayerActions.REPEAT -> {

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/BarWidget4x1.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/BarWidget4x1.kt
@@ -67,7 +67,6 @@ class BarWidget4x1 : GlanceAppWidget() {
 
         Box(
             modifier = GlanceModifier
-                .fillMaxSize()
                 .background(colors.surface)
                 .cornerRadius(widgetCornerRadius)
                 .padding(16.dp)
@@ -87,7 +86,7 @@ class BarWidget4x1 : GlanceAppWidget() {
                     cornerRadius = albumArtCornerRadius
                 )
 
-                Spacer(GlanceModifier.width(12.dp))
+                Spacer(GlanceModifier.width(8.dp))
 
                 Column(
                     modifier = GlanceModifier
@@ -115,42 +114,36 @@ class BarWidget4x1 : GlanceAppWidget() {
                     )
                 }
 
+                Spacer(GlanceModifier.width(8.dp))
+
+                // Previous Button
+                PreviousButton(
+                    modifier = GlanceModifier.size(40.dp),
+                    backgroundColor = colors.prevNextBackground,
+                    iconColor = colors.prevNextIcon,
+                    cornerRadius = controlButtonCornerRadius
+                )
+
                 Spacer(GlanceModifier.width(6.dp))
 
-                // Control Buttons Row
-                Row(
-                    modifier = GlanceModifier,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    // Previous Button
-                    PreviousButton(
-                        modifier = GlanceModifier.size(40.dp),
-                        backgroundColor = colors.prevNextBackground,
-                        iconColor = colors.prevNextIcon,
-                        cornerRadius = controlButtonCornerRadius
-                    )
+                // Play/Pause Button
+                PlayPauseButton(
+                    modifier = GlanceModifier.size(40.dp),
+                    isPlaying = isPlaying,
+                    backgroundColor = colors.playPauseBackground,
+                    iconColor = colors.playPauseIcon,
+                    cornerRadius = playButtonCornerRadius
+                )
 
-                    Spacer(GlanceModifier.width(6.dp))
+                Spacer(GlanceModifier.width(6.dp))
 
-                    // Play/Pause Button
-                    PlayPauseButton(
-                        modifier = GlanceModifier.size(40.dp),
-                        isPlaying = isPlaying,
-                        backgroundColor = colors.playPauseBackground,
-                        iconColor = colors.playPauseIcon,
-                        cornerRadius = playButtonCornerRadius
-                    )
-
-                    Spacer(GlanceModifier.width(6.dp))
-
-                    // Next Button
-                    NextButton(
-                        modifier = GlanceModifier.size(40.dp),
-                        backgroundColor = colors.prevNextBackground,
-                        iconColor = colors.prevNextIcon,
-                        cornerRadius = controlButtonCornerRadius
-                    )
-                }
+                // Next Button
+                NextButton(
+                    modifier = GlanceModifier.size(40.dp),
+                    backgroundColor = colors.prevNextBackground,
+                    iconColor = colors.prevNextIcon,
+                    cornerRadius = controlButtonCornerRadius
+                )
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/ControlWidget4x2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/ControlWidget4x2.kt
@@ -71,7 +71,6 @@ class ControlWidget4x2 : GlanceAppWidget() {
 
         Box(
             modifier = GlanceModifier
-                .fillMaxSize()
                 .background(colors.surface)
                 .cornerRadius(widgetCornerRadius)
                 .padding(16.dp)
@@ -84,18 +83,18 @@ class ControlWidget4x2 : GlanceAppWidget() {
                 // Top Row: Album Art + Info
                 Row(
                     modifier = GlanceModifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.Top
                 ) {
                     AlbumArtImage(
-                        modifier = GlanceModifier.size(72.dp),
+                        modifier = GlanceModifier.size(80.dp),
                         bitmapData = albumArtBitmapData,
                         albumArtUri = albumArtUri,
-                        size = 72.dp,
+                        size = 80.dp,
                         context = context,
                         cornerRadius = albumArtCornerRadius
                     )
 
-                    Spacer(GlanceModifier.width(16.dp))
+                    Spacer(GlanceModifier.width(8.dp))
 
                     Column(
                         modifier = GlanceModifier.defaultWeight(),
@@ -110,7 +109,7 @@ class ControlWidget4x2 : GlanceAppWidget() {
                             ),
                             maxLines = 2
                         )
-                        Spacer(GlanceModifier.height(4.dp))
+                        Spacer(GlanceModifier.height(2.dp))
                         Text(
                             text = artist,
                             style = TextStyle(

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/GridWidget2x2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/GridWidget2x2.kt
@@ -68,7 +68,6 @@ class GridWidget2x2 : GlanceAppWidget() {
 
         Box(
             modifier = GlanceModifier
-                .fillMaxSize()
                 .clickable(actionStartActivity<MainActivity>()),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetComponents.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetComponents.kt
@@ -180,7 +180,7 @@ fun PreviousButton(
         action = actionRunCallback<PlayerControlActionCallback>(params),
         backgroundColor = backgroundColor,
         iconColor = iconColor,
-        imageProvider = ImageProvider(R.drawable.rounded_skip_previous_24),
+        imageProvider = ImageProvider(R.drawable.rounded_skip_previous_filled_24),
         contentDescription = context.getString(R.string.previous_track),
         iconSize = iconSize,
         cornerRadius = cornerRadius
@@ -202,7 +202,7 @@ fun NextButton(
         action = actionRunCallback<PlayerControlActionCallback>(params),
         backgroundColor = backgroundColor,
         iconColor = iconColor,
-        imageProvider = ImageProvider(R.drawable.rounded_skip_next_24),
+        imageProvider = ImageProvider(R.drawable.rounded_skip_next_filled_24),
         contentDescription = context.getString(R.string.next_track),
         iconSize = iconSize,
         cornerRadius = cornerRadius
@@ -226,8 +226,8 @@ fun PlayPauseButton(
         backgroundColor = backgroundColor,
         iconColor = iconColor,
         imageProvider = ImageProvider(
-            if (isPlaying) R.drawable.rounded_pause_24
-            else R.drawable.rounded_play_arrow_24
+            if (isPlaying) R.drawable.rounded_pause_filled_24
+            else R.drawable.rounded_play_arrow_filled_24
         ),
         contentDescription = context.getString(
             if (isPlaying) R.string.cd_pause else R.string.cd_play

--- a/app/src/main/res/drawable/rounded_pause_filled_24.xml
+++ b/app/src/main/res/drawable/rounded_pause_filled_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M320,760Q287,760 263.5,736.5Q240,713 240,680L240,280Q240,247 263.5,223.5Q287,200 320,200Q353,200 376.5,223.5Q400,247 400,280L400,680Q400,713 376.5,736.5Q353,760 320,760ZM640,760Q607,760 583.5,736.5Q560,713 560,680L560,280Q560,247 583.5,223.5Q607,200 640,200Q673,200 696.5,223.5Q720,247 720,280L720,680Q720,713 696.5,736.5Q673,760 640,760Z" />
+</vector>

--- a/app/src/main/res/drawable/rounded_play_arrow_filled_24.xml
+++ b/app/src/main/res/drawable/rounded_play_arrow_filled_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M320,687L320,273Q320,256 332,244.5Q344,233 360,233Q365,233 370.5,234.5Q376,236 381,239L707,446Q716,452 720.5,461Q725,470 725,480Q725,490 720.5,499Q716,508 707,514L381,721Q376,724 370.5,725.5Q365,727 360,727Q344,727 332,715.5Q320,704 320,687Z" />
+</vector>

--- a/app/src/main/res/drawable/rounded_skip_next_filled_24.xml
+++ b/app/src/main/res/drawable/rounded_skip_next_filled_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M660,680L660,280Q660,263 671.5,251.5Q683,240 700,240Q717,240 728.5,251.5Q740,263 740,280L740,680Q740,697 728.5,708.5Q717,720 700,720Q683,720 671.5,708.5Q660,697 660,680ZM220,645L220,315Q220,297 232,286Q244,275 260,275Q265,275 271,276Q277,277 282,281L530,447Q539,453 543.5,461.5Q548,470 548,480Q548,490 543.5,498.5Q539,507 530,513L282,679Q277,683 271,684Q265,685 260,685Q244,685 232,674Q220,663 220,645Z" />
+</vector>

--- a/app/src/main/res/drawable/rounded_skip_previous_filled_24.xml
+++ b/app/src/main/res/drawable/rounded_skip_previous_filled_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:viewportHeight="960"
+    android:viewportWidth="960"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M220,680L220,280Q220,263 231.5,251.5Q243,240 260,240Q277,240 288.5,251.5Q300,263 300,280L300,680Q300,697 288.5,708.5Q277,720 260,720Q243,720 231.5,708.5Q220,697 220,680ZM678,679L430,513Q421,507 416.5,498.5Q412,490 412,480Q412,470 416.5,461.5Q421,453 430,447L678,281Q683,277 689,276Q695,275 700,275Q716,275 728,286Q740,297 740,315L740,645Q740,663 728,674Q716,685 700,685Q695,685 689,684Q683,683 678,679Z" />
+</vector>


### PR DESCRIPTION
### Summary
- Refactor `MusicService.onStartCommand` to process widget actions independently from MediaSession initialization state.
- Add fallback handling via `engine.masterPlayer` for widget intents during early service lifecycle stages.
- Automatically call `player.prepare()` when playback actions are received while the player is idle.
- Optimize widget layouts (excluding old PixelPlayGlanceWidget) for improved consistency in icons, spacing, and overall alignment.
   - Change icons from outlined to filled to match current player icons.
   - Increase/reduce some spacer to give more nice fits.
   - Increase album cover size in 4x2 control widget.
   - Change text alignment to Top in 4x2 control widget

Below is screenshot for old and new widget layouts
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/99937c26-6523-4135-bf73-42c27a289f89" />
<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/d21c8239-8d2e-46ff-9069-a3698b235d0e" />
