### PR TITLE
perf: critical Compose recomposition hotspot fixes

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -89,6 +89,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -179,7 +181,14 @@ fun CastBottomSheet(
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsStateWithLifecycle()
     val isCastConnecting by playerViewModel.isCastConnecting.collectAsStateWithLifecycle()
     val trackVolume by playerViewModel.trackVolume.collectAsStateWithLifecycle()
-    val isPlaying = playerViewModel.stablePlayerState.collectAsStateWithLifecycle().value.isPlaying
+    // Slice the stablePlayerState flow to just isPlaying before collecting; the
+    // full StablePlayerState changes on every position tick (~4×/s) but only
+    // isPlaying matters here.
+    val isPlaying by remember(playerViewModel) {
+        playerViewModel.stablePlayerState
+            .map { it.isPlaying }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = false)
     val context = LocalContext.current
 
     val requiredPermissions = remember {
@@ -217,73 +226,91 @@ fun CastBottomSheet(
     val activeRoute = selectedRoute?.takeUnless { it.isDefault }
     val isRemoteSession = (isRemotePlaybackActive || isCastConnecting) && activeRoute != null
 
-    val availableRoutes = if (isWifiEnabled) {
-        routes.filterNot { it.isDefault }
-    } else {
-        emptyList()
+    // Derived lists wrapped in remember so they don't rebuild on every recomposition.
+    // The sheet ticks frequently (Bluetooth state changes, Wi-Fi name updates, route
+    // volume drag, etc.) — without these wrappers each tick re-filters/re-maps the
+    // route + bluetooth lists.
+    val availableRoutes = remember(routes, isWifiEnabled) {
+        if (isWifiEnabled) routes.filterNot { it.isDefault } else emptyList()
     }
-    val bluetoothDevices = bluetoothAudioDeviceStates
-        .map { state -> state.copy(name = state.name.trim()) }
-        .filter { it.name.isNotEmpty() }
-        .distinctBy { it.stableId() }
-    val activeBluetoothName = bluetoothName
-        ?.trim()
-        ?.takeIf { activeName ->
-            activeName.isNotEmpty() && bluetoothDevices.any { it.name == activeName }
-        }
+    val bluetoothDevices = remember(bluetoothAudioDeviceStates) {
+        bluetoothAudioDeviceStates
+            .map { state -> state.copy(name = state.name.trim()) }
+            .filter { it.name.isNotEmpty() }
+            .distinctBy { it.stableId() }
+    }
+    val activeBluetoothName = remember(bluetoothName, bluetoothDevices) {
+        bluetoothName
+            ?.trim()
+            ?.takeIf { activeName ->
+                activeName.isNotEmpty() && bluetoothDevices.any { it.name == activeName }
+            }
+    }
 
-    val devices = buildList {
-        if (isWifiEnabled) {
-            addAll(
-                availableRoutes.map { route ->
-                    val isRouteActive = activeRoute?.id == route.id
-                    val normalizedConnectionState = when {
-                        isRouteActive && isCastConnecting ->
-                            MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTING
-                        isRouteActive && isRemoteSession ->
-                            MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED
-                        route.connectionState == MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED ->
-                            MediaRouter.RouteInfo.CONNECTION_STATE_DISCONNECTED
-                        else -> route.connectionState
+    val devices = remember(
+        isWifiEnabled,
+        isBluetoothEnabled,
+        availableRoutes,
+        bluetoothDevices,
+        activeRoute?.id,
+        isCastConnecting,
+        isRemoteSession,
+        activeBluetoothName,
+        trackVolume
+    ) {
+        buildList {
+            if (isWifiEnabled) {
+                addAll(
+                    availableRoutes.map { route ->
+                        val isRouteActive = activeRoute?.id == route.id
+                        val normalizedConnectionState = when {
+                            isRouteActive && isCastConnecting ->
+                                MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTING
+                            isRouteActive && isRemoteSession ->
+                                MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED
+                            route.connectionState == MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED ->
+                                MediaRouter.RouteInfo.CONNECTION_STATE_DISCONNECTED
+                            else -> route.connectionState
+                        }
+
+                        CastDeviceUi(
+                            id = route.id,
+                            name = route.name,
+                            deviceType = route.deviceType,
+                            playbackType = route.playbackType,
+                            connectionState = normalizedConnectionState,
+                            volumeHandling = route.volumeHandling,
+                            volume = route.volume,
+                            volumeMax = route.volumeMax,
+                            isSelected = isRouteActive
+                        )
                     }
+                )
+            }
 
-                    CastDeviceUi(
-                        id = route.id,
-                        name = route.name,
-                        deviceType = route.deviceType,
-                        playbackType = route.playbackType,
-                        connectionState = normalizedConnectionState,
-                        volumeHandling = route.volumeHandling,
-                        volume = route.volume,
-                        volumeMax = route.volumeMax,
-                        isSelected = isRouteActive
+            if (isBluetoothEnabled) {
+                bluetoothDevices.forEach { bluetoothDevice ->
+                    val isConnected = bluetoothDevice.name == activeBluetoothName
+                    add(
+                        CastDeviceUi(
+                            id = "bluetooth_${bluetoothDevice.stableId()}",
+                            name = bluetoothDevice.name,
+                            deviceType = MediaRouter.RouteInfo.DEVICE_TYPE_BLUETOOTH_A2DP,
+                            playbackType = MediaRouter.RouteInfo.PLAYBACK_TYPE_LOCAL,
+                            connectionState = if (isConnected) {
+                                MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED
+                            } else {
+                                MediaRouter.RouteInfo.CONNECTION_STATE_DISCONNECTED
+                            },
+                            volumeHandling = MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE,
+                            volume = if (isConnected) (trackVolume * 100).toInt() else 0,
+                            volumeMax = 100,
+                            isSelected = isConnected && !isRemoteSession,
+                            batteryPercent = bluetoothDevice.batteryPercent,
+                            isBluetooth = true
+                        )
                     )
                 }
-            )
-        }
-
-        if (isBluetoothEnabled) {
-            bluetoothDevices.forEach { bluetoothDevice ->
-                val isConnected = bluetoothDevice.name == activeBluetoothName
-                add(
-                    CastDeviceUi(
-                        id = "bluetooth_${bluetoothDevice.stableId()}",
-                        name = bluetoothDevice.name,
-                        deviceType = MediaRouter.RouteInfo.DEVICE_TYPE_BLUETOOTH_A2DP,
-                        playbackType = MediaRouter.RouteInfo.PLAYBACK_TYPE_LOCAL,
-                        connectionState = if (isConnected) {
-                            MediaRouter.RouteInfo.CONNECTION_STATE_CONNECTED
-                        } else {
-                            MediaRouter.RouteInfo.CONNECTION_STATE_DISCONNECTED
-                        },
-                        volumeHandling = MediaRouter.RouteInfo.PLAYBACK_VOLUME_VARIABLE,
-                        volume = if (isConnected) (trackVolume * 100).toInt() else 0,
-                        volumeMax = 100,
-                        isSelected = isConnected && !isRemoteSession,
-                        batteryPercent = bluetoothDevice.batteryPercent,
-                        isBluetooth = true
-                    )
-                )
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/DailyMixSection.kt
@@ -188,8 +188,11 @@ private fun DailyMixCard(
     playerViewModel: PlayerViewModel,
     onMoreOptionsClick: (Song) -> Unit
 ) {
-    val headerSongs = songs.take(3).toImmutableList()
-    val visibleSongs = songs.take(4).toImmutableList()
+    // .toImmutableList() runs O(n) on every recomposition without remember,
+    // and headerSongs / visibleSongs are derived only from `songs`. Wrap them
+    // so the take + immutable conversion only happens when songs changes.
+    val headerSongs = remember(songs) { songs.take(3).toImmutableList() }
+    val visibleSongs = remember(songs) { songs.take(4).toImmutableList() }
     val cornerRadius = 30.dp
     Card(
         shape = AbsoluteSmoothCornerShape(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -121,9 +121,11 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.compose.ui.platform.LocalView
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.theveloper.pixelplay.data.preferences.dataStore
 
@@ -177,6 +179,29 @@ internal fun lyricsSheetColors(colorScheme: ColorScheme): LyricsSheetColors {
         syncButtonContent = colorScheme.onSecondaryFixed
     )
 }
+
+/** Single snapshot of all seven lyrics-sheet preferences read directly from DataStore. */
+@androidx.compose.runtime.Immutable
+private data class LyricsSheetPrefs(
+    val alignment: String = "left",
+    val showTranslation: Boolean = true,
+    val showRomanization: Boolean = true,
+    val useAnimated: Boolean = false,
+    val animatedBlurEnabled: Boolean = true,
+    val animatedBlurStrength: Float = 2.5f,
+    val keepScreenOn: Boolean = false
+)
+
+private fun androidx.datastore.preferences.core.Preferences.toLyricsSheetPrefs(): LyricsSheetPrefs =
+    LyricsSheetPrefs(
+        alignment = this[stringPreferencesKey("lyrics_alignment")] ?: "left",
+        showTranslation = this[booleanPreferencesKey("show_lyrics_translation")] ?: true,
+        showRomanization = this[booleanPreferencesKey("show_lyrics_romanization")] ?: true,
+        useAnimated = this[booleanPreferencesKey("use_animated_lyrics")] ?: false,
+        animatedBlurEnabled = this[booleanPreferencesKey("animated_lyrics_blur_enabled")] ?: true,
+        animatedBlurStrength = this[floatPreferencesKey("animated_lyrics_blur_strength")] ?: 2.5f,
+        keepScreenOn = this[booleanPreferencesKey("keep_screen_on_lyrics")] ?: false
+    )
 
 private fun preferredContrastColor(
     background: Color,
@@ -298,10 +323,15 @@ fun LyricsSheet(
     val playPauseColor = sheetColors.playPauseContainer
     val onPlayPauseColor = sheetColors.playPauseContent
 
-    val isLoadingLyrics by remember(stablePlayerState) { derivedStateOf { stablePlayerState.isLoadingLyrics } }
-    val lyrics by remember(stablePlayerState) { derivedStateOf { stablePlayerState.lyrics } }
-    val isPlaying by remember(stablePlayerState) { derivedStateOf { stablePlayerState.isPlaying } }
-    val currentSong by remember(stablePlayerState) { derivedStateOf { stablePlayerState.currentSong } }
+    // These are plain captured values from the stablePlayerState parameter, not
+    // reads of State<T>, so derivedStateOf adds an extra State layer without
+    // the dependency-tracking it normally provides. Direct destructuring is
+    // sufficient — when stablePlayerState recomposes the parent, these locals
+    // recompute as part of the normal recomposition.
+    val isLoadingLyrics = stablePlayerState.isLoadingLyrics
+    val lyrics = stablePlayerState.lyrics
+    val isPlaying = stablePlayerState.isPlaying
+    val currentSong = stablePlayerState.currentSong
 
     val hasTranslatedLyrics = remember(lyrics) {
         // Translated lyrics read same timestamp on the lrc, not possible in plain type lyrics
@@ -318,48 +348,31 @@ fun LyricsSheet(
 
     val context = LocalContext.current
 
-    // Read lyrics alignment preference internally from DataStore
-    val lyricsAlignmentFlow = remember(context) {
-        context.dataStore.data.map { it[stringPreferencesKey("lyrics_alignment")] ?: "left" }
-    }
-    val lyricsAlignment by lyricsAlignmentFlow.collectAsStateWithLifecycle(initialValue = "left")
+    // Read all seven lyrics-sheet preferences in a single DataStore subscription.
+    // Previously each preference (alignment, translation, romanization, animated,
+    // blur enabled, blur strength, keep-screen-on) created its own collector
+    // mapping the same Preferences object — seven collectors observing one flow.
+    // Combined into a single mapped flow with distinctUntilChanged. The
+    // architectural-violation note from the perf audit (these reads bypass
+    // UserPreferencesRepository) is still open as a separate refactor.
+    val lyricsPrefs by remember(context) {
+        context.dataStore.data
+            .map { prefs -> prefs.toLyricsSheetPrefs() }
+            .distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = LyricsSheetPrefs())
+    val lyricsAlignment = lyricsPrefs.alignment
+    val showLyricsTranslation = lyricsPrefs.showTranslation
+    val showLyricsRomanization = lyricsPrefs.showRomanization
+    val useAnimatedLyrics = lyricsPrefs.useAnimated
+    val animatedLyricsBlurEnabled = lyricsPrefs.animatedBlurEnabled
+    val animatedLyricsBlurStrength = lyricsPrefs.animatedBlurStrength
 
-    // Read lyrics translation preference internally from DataStore
-    val showLyricsTranslationFlow = remember(context) {
-        context.dataStore.data.map { it[booleanPreferencesKey("show_lyrics_translation")] ?: true }
-    }
-    val showLyricsTranslation by showLyricsTranslationFlow.collectAsStateWithLifecycle(initialValue = true)
-
-    // Read lyrics romanization preference internally from DataStore
-    val showLyricsRomanizationFlow = remember(context) {
-        context.dataStore.data.map { it[booleanPreferencesKey("show_lyrics_romanization")] ?: true }
-    }
-    val showLyricsRomanization by showLyricsRomanizationFlow.collectAsStateWithLifecycle(initialValue = true)
-
-    // Read animated lyrics preference internally from DataStore
-    val useAnimatedLyricsFlow = remember(context) {
-        context.dataStore.data.map { it[booleanPreferencesKey("use_animated_lyrics")] ?: false }
-    }
-    val useAnimatedLyrics by useAnimatedLyricsFlow.collectAsStateWithLifecycle(initialValue = false)
-
-    val animatedLyricsBlurEnabledFlow = remember(context) {
-        context.dataStore.data.map { it[booleanPreferencesKey("animated_lyrics_blur_enabled")] ?: true }
-    }
-    val animatedLyricsBlurEnabled by animatedLyricsBlurEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
-
-    val animatedLyricsBlurStrengthFlow = remember(context) {
-        context.dataStore.data.map { it[androidx.datastore.preferences.core.floatPreferencesKey("animated_lyrics_blur_strength")] ?: 2.5f }
-    }
-    val animatedLyricsBlurStrength by animatedLyricsBlurStrengthFlow.collectAsStateWithLifecycle(initialValue = 2.5f)
-
-    // Read keep-screen-on preference from DataStore
-    val keepScreenOnFlow = remember(context) {
-        context.dataStore.data.map { it[booleanPreferencesKey("keep_screen_on_lyrics")] ?: false }
-    }
+    // keep-screen-on still uses a mutable local state because the lifecycle
+    // observer below writes back to DataStore on ON_STOP, and the sheet's
+    // toggle button drives it locally.
     var keepScreenOn by remember { mutableStateOf(false) }
-    // Sync DataStore → local state
-    LaunchedEffect(Unit) {
-        keepScreenOnFlow.collect { keepScreenOn = it }
+    LaunchedEffect(lyricsPrefs.keepScreenOn) {
+        keepScreenOn = lyricsPrefs.keepScreenOn
     }
     val coroutineScope = rememberCoroutineScope()
 
@@ -379,29 +392,6 @@ fun LyricsSheet(
             }
         }
 
-        if (keepScreenOn) {
-            view.keepScreenOn = true
-        }
-
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            view.keepScreenOn = false
-            lifecycleOwner.lifecycle.removeObserver(observer)
-        }
-    }
-
-    DisposableEffect(keepScreenOn, lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
-            if (event == androidx.lifecycle.Lifecycle.Event.ON_STOP && keepScreenOn) {
-                keepScreenOn = false
-                coroutineScope.launch {
-                    context.dataStore.edit { prefs ->
-                        prefs[booleanPreferencesKey("keep_screen_on_lyrics")] = false
-                    }
-                }
-            }
-        }
-        
         if (keepScreenOn) {
             view.keepScreenOn = true
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -1,11 +1,15 @@
 package com.theveloper.pixelplay.presentation.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColor
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDp
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -158,6 +162,7 @@ import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import kotlin.math.roundToInt
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -199,6 +204,19 @@ private data class QueueUndoBarProjection(
     val removedSongTitle: String = ""
 )
 
+/**
+ * Triple of orthogonal animation drivers for a queue item. Packed into a
+ * single value so QueuePlaylistSongItem can run one updateTransition
+ * (and the framework reuses one set of animation runtime objects) instead
+ * of six independent animateXAsState calls.
+ */
+@androidx.compose.runtime.Immutable
+private data class QueueItemAnimState(
+    val isCurrentSong: Boolean,
+    val isDragging: Boolean,
+    val isSwipeTargeted: Boolean
+)
+
 private fun PlayerUiState.toQueueUndoBarProjection(): QueueUndoBarProjection =
     QueueUndoBarProjection(
         isVisible = showQueueItemUndoBar,
@@ -214,7 +232,7 @@ fun QueueBottomSheet(
     viewModel: PlayerViewModel = hiltViewModel(),
     playlistViewModel: PlaylistViewModel = hiltViewModel(),
     settingsViewModel: SettingsViewModel = hiltViewModel(),
-    queue: List<Song>,
+    queue: ImmutableList<Song>,
     currentQueueSourceName: String,
     currentSongId: String?,
     currentMediaItemIndex: Int = -1,
@@ -1834,25 +1852,6 @@ fun QueuePlaylistSongItem(
 ) {
     val colors = MaterialTheme.colorScheme
 
-    val cornerRadius by animateDpAsState(
-        targetValue = if (isCurrentSong) 60.dp else 22.dp,
-        label = "cornerRadiusAnimation"
-    )
-
-    val itemShape = RoundedCornerShape(cornerRadius)
-
-    val albumCornerRadius by animateDpAsState(
-        targetValue = if (isCurrentSong) 60.dp else 8.dp,
-        label = "cornerRadiusAnimation"
-    )
-
-    val albumShape = RoundedCornerShape(albumCornerRadius)
-
-    val elevation by animateDpAsState(
-        targetValue = if (isDragging) 4.dp else 1.dp,
-        label = "elevationAnimation"
-    )
-
     val backgroundColor = colors.surfaceContainerLowest
     val mvContainerColor = if (isCurrentSong) colors.tertiaryContainer else colors.surfaceContainerHigh
     val mvContentColor = if (isCurrentSong) colors.onTertiaryContainer else colors.onSurface
@@ -1886,21 +1885,43 @@ fun QueuePlaylistSongItem(
         (revealWidthPx / (56.dp.value * density.density)).coerceIn(0f, 1f)
     } else 0f
 
-    val dismissBackgroundColor by animateColorAsState(
-        targetValue = if (isSwipeTargeted) colors.errorContainer else colors.errorContainer.copy(alpha = 0.82f),
-        animationSpec = tween(durationMillis = 150),
+    // Consolidate six independent animateXAsState calls into a single
+    // updateTransition keyed on (isCurrentSong, isDragging, isSwipeTargeted).
+    // Same pattern that was already applied to EnhancedSongListItem — saves
+    // 5 animation runtime objects per queue item plus one composition slot.
+    val animState = QueueItemAnimState(isCurrentSong, isDragging, isSwipeTargeted)
+    val transition = updateTransition(animState, label = "queueItemAnim")
+    val cornerRadius by transition.animateDp(label = "cornerRadius") { state ->
+        if (state.isCurrentSong) 60.dp else 22.dp
+    }
+    val albumCornerRadius by transition.animateDp(label = "albumCornerRadius") { state ->
+        if (state.isCurrentSong) 60.dp else 8.dp
+    }
+    val elevation by transition.animateDp(label = "elevation") { state ->
+        if (state.isDragging) 4.dp else 1.dp
+    }
+    val dismissBackgroundColor by transition.animateColor(
+        transitionSpec = { tween(durationMillis = 150) },
         label = "dismissBackgroundColor"
-    )
-    val dismissIconAlpha by animateFloatAsState(
-        targetValue = revealProgress * if (isSwipeTargeted) 1f else 0.88f,
-        animationSpec = tween(durationMillis = 120),
-        label = "dismissIconAlpha"
-    )
-    val dismissIconScale by animateFloatAsState(
-        targetValue = if (isSwipeTargeted) 1.08f else 0.95f,
-        animationSpec = tween(durationMillis = 120),
+    ) { state ->
+        if (state.isSwipeTargeted) colors.errorContainer else colors.errorContainer.copy(alpha = 0.82f)
+    }
+    val dismissIconAlphaFactor by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 120) },
+        label = "dismissIconAlphaFactor"
+    ) { state ->
+        if (state.isSwipeTargeted) 1f else 0.88f
+    }
+    val dismissIconScale by transition.animateFloat(
+        transitionSpec = { tween(durationMillis = 120) },
         label = "dismissIconScale"
-    )
+    ) { state ->
+        if (state.isSwipeTargeted) 1.08f else 0.95f
+    }
+    val dismissIconAlpha = revealProgress * dismissIconAlphaFactor
+
+    val itemShape = RoundedCornerShape(cornerRadius)
+    val albumShape = RoundedCornerShape(albumCornerRadius)
 
     var surfaceHeightPx by remember { mutableStateOf(0f) }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1294,7 +1294,7 @@ private fun predictSkipPreviousCarouselIndex(
 @Composable
 private fun FullPlayerSongMetadataSection(
     song: Song,
-    currentSongArtists: List<Artist>,
+    currentSongArtists: ImmutableList<Artist>,
     loadingTweaks: FullPlayerLoadingTweaks,
     isSheetDragGestureActive: Boolean,
     expansionFractionProvider: () -> Float,
@@ -1440,7 +1440,7 @@ private fun FullPlayerLandscapeContent(
 @Composable
 private fun SongMetadataDisplaySection(
     song: Song?,
-    currentSongArtists: List<Artist>,
+    currentSongArtists: ImmutableList<Artist>,
     expansionFractionProvider: () -> Float,
     textColor: Color,
     artistTextColor: Color,
@@ -2116,7 +2116,7 @@ private fun PlayerSongInfo(
     title: String,
     artist: String,
     artistId: Long,
-    artists: List<Artist>,
+    artists: ImmutableList<Artist>,
     expansionFractionProvider: () -> Float,
     textColor: Color,
     artistTextColor: Color,
@@ -2127,8 +2127,12 @@ private fun PlayerSongInfo(
 ) {
     val coroutineScope = rememberCoroutineScope()
     var isNavigatingToArtist by remember { mutableStateOf(false) }
-    val resolvedArtistId by remember(artists, artistId) {
-        derivedStateOf { artists.firstOrNull { it.id != 0L && it.id != -1L }?.id ?: artistId }
+    // derivedStateOf is unnecessary here: the calculation reads only the
+    // `artists` parameter and the captured `artistId`, not any State<T>.
+    // A plain remember is enough and skips an extra State allocation +
+    // snapshot read per recomposition.
+    val resolvedArtistId = remember(artists, artistId) {
+        artists.firstOrNull { it.id != 0L && it.id != -1L }?.id ?: artistId
     }
     val titleStyle = MaterialTheme.typography.headlineSmall.copy(
         fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerArtistPickerBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/PlayerArtistPickerBottomSheet.kt
@@ -42,6 +42,7 @@ import com.theveloper.pixelplay.data.model.Artist
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.presentation.components.SmartImage
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
+import kotlinx.collections.immutable.ImmutableList
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
 private data class PlayerArtistShortcutItem(
@@ -53,7 +54,7 @@ private data class PlayerArtistShortcutItem(
 @Composable
 internal fun PlayerArtistPickerBottomSheet(
     song: Song,
-    artists: List<Artist>,
+    artists: ImmutableList<Artist>,
     sheetState: SheetState,
     onDismiss: () -> Unit,
     onArtistClick: (Artist) -> Unit

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
@@ -73,6 +73,15 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.text.style.TextOverflow
 
+/**
+ * Shared empty color-scheme flow used as a placeholder while paged album items
+ * are still loading. Hoisted to file scope so we don't allocate a fresh
+ * MutableStateFlow on every placeholder rendering inside the LazyColumn /
+ * LazyVerticalGrid items lambda.
+ */
+private val EMPTY_ALBUM_COLOR_SCHEME_FLOW: StateFlow<ColorSchemePair?> =
+    MutableStateFlow(null)
+
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun LibraryAlbumsTab(
@@ -342,8 +351,13 @@ fun LibraryAlbumsTab(
                                 ) { index ->
                                     val album = albums[index]
                                     if (album != null) {
-                                        val albumSpecificColorSchemeFlow =
-                                            playerViewModel.themeStateHolder.getAlbumColorSchemeFlow(album.albumArtUriString ?: "")
+                                        val artUri = album.albumArtUriString ?: ""
+                                        // Cache the flow lookup so each scroll/recomposition does not
+                                        // re-enter ThemeStateHolder.getAlbumColorSchemeFlow (which on
+                                        // a cache miss launches a generation coroutine).
+                                        val albumSpecificColorSchemeFlow = remember(artUri) {
+                                            playerViewModel.themeStateHolder.getAlbumColorSchemeFlow(artUri)
+                                        }
                                         val rememberedOnClick = remember(album.id, onAlbumClick) {
                                             { onAlbumClick(album.id) }
                                         }
@@ -367,7 +381,7 @@ fun LibraryAlbumsTab(
                                     } else {
                                         AlbumListItem(
                                             album = Album.empty(),
-                                            albumColorSchemePairFlow = MutableStateFlow<ColorSchemePair?>(null),
+                                            albumColorSchemePairFlow = EMPTY_ALBUM_COLOR_SCHEME_FLOW,
                                             onClick = {},
                                             isLoading = true
                                         )
@@ -412,8 +426,10 @@ fun LibraryAlbumsTab(
                                 ) { index ->
                                     val album = albums[index]
                                     if (album != null) {
-                                        val albumSpecificColorSchemeFlow =
-                                            playerViewModel.themeStateHolder.getAlbumColorSchemeFlow(album.albumArtUriString ?: "")
+                                        val artUri = album.albumArtUriString ?: ""
+                                        val albumSpecificColorSchemeFlow = remember(artUri) {
+                                            playerViewModel.themeStateHolder.getAlbumColorSchemeFlow(artUri)
+                                        }
                                         val rememberedOnClick = remember(album.id, onAlbumClick) {
                                             { onAlbumClick(album.id) }
                                         }
@@ -437,7 +453,7 @@ fun LibraryAlbumsTab(
                                     } else {
                                         AlbumGridItemRedesigned(
                                             album = Album.empty(),
-                                            albumColorSchemePairFlow = MutableStateFlow<ColorSchemePair?>(null),
+                                            albumColorSchemePairFlow = EMPTY_ALBUM_COLOR_SCHEME_FLOW,
                                             onClick = {},
                                             isLoading = true
                                         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryPlaybackAwareSongItem.kt
@@ -3,21 +3,21 @@ package com.theveloper.pixelplay.presentation.screens
 import androidx.annotation.OptIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.presentation.components.subcomps.EnhancedSongListItem
-import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 
+/**
+ * Lightweight playback projection shared by every song item in a list. Parent
+ * tabs collect this once from PlayerViewModel and pass the same instance down
+ * to every item, so a list of 100 items causes one upstream subscription
+ * instead of 100 N×N collectors.
+ */
 @Immutable
-internal data class LibrarySongPlaybackUiState(
-    val isCurrentSong: Boolean = false,
+internal data class LibraryPlaybackHints(
+    val currentSongId: String? = null,
     val isPlaying: Boolean = false
 )
 
@@ -25,7 +25,7 @@ internal data class LibrarySongPlaybackUiState(
 @Composable
 internal fun LibraryPlaybackAwareSongItem(
     song: Song,
-    playerViewModel: PlayerViewModel,
+    playbackHints: LibraryPlaybackHints,
     albumArtSize: Dp = 50.dp,
     isSelected: Boolean = false,
     selectionIndex: Int? = null,
@@ -34,22 +34,11 @@ internal fun LibraryPlaybackAwareSongItem(
     onMoreOptionsClick: (Song) -> Unit,
     onClick: () -> Unit
 ) {
-    val playbackUiState by remember(song.id, playerViewModel) {
-        playerViewModel.stablePlayerState
-            .map { state ->
-                val isCurrentSong = state.currentSong?.id == song.id
-                LibrarySongPlaybackUiState(
-                    isCurrentSong = isCurrentSong,
-                    isPlaying = isCurrentSong && state.isPlaying
-                )
-            }
-            .distinctUntilChanged()
-    }.collectAsStateWithLifecycle(initialValue = LibrarySongPlaybackUiState())
-
+    val isCurrentSong = playbackHints.currentSongId == song.id
     EnhancedSongListItem(
         song = song,
-        isPlaying = playbackUiState.isPlaying,
-        isCurrentSong = playbackUiState.isCurrentSong,
+        isPlaying = isCurrentSong && playbackHints.isPlaying,
+        isCurrentSong = isCurrentSong,
         isLoading = false,
         albumArtSize = albumArtSize,
         isSelected = isSelected,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -468,10 +468,14 @@ fun LibraryScreen(
     val compactInitialPage = remember(tabCount, normalizedLastTabIndex) {
         infinitePagerInitialPage(tabCount, normalizedLastTabIndex)
     }
-    val pagerState = if (isCompactNavigation) {
-        rememberPagerState(initialPage = compactInitialPage) { Int.MAX_VALUE }
-    } else {
-        rememberPagerState(initialPage = normalizedLastTabIndex) { tabCount }
+    // Single rememberPagerState call instead of a conditional remember anti-pattern
+    // (the previous if/else allocated separate slots on each branch and lost scroll
+    // state when libraryNavigationMode toggled between COMPACT_PILL and the full
+    // tab strip). initialPage is captured once; pageCount is a lambda that re-reads
+    // the mode on every measure pass.
+    val pagerInitialPage = if (isCompactNavigation) compactInitialPage else normalizedLastTabIndex
+    val pagerState = rememberPagerState(initialPage = pagerInitialPage) {
+        if (isCompactNavigation) Int.MAX_VALUE else tabCount
     }
     val currentTabIndex by remember(pagerState, tabTitles, isCompactNavigation) {
         derivedStateOf {
@@ -543,6 +547,14 @@ fun LibraryScreen(
 
     val onSongSelectionToggle: (Song) -> Unit = remember(multiSelectionState) {
         { song -> multiSelectionState.toggleSelection(song) }
+    }
+
+    // Bound method reference hoisted via remember so it is referentially stable
+    // across recompositions. Without this, each render passes a fresh lambda
+    // identity into LibrarySongsTab / LibraryFavoritesTab / LibraryFoldersTab,
+    // breaking parameter stability on those composables.
+    val getSelectionIndex: (String) -> Int? = remember(multiSelectionState) {
+        multiSelectionState::getSelectionIndex
     }
 
     val toggleAlbumSelection: (Album) -> Unit = remember(selectedAlbums, playerViewModel, context) {
@@ -816,17 +828,21 @@ fun LibraryScreen(
         }
     }
 
-    val gradientColorsDark = listOf(
-        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
-        Color.Transparent
-    ).toImmutableList()
-
-    val gradientColorsLight = listOf(
-        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.2f),
-        Color.Transparent
-    ).toImmutableList()
-
-    val gradientColors = if (dm) gradientColorsDark else gradientColorsLight
+    val gradientPrimary = MaterialTheme.colorScheme.primaryContainer
+    val gradientOnPrimary = MaterialTheme.colorScheme.onPrimaryContainer
+    val gradientColors = remember(dm, gradientPrimary, gradientOnPrimary) {
+        if (dm) {
+            persistentListOf(
+                gradientPrimary.copy(alpha = 0.5f),
+                Color.Transparent
+            )
+        } else {
+            persistentListOf(
+                gradientOnPrimary.copy(alpha = 0.2f),
+                Color.Transparent
+            )
+        }
+    }
 
     val gradientBrush = remember(gradientColors) {
         Brush.verticalGradient(colors = gradientColors)
@@ -1526,7 +1542,7 @@ fun LibraryScreen(
                                             selectedSongIds = selectedSongIds,
                                             onSongLongPress = onSongLongPress,
                                             onSongSelectionToggle = onSongSelectionToggle,
-                                            getSelectionIndex = playerViewModel.multiSelectionStateHolder::getSelectionIndex,
+                                            getSelectionIndex = getSelectionIndex,
                                             onLocateCurrentSongVisibilityChanged = { songsShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { songsLocateAction = it },
                                             sortOption = playerUiState.currentSongSortOption,
@@ -1618,7 +1634,7 @@ fun LibraryScreen(
                                             selectedSongIds = selectedSongIds,
                                             onSongLongPress = onSongLongPress,
                                             onSongSelectionToggle = onSongSelectionToggle,
-                                            getSelectionIndex = playerViewModel.multiSelectionStateHolder::getSelectionIndex,
+                                            getSelectionIndex = getSelectionIndex,
                                             sortOption = playerUiState.currentFavoriteSortOption,
                                             onLocateCurrentSongVisibilityChanged = { likedShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { likedLocateAction = it },
@@ -1667,7 +1683,7 @@ fun LibraryScreen(
                                             selectedSongIds = selectedSongIds,
                                             onSongLongPress = onSongLongPress,
                                             onSongSelectionToggle = onSongSelectionToggle,
-                                            getSelectionIndex = playerViewModel.multiSelectionStateHolder::getSelectionIndex,
+                                            getSelectionIndex = getSelectionIndex,
                                             onLocateCurrentSongVisibilityChanged = { foldersShowLocateButton = it },
                                             onRegisterLocateCurrentSongAction = { foldersLocateAction = it },
                                             pendingLocatePath = pendingFoldersLocatePath,
@@ -2873,17 +2889,21 @@ fun LibraryFoldersTab(
         val isRoot = targetPath == FOLDER_NAVIGATION_ROOT_KEY
         val activeFolder = if (isRoot) null else currentFolder
         val showPlaylistCards = playlistMode && activeFolder == null
-        val itemsToShow = remember(activeFolder, folders, flattenedFolders, currentSortOption) {
+        // .toImmutableList() runs inside the remember block so it doesn't
+        // re-allocate the persistent list on every recomposition. showPlaylistCards
+        // is added to the key list because it factors playlistMode in, which the
+        // previous key set was missing.
+        val itemsToShow = remember(showPlaylistCards, activeFolder, folders, flattenedFolders, currentSortOption) {
             when {
                 showPlaylistCards -> flattenedFolders
                 activeFolder != null -> sortMusicFoldersByOption(activeFolder.subFolders, currentSortOption)
                 else -> sortMusicFoldersByOption(folders, currentSortOption)
-            }
-        }.toImmutableList()
+            }.toImmutableList()
+        }
 
         val songsToShow = remember(activeFolder, currentSortOption) {
-            sortSongsForFolderView(activeFolder?.songs ?: emptyList(), currentSortOption)
-        }.toImmutableList()
+            sortSongsForFolderView(activeFolder?.songs ?: emptyList(), currentSortOption).toImmutableList()
+        }
         val currentSong = stablePlayerState.currentSong
         val currentSongId = currentSong?.id
         val currentSongIndexInSongs = remember(songsToShow, currentSongId) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsAndFavoritesTabs.kt
@@ -103,11 +103,14 @@ fun LibraryFavoritesTab(
     var lastHandledFavoriteSortKey by remember { mutableStateOf(sortOption.storageKey) }
     var pendingFavoriteSortScrollReset by remember { mutableStateOf(false) }
     var favoriteSortSawRefreshLoading by remember { mutableStateOf(false) }
-    val currentSongId by remember(playerViewModel) {
+    // Shared playback projection so every item below gets the same hints
+    // instance instead of starting its own stablePlayerState collector.
+    val playbackHints by remember(playerViewModel) {
         playerViewModel.stablePlayerState
-            .map { it.currentSong?.id }
+            .map { LibraryPlaybackHints(it.currentSong?.id, it.isPlaying) }
             .distinctUntilChanged()
-    }.collectAsStateWithLifecycle(initialValue = null)
+    }.collectAsStateWithLifecycle(initialValue = LibraryPlaybackHints())
+    val currentSongId = playbackHints.currentSongId
 
     val currentSongListIndex = remember(favoriteSongs.itemCount, currentSongId) {
         if (currentSongId == null) -1
@@ -247,7 +250,7 @@ fun LibraryFavoritesTab(
                             if (song != null) {
                                 LibraryPlaybackAwareSongItem(
                                     song = song,
-                                    playerViewModel = playerViewModel,
+                                    playbackHints = playbackHints,
                                     onMoreOptionsClick = { onMoreOptionsClick(song) },
                                     isSelected = selectedSongIds.contains(song.id),
                                     selectionIndex = if (isSelectionMode) getSelectionIndex(song.id) else null,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -96,11 +96,17 @@ fun LibrarySongsTab(
     var lastHandledSongSortKey by remember { mutableStateOf(sortOption.storageKey) }
     var pendingSongSortScrollReset by remember { mutableStateOf(false) }
     var songSortSawRefreshLoading by remember { mutableStateOf(false) }
-    val currentSongId by remember(playerViewModel) {
+    // Single shared playback projection. Previously each LibraryPlaybackAwareSongItem
+    // spun up its own stablePlayerState.map{}.distinctUntilChanged() collector,
+    // which meant N visible items = N upstream subscriptions checking every
+    // emission. Now there is one upstream collector here and every item receives
+    // the same LibraryPlaybackHints instance.
+    val playbackHints by remember(playerViewModel) {
         playerViewModel.stablePlayerState
-            .map { it.currentSong?.id }
+            .map { LibraryPlaybackHints(it.currentSong?.id, it.isPlaying) }
             .distinctUntilChanged()
-    }.collectAsStateWithLifecycle(initialValue = null)
+    }.collectAsStateWithLifecycle(initialValue = LibraryPlaybackHints())
+    val currentSongId = playbackHints.currentSongId
 
     // Check if list is effectively empty (based on Paging state)
     // val isListEmpty = songs.itemCount == 0 && songs.loadState.refresh is LoadState.NotLoading
@@ -346,7 +352,7 @@ fun LibrarySongsTab(
 
                                     LibraryPlaybackAwareSongItem(
                                         song = song,
-                                        playerViewModel = playerViewModel,
+                                        playbackHints = playbackHints,
                                         isSelected = isSelected,
                                         //albumArtSize = 46.dp,
                                         isSelectionMode = isSelectionMode,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -440,15 +440,15 @@ class PlayerViewModel @Inject constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val currentSongArtists: StateFlow<List<Artist>> = stablePlayerState
+    val currentSongArtists: StateFlow<ImmutableList<Artist>> = stablePlayerState
         .map { it.currentSong?.id }
         .distinctUntilChanged()
         .flatMapLatest { songId ->
             val idLong = songId?.toLongOrNull()
-            if (idLong == null) flowOf(emptyList())
-            else musicRepository.getArtistsForSong(idLong)
+            if (idLong == null) flowOf(persistentListOf())
+            else musicRepository.getArtistsForSong(idLong).map { it.toImmutableList() }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), persistentListOf())
 
     private val _sheetState = MutableStateFlow(PlayerSheetState.COLLAPSED)
     val sheetState: StateFlow<PlayerSheetState> = _sheetState.asStateFlow()
@@ -1238,7 +1238,7 @@ class PlayerViewModel @Inject constructor(
     // composable. Now a single collect + distinctUntilChanged batches all settings.
     // ---------------------------------------------------------------------------
     data class FullPlayerSlice(
-        val currentSongArtists: List<Artist> = emptyList(),
+        val currentSongArtists: ImmutableList<Artist> = persistentListOf(),
         val lyricsSyncOffset: Int = 0,
         val albumArtQuality: AlbumArtQuality = AlbumArtQuality.MEDIUM,
         val audioMetadata: PlaybackAudioMetadata = PlaybackAudioMetadata(),
@@ -1259,7 +1259,7 @@ class PlayerViewModel @Inject constructor(
         albumArtQuality,
         playbackAudioMetadata,
         showPlayerFileInfo
-    ) { artists: List<Artist>, syncOffset: Int, artQuality: AlbumArtQuality,
+    ) { artists: ImmutableList<Artist>, syncOffset: Int, artQuality: AlbumArtQuality,
         audioMeta: PlaybackAudioMetadata, showFileInfo: Boolean ->
         FullPlayerSlicePart1(artists, syncOffset, artQuality, audioMeta, showFileInfo)
     }
@@ -1284,7 +1284,7 @@ class PlayerViewModel @Inject constructor(
     }
 
     private data class FullPlayerSlicePart1(
-        val currentSongArtists: List<Artist>,
+        val currentSongArtists: ImmutableList<Artist>,
         val lyricsSyncOffset: Int,
         val albumArtQuality: AlbumArtQuality,
         val audioMetadata: PlaybackAudioMetadata,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/SongInfoBottomSheetViewModel.kt
@@ -15,6 +15,9 @@ import com.theveloper.pixelplay.utils.AudioMetaUtils
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.File
 import javax.inject.Inject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -40,8 +43,8 @@ class SongInfoBottomSheetViewModel @Inject constructor(
     )
 
     private val _audioMeta = MutableStateFlow<AudioMeta?>(null)
-    private val _resolvedArtists = MutableStateFlow<List<Artist>>(emptyList())
-    val resolvedArtists: StateFlow<List<Artist>> = _resolvedArtists.asStateFlow()
+    private val _resolvedArtists = MutableStateFlow<ImmutableList<Artist>>(persistentListOf())
+    val resolvedArtists: StateFlow<ImmutableList<Artist>> = _resolvedArtists.asStateFlow()
     private val _isPixelPlayWatchAvailable = MutableStateFlow(false)
     val isPixelPlayWatchAvailable: StateFlow<Boolean> = _isPixelPlayWatchAvailable.asStateFlow()
     private val _isWatchAvailabilityResolved = MutableStateFlow(false)
@@ -82,7 +85,7 @@ class SongInfoBottomSheetViewModel @Inject constructor(
     fun loadArtistsForSong(song: Song) {
         val refs = song.artists
         if (refs.isEmpty() || refs.size < 2) {
-            _resolvedArtists.value = emptyList()
+            _resolvedArtists.value = persistentListOf()
             return
         }
         viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
@@ -95,7 +98,7 @@ class SongInfoBottomSheetViewModel @Inject constructor(
             val resolved = refs.map { ref ->
                 entitiesById[ref.id]?.toArtist()
                     ?: Artist(id = ref.id, name = ref.name, songCount = 0)
-            }
+            }.toImmutableList()
             _resolvedArtists.value = resolved
         }
     }


### PR DESCRIPTION
Targets the Critical / High items from section 4 (UI/Compose performance) of the multi-agent codebase review.

> **Stacked on top of PR #2048.** This PR's base is \`security/xxe-allowlist-ai-keys-fk\`. Once #2048 merges, this PR will rebase onto master automatically. The diff visible here is just the perf work.

## What changed (10 task buckets)

### 1. `LibraryScreen.kt` recomp hotspots
- Folder tab `itemsToShow` / `songsToShow`: \`.toImmutableList()\` now runs INSIDE the remember block; \`showPlaylistCards\` added to the key set (the previous key list missed \`playlistMode\`).
- \`rememberPagerState\` was conditional on \`isCompactNavigation\` — lost scroll state on toggle. Replaced by a single unconditional call with a mode-aware \`initialPage\` + \`pageCount\` lambda.
- Gradient color lists wrapped in \`remember(dm, primaryContainer, onPrimaryContainer)\` with \`persistentListOf\` so they don't re-allocate every frame.
- \`getSelectionIndex\` bound method reference hoisted into a \`remember(multiSelectionState)\` so the three tabs receive the same lambda identity across recompositions.

### 2. `LibraryMediaTabs.kt`
- \`getAlbumColorSchemeFlow(uri)\` wrapped in \`remember(artUri)\` — was running synchronization + dispatcher launch on every recomp inside the items lambda.
- Placeholder \`MutableStateFlow<ColorSchemePair?>(null)\` allocations replaced with a file-scope \`EMPTY_ALBUM_COLOR_SCHEME_FLOW\`.

### 3. `LibraryPlaybackAwareSongItem` N×N flow subscriptions
- Each item used to spin up its own \`stablePlayerState.map{}.distinctUntilChanged()\` collector. With 100+ visible items that is 100+ upstream subscriptions. Lifted into the parent tabs as a single \`LibraryPlaybackHints(currentSongId, isPlaying)\`; items receive that one instance.

### 4. `CastBottomSheet.kt`
- \`stablePlayerState\` sliced to just \`isPlaying\` so position ticks (~4×/s) don't recompose the sheet.
- \`availableRoutes\` / \`bluetoothDevices\` / \`activeBluetoothName\` / \`devices\` derived lists wrapped in \`remember(inputs)\`. \`activeDevice\` deliberately left inline (captures \`stringResource\`, composable-only).
- The 13 \`collectAsStateWithLifecycle\` calls were deliberately kept separate — Compose smart-skipping already invalidates only the slice that changed; a single combine slice is not an unambiguous win.

### 5. `QueueBottomSheet` item animations (Hallazgo 3 reappeared)
- Six independent \`animateDpAsState\` / \`animateColorAsState\` / \`animateFloatAsState\` calls per queue item consolidated into a single \`updateTransition\` keyed on a \`QueueItemAnimState(isCurrentSong, isDragging, isSwipeTargeted)\`. Same pattern already applied to \`EnhancedSongListItem\`. \`dismissIconAlpha\` now derives from \`revealProgress × animatedFactor\` so the continuous \`revealProgress\` doesn't need its own animation.
- \`queue\` param signature: \`List<Song>\` → \`ImmutableList<Song>\` (caller already had it as ImmutableList; the downcast was erasing stability).

### 6. `currentSongArtists` stability
- \`PlayerViewModel.currentSongArtists\`: \`StateFlow<List<Artist>>\` → \`StateFlow<ImmutableList<Artist>>\`. \`FullPlayerSlice.currentSongArtists\` and \`FullPlayerSlicePart1.currentSongArtists\` migrated to match.
- Downstream composables — \`FullPlayerSongMetadataSection\`, \`SongMetadataDisplaySection\`, \`PlayerSongInfo\`, \`PlayerArtistPickerBottomSheet\` — now accept \`ImmutableList<Artist>\` so Compose strong-skipping treats the parameter as stable.
- \`SongInfoBottomSheetViewModel.resolvedArtists\` also migrated for the picker call site.

### 7. \`derivedStateOf\` misuses
- \`LyricsSheet.kt\` had four \`remember(state) { derivedStateOf { state.field } }\` wrappers on plain captured values. \`derivedStateOf\` provides State-dependency tracking — without a State<T> read inside, it's an extra State allocation + snapshot read for nothing. Replaced with direct destructuring.
- \`FullPlayerContent.kt:resolvedArtistId\` same pattern. Replaced with plain \`remember(artists, artistId)\`.

### 8. \`LyricsSheet\` DataStore reads
- Seven separate \`context.dataStore.data.map{}\` subscriptions (alignment, translation, romanization, animated, blur enabled, blur strength, keep-screen-on) collapsed into a single mapped \`Flow<LyricsSheetPrefs>\` with \`distinctUntilChanged\`. New file-private \`LyricsSheetPrefs\` data class + \`Preferences.toLyricsSheetPrefs()\` helper.
- Removed a duplicate \`DisposableEffect\` that registered an identical second lifecycle observer for keep-screen-on (merge artifact).

### 9. \`DailyMixSection\` allocations
- \`headerSongs\` / \`visibleSongs\` called \`songs.take(n).toImmutableList()\` on every recomposition. Wrapped in \`remember(songs)\`.

## Verification

- \`./gradlew :app:testDebugUnitTest\`: **302 tests passing, 0 failing**. Same baseline as before the perf work — no regressions.
- \`./gradlew :app:assembleDebug\`: BUILD SUCCESSFUL.

## What's intentionally NOT in this PR

- **\`List<Song>\` / \`List<Album>\` / \`List<Playlist>\` parameter migrations** on \`PlaylistBottomSheet\`, \`PlaylistArtCollage\`, \`MultiSelectionBottomSheet\`, \`AlbumMultiSelectionOptionSheet\`, \`PlaylistContainer\`. Tried and reverted — each has ~10 call sites passing plain \`playlist.songs: List<Song>\`. Flipping the parameter requires either \`.toImmutableList()\` boilerplate at every site (anti-pattern) or migrating \`Playlist.songs\` upstream to \`ImmutableList\`. The second is the proper fix and belongs to a separate task once the source data model is touched.
- **\`LyricsSheet\` architectural violation.** The 7 reads are consolidated into one flow but still bypass \`UserPreferencesRepository\`. Properly routing them through the repository needs new flow exposures there and is its own task.
- **\`CastBottomSheet\` 13 \`collectAsStateWithLifecycle\` consolidation.** Compose smart skipping already invalidates only the slice that changed; a single combine slice was not an unambiguous win.
- **\`triggerShuffleAllFromTile\` behavioral change is in #2048**, not here. It belongs there because it was the fix for a failing unit test.

## Reviewer notes

- The single largest perf win is probably the \`LibraryPlaybackAwareSongItem\` lift — going from N collectors to 1 across the songs/favorites tabs.
- The \`updateTransition\` consolidation in \`QueueBottomSheet\` mirrors the EnhancedSongListItem refactor that was already in master. Worth keeping the pattern consistent.
- \`LibraryPlaybackHints\` is marked \`@Immutable\` — \`compose_stability.conf\` only covers \`data.model.**\`, so this annotation is needed explicitly.
- The \`gradient*Colors\` change uses \`persistentListOf\` instead of \`toImmutableList()\` because the input is a small literal list and \`persistentListOf\` avoids an extra wrap step.
- The reverted \`PlaylistArtCollage\` / \`PlaylistBottomSheet\` migrations are still tracked as TODO in the codebase — they're called out in the commit message's "What is NOT in this PR" section so the next maintainer doesn't redo the same revert cycle.