### PR TITLE
ui: enforce single-line text for actions and add track location to queue

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AiMetadataSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AiMetadataSheet.kt
@@ -36,6 +36,7 @@ import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringResource
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -213,7 +214,7 @@ fun AiMetadataSheet(
                         shape = smoothCornerShape,
                         colors = ButtonDefaults.buttonColors(containerColor = colors.error)
                     ) {
-                        Text(stringResource(R.string.action_try_again))
+                        Text(stringResource(R.string.action_try_again), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }
@@ -230,7 +231,7 @@ fun AiMetadataSheet(
                 ) {
                     Icon(Icons.Rounded.Close, null)
                     Spacer(Modifier.width(8.dp))
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
                 Button(
                     onClick = {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AllFilesAccessDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AllFilesAccessDialog.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun AllFilesAccessDialog(
@@ -18,12 +19,12 @@ fun AllFilesAccessDialog(
         text = { Text(text = stringResource(id = R.string.all_files_access_description)) },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text(text = stringResource(id = R.string.grant_permission_button))
+                Text(text = stringResource(id = R.string.grant_permission_button), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(text = stringResource(id = R.string.cancel))
+                Text(text = stringResource(id = R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AppRebrandDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AppRebrandDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,7 +60,7 @@ fun AppRebrandDialog(
                     onDismiss()
                 }
             ) {
-                Text(text = stringResource(id = R.string.dismiss))
+                Text(text = stringResource(id = R.string.dismiss), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -506,7 +506,7 @@ private fun CastPermissionStep(
             modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(50)
         ) {
-            Text(text = stringResource(R.string.presentation_batch_g_cast_allow_access))
+            Text(text = stringResource(R.string.presentation_batch_g_cast_allow_access), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
 
         if (missingPermissions.isNotEmpty()) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CrashReportDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CrashReportDialog.kt
@@ -194,7 +194,7 @@ fun CrashReportDialog(
         confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.dismiss))
+                Text(stringResource(R.string.dismiss), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DismissUndoBar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DismissUndoBar.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun DismissUndoBar(
@@ -85,7 +86,7 @@ fun DismissUndoBar(
                         ),
                         onClick = onUndo
                     ) {
-                        Text(stringResource(R.string.action_undo), color = MaterialTheme.colorScheme.primary)
+                        Text(stringResource(R.string.action_undo), color = MaterialTheme.colorScheme.primary, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                     FilledIconButton(
                         colors = IconButtonDefaults.filledIconButtonColors(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
@@ -88,6 +88,7 @@ import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import java.io.ByteArrayOutputStream
 import java.util.Locale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 
 private fun formatReplayGainForInput(gainDb: Float?): String {
     return gainDb?.let { String.format(Locale.US, "%.2f", it) }.orEmpty()
@@ -272,7 +273,7 @@ private fun EditSongContent(
             text = { Text(stringResource(R.string.edit_song_info_dialog_body)) },
             confirmButton = {
                 TextButton(onClick = { showInfoDialog = false }) {
-                    Text(stringResource(R.string.edit_song_got_it))
+                    Text(stringResource(R.string.edit_song_got_it), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )
@@ -621,7 +622,7 @@ private fun EditSongContent(
                                 contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                             )
                         ) {
-                            Text(stringResource(R.string.cancel))
+                            Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                         Spacer(
                             modifier = Modifier.width(8.dp)
@@ -774,14 +775,14 @@ private fun CoverArtEditorCard(
                 FilledTonalButton(onClick = onPickNewArt) {
                     Icon(Icons.Rounded.Image, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(R.string.edit_song_change_cover_art))
+                    Text(stringResource(R.string.edit_song_change_cover_art), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
 
                 if (preview != null || isDeleted) {
                     TextButton(onClick = onReset) {
                         Icon(Icons.Rounded.Restore, contentDescription = null)
                         Spacer(modifier = Modifier.width(4.dp))
-                        Text(stringResource(R.string.action_reset))
+                        Text(stringResource(R.string.action_reset), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 } else if (albumArtUri != null) {
                     FilledTonalButton(
@@ -793,7 +794,7 @@ private fun CoverArtEditorCard(
                     ) {
                         Icon(Icons.Rounded.Delete, contentDescription = null)
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.edit_song_delete_cover_art))
+                        Text(stringResource(R.string.edit_song_delete_cover_art), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }
@@ -990,7 +991,7 @@ private fun CoverArtCropperDialog(
                         enabled = !isSaving,
                         onClick = onDismiss
                     ) {
-                        Text(stringResource(R.string.cancel))
+                        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
 
                     val canConfirm = !isLoading && loadError == null && loadedBitmap != null

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -508,7 +508,7 @@ fun LyricsSheet(
             confirmButton = {},
             dismissButton = {
                 TextButton(onClick = { showSaveLyricsDialog = false }) {
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/NoInternetComponents.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/NoInternetComponents.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun NoInternetDialog(
@@ -55,7 +56,7 @@ fun NoInternetDialog(
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.ok))
+                Text(stringResource(R.string.ok), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )
@@ -108,7 +109,7 @@ fun NoInternetScreen(
                 onClick = onRetry,
                 modifier = Modifier.fillMaxWidth(0.5f)
             ) {
-                Text(stringResource(R.string.auth_web_retry))
+                Text(stringResource(R.string.auth_web_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistContainer.kt
@@ -600,7 +600,7 @@ fun CreatePlaylistDialogRedesigned(
                         onClick = onDismiss,
                         modifier = Modifier.weight(1f)
                     ) {
-                        Text(stringResource(R.string.cancel), fontWeight = FontWeight.SemiBold)
+                        Text(stringResource(R.string.cancel), fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
 
                     Button(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistCreationDialogs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/PlaylistCreationDialogs.kt
@@ -102,6 +102,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun PlaylistCreationTypeDialog(
@@ -953,7 +954,7 @@ private fun ChipsSingleSelect(
                         customInputValue = ""
                     }
                 ) {
-                    Text(stringResource(R.string.action_save))
+                    Text(stringResource(R.string.action_save), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
@@ -961,7 +962,7 @@ private fun ChipsSingleSelect(
                     showCustomDialog = false
                     customInputValue = ""
                 }) {
-                    Text(stringResource(R.string.dismiss))
+                    Text(stringResource(R.string.dismiss), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -192,6 +192,7 @@ import kotlinx.coroutines.flow.map
 import java.util.RandomAccess
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import kotlin.math.abs
 
 private data class QueueUndoBarProjection(
     val isVisible: Boolean = false,
@@ -710,6 +711,18 @@ fun QueueBottomSheet(
                     onPlayPause = { viewModel.playPause() },
                     onNext = { viewModel.nextSong() },
                     colorScheme = albumColorScheme,
+                    onLocateCurrentSong = {
+                        if (currentSongDisplayIndex in 0..<displaySongCount) {
+                            queueCoroutineScope.launch {
+                                val firstVisible = listState.firstVisibleItemIndex
+                                if (abs(currentSongDisplayIndex - firstVisible) > 20) {
+                                    listState.scrollToItem(currentSongDisplayIndex)
+                                } else {
+                                    listState.animateScrollToItem(currentSongDisplayIndex)
+                                }
+                            }
+                        }
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .then(directSheetDragModifier)
@@ -1130,14 +1143,14 @@ fun QueueBottomSheet(
                             showClearQueueDialog = false
                         }
                     ) {
-                        Text(stringResource(R.string.presentation_batch_b_clear))
+                        Text(stringResource(R.string.presentation_batch_b_clear), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 },
                 dismissButton = {
                     TextButton(
                         onClick = { showClearQueueDialog = false }
                     ) {
-                        Text(stringResource(R.string.cancel))
+                        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             )
@@ -1204,6 +1217,7 @@ private fun QueueHeaderSection(
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
     colorScheme: ColorScheme? = null,
+    onLocateCurrentSong: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val colors = MaterialTheme.colorScheme
@@ -1232,7 +1246,8 @@ private fun QueueHeaderSection(
             QueueHeader(
                 queueSourceName = queueSourceName,
                 queueCount = queueCount,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                onLocateCurrentSong = onLocateCurrentSong
             )
         }
     }
@@ -1242,7 +1257,8 @@ private fun QueueHeaderSection(
 private fun QueueHeader(
     queueSourceName: String,
     queueCount: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onLocateCurrentSong: () -> Unit = {}
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -1254,6 +1270,12 @@ private fun QueueHeader(
             verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
             Text(
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) {
+                    onLocateCurrentSong()
+                },
                 text = stringResource(R.string.presentation_batch_e_next_up),
                 style = MaterialTheme.typography.headlineLarge.copy(
                     fontFamily = GoogleSansRounded,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderPresetsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderPresetsSheet.kt
@@ -77,6 +77,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -103,11 +104,11 @@ fun ReorderPresetsSheet(
                         onDismiss()
                     }
                 ) {
-                    Text(stringResource(R.string.cd_reset))
+                    Text(stringResource(R.string.cd_reset), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showResetDialog = false }) { Text(stringResource(R.string.cancel)) }
+                TextButton(onClick = { showResetDialog = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) }
             }
         )
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ReorderTabsSheet.kt
@@ -63,6 +63,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -92,14 +93,14 @@ fun ReorderTabsSheet(
                         showResetDialog = false
                     }
                 ) {
-                    Text(stringResource(R.string.action_reset))
+                    Text(stringResource(R.string.action_reset), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
                 TextButton(
                     onClick = { showResetDialog = false }
                 ) {
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SavePresetDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SavePresetDialog.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
 import androidx.compose.ui.res.stringResource
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun SavePresetDialog(
@@ -77,7 +78,7 @@ fun SavePresetDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
+                Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )
@@ -136,7 +137,7 @@ fun RenamePresetDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.cancel))
+                Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/SongPickerBottomSheet.kt
@@ -470,7 +470,7 @@ fun SongPickerPagingList(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     Button(onClick = { pagedSongs.retry() }) {
-                        Text(stringResource(R.string.library_retry))
+                        Text(stringResource(R.string.library_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }
@@ -532,7 +532,7 @@ fun SongPickerPagingList(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Button(onClick = { pagedSongs.retry() }) {
-                                    Text(stringResource(R.string.song_picker_load_more))
+                                    Text(stringResource(R.string.song_picker_load_more), maxLines = 1, overflow = TextOverflow.Ellipsis)
                                 }
                             }
                         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/TimerOptionsBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/TimerOptionsBottomSheet.kt
@@ -53,6 +53,7 @@ import kotlin.math.roundToInt
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.theveloper.pixelplay.R
+import androidx.compose.ui.text.style.TextOverflow
 
 val predefinedTimes = listOf(0, 5, 10, 15, 20, 30, 45, 60) // 0 represents 'Off'
 
@@ -442,7 +443,7 @@ fun TimerOptionsBottomSheet(
                         showCustomTimePicker = false // Dismiss the M3 dialog
                     }
                 ) {
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/FetchLyricsDialog.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/FetchLyricsDialog.kt
@@ -255,7 +255,7 @@ private fun IdleContent(
         ) {
             Icon(Icons.Rounded.Search, contentDescription = null, modifier = Modifier.size(20.dp))
             Spacer(modifier = Modifier.width(8.dp))
-            Text(stringResource(R.string.search))
+            Text(stringResource(R.string.search), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
 
         Button(
@@ -278,7 +278,7 @@ private fun IdleContent(
             modifier = Modifier.fillMaxWidth().height(52.dp),
             shape = RoundedCornerShape(18.dp)
         ) {
-            Text(stringResource(R.string.cancel))
+            Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }
@@ -344,7 +344,7 @@ private fun PickResultContent(
         modifier = Modifier.fillMaxWidth(),
         colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurfaceVariant)
     ) {
-        Text(stringResource(R.string.cancel))
+        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
     }
 }
 
@@ -550,7 +550,7 @@ fun NotFoundContent(
             modifier = Modifier.fillMaxWidth().height(52.dp),
             shape = RoundedCornerShape(18.dp)
         ) {
-            Text(stringResource(R.string.cancel))
+            Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }
@@ -603,7 +603,7 @@ private fun ErrorContent(
         ),
         shape = RoundedCornerShape(18.dp)
     ) {
-        Text(stringResource(R.string.ok))
+        Text(stringResource(R.string.ok), maxLines = 1, overflow = TextOverflow.Ellipsis)
     }
 }
 
@@ -663,7 +663,7 @@ private fun ErrorContent(
 //                                ) {
 //                                    Icon(painter = painterResource(R.drawable.rounded_upload_file_24), contentDescription = null, modifier = Modifier.size(18.dp))
 //                                    Spacer(modifier = Modifier.width(8.dp))
-//                                    Text(stringResource(R.string.import_file))
+//                                    Text(stringResource(R.string.import_file), maxLines = 1, overflow = TextOverflow.Ellipsis)
 //                                }
 //                                Button(
 //                                    onClick = onConfirm,
@@ -671,7 +671,7 @@ private fun ErrorContent(
 //                                ) {
 //                                    Icon(painter = painterResource(R.drawable.rounded_manage_search_24), contentDescription = null, modifier = Modifier.size(18.dp))
 //                                    Spacer(modifier = Modifier.width(8.dp))
-//                                    Text(stringResource(R.string.search))
+//                                    Text(stringResource(R.string.search), maxLines = 1, overflow = TextOverflow.Ellipsis)
 //                                }
 //                            }
 //                        }
@@ -794,7 +794,7 @@ private fun ErrorContent(
 //                                horizontalArrangement = Arrangement.End
 //                            ) {
 //                                TextButton(onClick = onDismiss) {
-//                                    Text(stringResource(R.string.ok))
+//                                    Text(stringResource(R.string.ok), maxLines = 1, overflow = TextOverflow.Ellipsis)
 //                                }
 //                            }
 //                        }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/subcomps/LyricsMoreBottomSheet.kt
@@ -51,6 +51,7 @@ import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.data.model.Lyrics
 import com.theveloper.pixelplay.presentation.components.ToggleSegmentButton
 import com.theveloper.pixelplay.presentation.components.player.BottomToggleRow
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -191,14 +192,14 @@ fun LyricsMoreBottomSheet(
                                 onResetImportedLyrics()
                             }
                         ) {
-                            Text(stringResource(R.string.action_reset), color = MaterialTheme.colorScheme.error)
+                            Text(stringResource(R.string.action_reset), color = MaterialTheme.colorScheme.error, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     },
                     dismissButton = {
                         androidx.compose.material3.TextButton(
                             onClick = { showResetDialog = false }
                         ) {
-                            Text(stringResource(R.string.cancel))
+                            Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     },
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/gdrive/dashboard/GDriveDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/gdrive/dashboard/GDriveDashboardScreen.kt
@@ -232,7 +232,7 @@ fun GDriveDashboardScreen(
                             modifier = Modifier.size(18.dp)
                         )
                         Spacer(Modifier.width(4.dp))
-                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded)
+                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/jellyfin/dashboard/JellyfinDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/jellyfin/dashboard/JellyfinDashboardScreen.kt
@@ -251,7 +251,7 @@ private fun JellyfinDashboardContent(
                         modifier = Modifier.size(18.dp)
                     )
                     Spacer(Modifier.width(4.dp))
-                    Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded)
+                    Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navidrome/dashboard/NavidromeDashboardScreen.kt
@@ -288,7 +288,7 @@ private fun DashboardContent(
                         modifier = Modifier.size(18.dp)
                     )
                     Spacer(Modifier.width(4.dp))
-                    Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded)
+                    Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/auth/NeteaseLoginActivity.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.delay
 import org.json.JSONObject
 import androidx.compose.ui.res.stringResource
 import android.content.Context
+import androidx.compose.ui.text.style.TextOverflow
 
 @AndroidEntryPoint
 class NeteaseLoginActivity : ComponentActivity() {
@@ -216,12 +217,12 @@ fun NeteaseWebLoginScreen(
                         onClose()
                     }
                 ) {
-                    Text(text = stringResource(R.string.auth_exit), fontFamily = GoogleSansRounded)
+                    Text(text = stringResource(R.string.auth_exit), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showExitDialog = false }) {
-                    Text(text = stringResource(R.string.auth_stay), fontFamily = GoogleSansRounded)
+                    Text(text = stringResource(R.string.auth_stay), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )
@@ -433,7 +434,7 @@ fun NeteaseWebLoginScreen(
                                 webView?.reload()
                             }
                         ) {
-                            Text(text = stringResource(R.string.auth_web_retry), fontFamily = GoogleSansRounded)
+                            Text(text = stringResource(R.string.auth_web_retry), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     }
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/netease/dashboard/NeteaseDashboardScreen.kt
@@ -226,7 +226,7 @@ fun NeteaseDashboardScreen(
                             modifier = Modifier.size(18.dp)
                         )
                         Spacer(Modifier.width(4.dp))
-                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded)
+                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/auth/QqMusicLoginActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/auth/QqMusicLoginActivity.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.delay
 import org.json.JSONObject
 import androidx.compose.ui.res.stringResource
 import android.content.Context
+import androidx.compose.ui.text.style.TextOverflow
 
 @AndroidEntryPoint
 class QqMusicLoginActivity : ComponentActivity() {
@@ -216,12 +217,12 @@ private fun QqMusicLoginScreen(
                         onClose()
                     }
                 ) {
-                    Text(text = stringResource(R.string.auth_exit), fontFamily = GoogleSansRounded)
+                    Text(text = stringResource(R.string.auth_exit), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showExitDialog = false }) {
-                    Text(text = stringResource(R.string.auth_stay), fontFamily = GoogleSansRounded)
+                    Text(text = stringResource(R.string.auth_stay), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )
@@ -434,7 +435,7 @@ private fun QqMusicLoginScreen(
                                 webView?.reload()
                             }
                         ) {
-                            Text(text = stringResource(R.string.auth_web_retry), fontFamily = GoogleSansRounded)
+                            Text(text = stringResource(R.string.auth_web_retry), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     }
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/qqmusic/dashboard/QqMusicDashboardScreen.kt
@@ -245,7 +245,7 @@ fun QqMusicDashboardScreen(
                             modifier = Modifier.size(18.dp)
                         )
                         Spacer(Modifier.width(4.dp))
-                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded)
+                        Text(stringResource(R.string.dash_action_sync), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DelimiterConfigScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DelimiterConfigScreen.kt
@@ -81,6 +81,7 @@ import com.theveloper.pixelplay.presentation.components.ExpressiveTopBarContent
 import com.theveloper.pixelplay.presentation.viewmodel.ArtistSettingsViewModel
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -430,7 +431,7 @@ fun DelimiterConfigScreen(
                     TextButton(
                         onClick = { showResetDialog = false }
                     ) {
-                        Text(stringResource(R.string.cancel))
+                        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 },
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import androidx.compose.ui.text.style.TextOverflow
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
@@ -229,7 +230,7 @@ fun LibraryAlbumsTab(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(onClick = { albums.retry() }) {
-                        Text(stringResource(R.string.library_retry))
+                        Text(stringResource(R.string.library_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }
@@ -539,7 +540,7 @@ fun LibraryArtistsTab(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(onClick = { artists.retry() }) {
-                        Text(stringResource(R.string.library_retry))
+                        Text(stringResource(R.string.library_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -375,7 +375,7 @@ private fun WatchTransferProgressDialog(
                         contentColor = MaterialTheme.colorScheme.onError
                     )
                 ) {
-                    Text(text = stringResource(R.string.presentation_batch_d_watch_cancel_transfer))
+                    Text(text = stringResource(R.string.presentation_batch_d_watch_cancel_transfer), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }
@@ -2143,7 +2143,7 @@ fun LibraryScreen(
                     pendingMergePlaylistIds = emptyList()
                     mergePlaylistName = ""
                 }) {
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
@@ -66,6 +66,7 @@ import com.theveloper.pixelplay.presentation.viewmodel.StablePlayerState
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import androidx.compose.ui.text.style.TextOverflow
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
@@ -353,7 +354,7 @@ fun LibrarySongsTabPaginated(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(onClick = { paginatedSongs.retry() }) {
-                        Text(stringResource(R.string.library_retry))
+                        Text(stringResource(R.string.library_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -54,6 +54,7 @@ import androidx.paging.LoadState
 import com.theveloper.pixelplay.R
 import com.theveloper.pixelplay.presentation.components.ExpressiveScrollBar
 import com.theveloper.pixelplay.presentation.components.songFastScrollLabel
+import androidx.compose.ui.text.style.TextOverflow
 
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -240,7 +241,7 @@ fun LibrarySongsTab(
                     )
                     Spacer(modifier = Modifier.height(8.dp))
                     Button(onClick = { songs.retry() }) {
-                        Text(stringResource(R.string.library_retry))
+                        Text(stringResource(R.string.library_retry), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/MashupScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/MashupScreen.kt
@@ -239,11 +239,11 @@ private fun DeckUi(
                     horizontalArrangement = Arrangement.SpaceAround,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    OutlinedButton(onClick = { onNudge(-100) }, enabled = deckState.song != null) { Text("<<") }
+                    OutlinedButton(onClick = { onNudge(-100) }, enabled = deckState.song != null) { Text("<<", maxLines = 1, overflow = TextOverflow.Ellipsis) }
                     IconButton(onClick = onPlayPause, enabled = deckState.song != null, modifier = Modifier.size(56.dp)) {
                         Icon(painter = painterResource(if (deckState.isPlaying) R.drawable.rounded_pause_24 else R.drawable.rounded_play_arrow_24), contentDescription = stringResource(R.string.mashup_cd_play_pause), modifier = Modifier.fillMaxSize())
                     }
-                    OutlinedButton(onClick = { onNudge(100) }, enabled = deckState.song != null) { Text(">>") }
+                    OutlinedButton(onClick = { onNudge(100) }, enabled = deckState.song != null) { Text(">>", maxLines = 1, overflow = TextOverflow.Ellipsis) }
                 }
 
                 Column(modifier = Modifier.padding(top = 8.dp)) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/PlaylistDetailScreen.kt
@@ -823,12 +823,12 @@ fun PlaylistDetailScreen(
                         showDeleteConfirmation = false
                     }
                 ) {
-                    Text(stringResource(R.string.delete_action))
+                    Text(stringResource(R.string.delete_action), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirmation = false }) {
-                    Text(stringResource(R.string.cancel))
+                    Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )
@@ -1062,8 +1062,8 @@ fun RenamePlaylistDialog(currentName: String, onDismiss: () -> Unit, onRename: (
             Button(
                 onClick = { if (newName.text.isNotBlank()) onRename(newName.text) },
                 enabled = newName.text.isNotBlank() && newName.text != currentName
-            ) { Text(renameAction) }
+            ) { Text(renameAction, maxLines = 1, overflow = TextOverflow.Ellipsis) }
         },
-        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) } }
+        dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) } }
     )
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/QuickFillScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/QuickFillScreen.kt
@@ -222,7 +222,7 @@ fun QuickFillContent(
                             contentPadding = PaddingValues(horizontal = 16.dp),
                             modifier = Modifier.fillMaxHeight()
                         ) {
-                            Text(stringResource(R.string.presentation_batch_b_select_all), style = MaterialTheme.typography.labelLarge)
+                            Text(stringResource(R.string.presentation_batch_b_select_all), style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                         
                         // Divider/Spacer
@@ -238,7 +238,7 @@ fun QuickFillContent(
                             contentPadding = PaddingValues(horizontal = 16.dp),
                             modifier = Modifier.fillMaxHeight()
                         ) {
-                            Text(stringResource(R.string.presentation_batch_b_clear), style = MaterialTheme.typography.labelLarge)
+                            Text(stringResource(R.string.presentation_batch_b_clear), style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
                         }
                     }
                     Spacer(modifier = Modifier.weight(1f))
@@ -458,10 +458,10 @@ fun GenreValidatorContent(
                             showCustomDialog = false
                         }
                     }
-                ) { Text(addLabel) }
+                ) { Text(addLabel, maxLines = 1, overflow = TextOverflow.Ellipsis) }
             },
             dismissButton = {
-                TextButton(onClick = { showCustomDialog = false }) { Text(stringResource(R.string.cancel)) }
+                TextButton(onClick = { showCustomDialog = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) }
             }
         )
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -562,7 +562,7 @@ fun SearchHistoryList(
             )
             if (historyItems.isNotEmpty()) {
                 TextButton(onClick = onClearAllHistory) {
-                    Text(stringResource(R.string.clear_all))
+                    Text(stringResource(R.string.clear_all), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsCategoryScreen.kt
@@ -1409,7 +1409,7 @@ fun SettingsCategoryScreen(
                         onClick = {},
                         enabled = false
                     ) {
-                        Text(stringResource(R.string.working_ellipsis))
+                        Text(stringResource(R.string.working_ellipsis), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 } else {
                     TextButton(
@@ -1452,7 +1452,7 @@ fun SettingsCategoryScreen(
                     TextButton(
                         onClick = { showRegenerateAllPalettesDialog = false }
                     ) {
-                        Text(stringResource(R.string.cancel))
+                        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }
@@ -1466,8 +1466,8 @@ fun SettingsCategoryScreen(
             title = { Text(stringResource(R.string.dialog_reset_lyrics_title)) },
             text = { Text(stringResource(R.string.dialog_cannot_undo)) },
             onDismissRequest = { showClearLyricsDialog = false },
-            confirmButton = { TextButton(onClick = { showClearLyricsDialog = false; playerViewModel.resetAllLyrics() }) { Text(stringResource(R.string.confirm)) } },
-            dismissButton = { TextButton(onClick = { showClearLyricsDialog = false }) { Text(stringResource(R.string.cancel)) } }
+            confirmButton = { TextButton(onClick = { showClearLyricsDialog = false; playerViewModel.resetAllLyrics() }) { Text(stringResource(R.string.confirm), maxLines = 1, overflow = TextOverflow.Ellipsis) } },
+            dismissButton = { TextButton(onClick = { showClearLyricsDialog = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) } }
         )
     }
 
@@ -1493,7 +1493,7 @@ fun SettingsCategoryScreen(
                     Text(stringResource(R.string.rebuild)) 
                 } 
             },
-            dismissButton = { TextButton(onClick = { showRebuildDatabaseWarning = false }) { Text(stringResource(R.string.cancel)) } }
+            dismissButton = { TextButton(onClick = { showRebuildDatabaseWarning = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) } }
         )
     }
 
@@ -1511,10 +1511,10 @@ fun SettingsCategoryScreen(
                         Toast.makeText(context, context.getString(R.string.toast_daily_mix_regeneration_started), Toast.LENGTH_SHORT).show()
                     }
                 ) {
-                    Text(stringResource(R.string.dialog_regenerate))
+                    Text(stringResource(R.string.dialog_regenerate), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
-            dismissButton = { TextButton(onClick = { showRegenerateDailyMixDialog = false }) { Text(stringResource(R.string.cancel)) } }
+            dismissButton = { TextButton(onClick = { showRegenerateDailyMixDialog = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) } }
         )
     }
 
@@ -1532,10 +1532,10 @@ fun SettingsCategoryScreen(
                         Toast.makeText(context, context.getString(R.string.toast_stats_regeneration_started), Toast.LENGTH_SHORT).show()
                     }
                 ) {
-                    Text(stringResource(R.string.dialog_regenerate))
+                    Text(stringResource(R.string.dialog_regenerate), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
-            dismissButton = { TextButton(onClick = { showRegenerateStatsDialog = false }) { Text(stringResource(R.string.cancel)) } }
+            dismissButton = { TextButton(onClick = { showRegenerateStatsDialog = false }) { Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis) } }
         )
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsComponents.kt
@@ -697,7 +697,7 @@ fun ActionSettingsItem(
                 enabled = enabled,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(primaryActionLabel)
+                Text(primaryActionLabel, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
 
             // Secondary Action (Optional)
@@ -708,7 +708,7 @@ fun ActionSettingsItem(
                     enabled = enabled,
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text(secondaryActionLabel)
+                    Text(secondaryActionLabel, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         }
@@ -770,7 +770,7 @@ fun AiApiKeyItem(
                     },
                     enabled = hasChanges
                 ) {
-                    Text(stringResource(R.string.presentation_batch_f_save))
+                    Text(stringResource(R.string.presentation_batch_f_save), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
                 if (showSaved) {
                     Text(
@@ -879,13 +879,13 @@ fun AiSystemPromptItem(
                     },
                     enabled = hasChanges
                 ) {
-                    Text(stringResource(R.string.presentation_batch_f_save))
+                    Text(stringResource(R.string.presentation_batch_f_save), maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
                 if (!isDefault) {
                     OutlinedButton(onClick = {
                         onReset()
                     }) {
-                        Text(stringResource(R.string.presentation_batch_f_reset))
+                        Text(stringResource(R.string.presentation_batch_f_reset), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
                 if (showSaved) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SetupScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SetupScreen.kt
@@ -160,6 +160,7 @@ import java.util.Date
 import java.util.Locale
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalPermissionsApi::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
@@ -502,7 +503,7 @@ fun DirectorySelectionPage(
         )
     ) {
         TextButton(onClick = onSkip) {
-            Text(stringResource(R.string.skip_for_now))
+            Text(stringResource(R.string.skip_for_now), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 
@@ -873,7 +874,7 @@ fun AlarmsPermissionPage(
     ) {
         if (!isGranted) {
             TextButton(onClick = onSkip) {
-                Text(stringResource(R.string.skip_for_now))
+                Text(stringResource(R.string.skip_for_now), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }
@@ -959,7 +960,7 @@ fun BackupRestorePage(
             onClick = onSkip,
             enabled = !uiState.isRestoringBackup
         ) {
-            Text(stringResource(R.string.skip_not_now))
+            Text(stringResource(R.string.skip_not_now), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }
@@ -1506,7 +1507,7 @@ fun BatteryOptimizationPage(
     ) {
         if (!isIgnoringBatteryOptimizations) {
             TextButton(onClick = onSkip) {
-                Text(stringResource(R.string.skip_for_now))
+                Text(stringResource(R.string.skip_for_now), maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }
@@ -1674,7 +1675,7 @@ private fun SetupRestoreDialog(
                                 enabled = !inProgress,
                                 modifier = Modifier.height(52.dp)
                             ) {
-                                Text(stringResource(R.string.cancel))
+                                Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                             }
                             Button(
                                 onClick = onConfirm,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/WordDelimiterConfigScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/WordDelimiterConfigScreen.kt
@@ -75,6 +75,7 @@ import com.theveloper.pixelplay.presentation.components.CollapsibleCommonTopBar
 import com.theveloper.pixelplay.presentation.viewmodel.ArtistSettingsViewModel
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import androidx.compose.ui.text.style.TextOverflow
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -425,7 +426,7 @@ fun WordDelimiterConfigScreen(
                     TextButton(
                         onClick = { showResetDialog = false }
                     ) {
-                        Text(stringResource(R.string.cancel))
+                        Text(stringResource(R.string.cancel), maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 },
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/auth/TelegramLoginActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/auth/TelegramLoginActivity.kt
@@ -113,6 +113,7 @@ import org.drinkless.tdlib.TdApi
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import java.util.Locale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 
 @AndroidEntryPoint
 class TelegramLoginActivity : ComponentActivity() {
@@ -849,10 +850,10 @@ fun ExpressiveCodeInput(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             TextButton(onClick = onEditPhone, enabled = !isLoading) {
-                Text(text = stringResource(R.string.presentation_batch_f_edit_phone), fontFamily = GoogleSansRounded)
+                Text(text = stringResource(R.string.presentation_batch_f_edit_phone), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
             TextButton(onClick = onResendCode, enabled = !isLoading) {
-                Text(text = stringResource(R.string.presentation_batch_f_resend_code), fontFamily = GoogleSansRounded)
+                Text(text = stringResource(R.string.presentation_batch_f_resend_code), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
 
@@ -964,7 +965,7 @@ fun ExpressivePasswordInput(
             horizontalArrangement = Arrangement.End
         ) {
             TextButton(onClick = onEditPhone, enabled = !isLoading) {
-                Text(text = stringResource(R.string.presentation_batch_f_edit_phone), fontFamily = GoogleSansRounded)
+                Text(text = stringResource(R.string.presentation_batch_f_edit_phone), fontFamily = GoogleSansRounded, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/telegram/dashboard/TelegramDashboardScreen.kt
@@ -957,7 +957,7 @@ private fun ExpressiveEmptyState(
                 modifier = Modifier.size(18.dp)
             )
             Spacer(modifier = Modifier.size(8.dp))
-            Text(stringResource(R.string.presentation_batch_f_add_channel_button))
+            Text(stringResource(R.string.presentation_batch_f_add_channel_button), maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }


### PR DESCRIPTION
Updates `Text` components across the presentation layer to ensure consistent UI behavior on smaller screens or with long localized strings. Additionally, introduces a "tap to locate" feature in the queue header to navigate quickly to the currently playing track.

- Applied `maxLines = 1` and `TextOverflow.Ellipsis` to buttons, dialog actions, and labels across multiple screens and sheets.
- Added a clickable interaction to the "Next Up" header in `QueueBottomSheet` to trigger track location.
- Implemented smart scrolling logic in `QueueBottomSheet` that uses animated scrolling for nearby items and instant scrolling for distant tracks.
- Updated relevant imports for `TextOverflow` and math utilities across the modified components.