### PR TITLE
feat: use dynamic corner radius for navigation bar expansion

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -792,6 +792,7 @@ class MainActivity : ComponentActivity() {
                             navBarStyle,
                             showPlayerContentArea,
                             playerContentExpansionFraction,
+                            navBarCornerRadius
                         ) {
                             derivedStateOf {
                                 if (navBarStyle == NavBarStyle.FULL_WIDTH) {
@@ -800,7 +801,7 @@ class MainActivity : ComponentActivity() {
 
                                 if (showPlayerContentArea) {
                                     if (playerContentExpansionFraction < 0.2f) {
-                                        lerp(12.dp, 26.dp, (playerContentExpansionFraction / 0.2f).coerceIn(0f, 1f))
+                                        lerp(navBarCornerRadius.dp, 26.dp, (playerContentExpansionFraction / 0.2f).coerceIn(0f, 1f))
                                     } else {
                                         26.dp
                                     }


### PR DESCRIPTION
Replaces the hardcoded `12.dp` value with `navBarCornerRadius` when calculating the navigation bar's corner radius state during player expansion.

- Added `navBarCornerRadius` as a dependency in the state calculation block.
- Updated the `lerp` function to use `navBarCornerRadius.dp` as the starting base value.