### PR TITLE
refactor: externalize Telegram API credentials to BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,13 @@ val keystoreProperties = Properties().apply {
     }
 }
 
+val localProperties = Properties().apply {
+    val propFile = rootProject.file("local.properties")
+    if (propFile.exists()) {
+        propFile.inputStream().use { load(it) }
+    }
+}
+
 val enableAbiSplits = providers.gradleProperty("pixelplay.enableAbiSplits")
     .getOrElse("true")
     .toBoolean()
@@ -66,6 +73,11 @@ android {
         versionName = (project.findProperty("APP_VERSION_NAME") as? String) ?: "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val telegramApiId = localProperties.getProperty("TELEGRAM_API_ID") ?: ""
+        val telegramApiHash = localProperties.getProperty("TELEGRAM_API_HASH") ?: ""
+        buildConfigField("int", "TELEGRAM_API_ID", telegramApiId.ifEmpty { "0" })
+        buildConfigField("String", "TELEGRAM_API_HASH", "\"$telegramApiHash\"")
     }
 
     signingConfigs {

--- a/app/src/main/java/com/theveloper/pixelplay/data/telegram/TelegramClientManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/telegram/TelegramClientManager.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.data.telegram
 
 import android.content.Context
+import com.theveloper.pixelplay.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -108,12 +109,12 @@ class TelegramClientManager @Inject constructor(
                     true, // useChatInfoDatabase
                     true, // useMessageDatabase
                     false, // useSecretChats
-                    2040, // apiId
-                    "b18441a1ff607e10a989891a5462e627", // apiHash
+                    BuildConfig.TELEGRAM_API_ID,
+                    BuildConfig.TELEGRAM_API_HASH,
                     "en", // systemLanguageCode
-                    android.os.Build.MODEL, // deviceModel
+                    "PixelPlayer Instance", // deviceModel
                     android.os.Build.VERSION.RELEASE, // systemVersion
-                    "1.0" // applicationVersion
+                    BuildConfig.VERSION_NAME
                 ), defaultHandler)
             }
             is TdApi.AuthorizationStateWaitPhoneNumber -> {


### PR DESCRIPTION
Removes hardcoded Telegram API credentials from `TelegramClientManager` and moves them to `BuildConfig` fields populated from `local.properties`. This change also updates the device model and version metadata sent to the Telegram API.

- Added `TELEGRAM_API_ID` and `TELEGRAM_API_HASH` fields to `build.gradle.kts`.
- Updated `TelegramClientManager` to use `BuildConfig` for API identity and application version.
- Changed the Telegram client `deviceModel` from the physical device model to "PixelPlayer Instance".
- Implemented `local.properties` parsing in the app-level Gradle script to manage sensitive credentials.