### PR TITLE
perf: optimize Cast MIME probing and implement auto-skip for remote p…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/CastPlayer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/CastPlayer.kt
@@ -35,6 +35,13 @@ class CastPlayer(
     private val contentResolver: ContentResolver? = null
 ) {
 
+    companion object {
+        private const val MIME_NONE = ""
+        private val extractorMimeCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+        private val retrieverMimeCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+        private val signatureMimeCache = java.util.concurrent.ConcurrentHashMap<String, String>()
+    }
+
     private val remoteMediaClient: RemoteMediaClient? = castSession.remoteMediaClient
     private val queueLoadTimeoutMs = 25000L
     private val commandTimeoutMs = 3500L
@@ -49,7 +56,6 @@ class CastPlayer(
     private var pendingSeekPositionMs: Long? = null
     private var seekDispatchRunnable: Runnable? = null
     private val castLogTag = "CastPlayer"
-    private val signatureMimeCache = mutableMapOf<String, String?>()
 
     private data class QueuedCommand(
         val name: String,
@@ -258,38 +264,48 @@ class CastPlayer(
                 try {
                     val forcedMimeBySongId = mutableMapOf<String, String>()
 
-                    // Probe every song that could be in an M4A container for ALAC codec.
-                    // The server transcodes ALAC → AAC ADTS (audio/aac), so those queue items must be
-                    // declared as audio/aac, not audio/mp4 (the container type).
-                    // IMPORTANT: only force audio/aac when the raw codec MIME is "audio/alac".
-                    // "audio/mp4a-latm" means AAC-LC inside an MP4 container; the server serves it
-                    // as audio/mp4 (no transcode), so declaring audio/aac would cause a MIME mismatch
-                    // and a Cast load failure (status 2103).  Let resolveCastContentType() handle those.
-                    for (song in songs) {
+                    // Probe songs that could be transcode candidates.
+                    // The server transcodes ALAC or FLAC → AAC ADTS (audio/aac).
+                    for (index in songs.indices) {
+                        val song = songs[index]
                         val ext = song.path.substringAfterLast('.', "").lowercase(Locale.ROOT)
                         val mimeL = song.mimeType?.lowercase(Locale.ROOT)
-                        // We need to probe songs that the server will transcode (ALAC or FLAC → AAC).
+
+                        // Optimize: FLAC is easily identified without extractor calls
+                        val isFlac = ext == "flac" || mimeL == "audio/flac" || mimeL == "audio/x-flac"
+                        if (isFlac) {
+                            val flacDecoderAvailable = isFlacTranscodeSupported()
+                            val forcedMime = if (flacDecoderAvailable) "audio/aac" else "audio/flac"
+                            forcedMimeBySongId[song.id] = forcedMime
+                            Log.i(
+                                "PX_CAST_QLOAD",
+                                "flac_direct songId=${song.id} forcedMime=$forcedMime decoderAvailable=$flacDecoderAvailable nonce=$queueLoadNonce"
+                            )
+                            continue
+                        }
+
+                        // We need to probe songs that the server will transcode (ALAC → AAC).
                         val isMaybeTranscodeCandidate =
-                            ext.let { it == "m4a" || it == "m4b" || it == "mp4" || it == "3gp" || it == "3gpp" || it == "flac" } ||
-                            mimeL?.let { it.contains("mp4") || it.contains("m4a") || it == "audio/alac" || it == "audio/flac" || it == "audio/x-flac" } == true
+                            ext.let { it == "m4a" || it == "m4b" || it == "mp4" || it == "3gp" || it == "3gpp" } ||
+                            mimeL?.let { it.contains("mp4") || it.contains("m4a") || it == "audio/alac" } == true
 
                         if (!isMaybeTranscodeCandidate && song.id != startSong?.id) {
                             // Not a transcode-candidate file and not the start song — skip the probe.
                             continue
                         }
 
-                        val rawExtractorMime = detectAudioMimeTypeViaExtractor(song)
+                        // Sliding window: only probe if cached, start song, or within window
+                        val cachedExtractorMime = extractorMimeCache[song.id]
+                        val rawExtractorMime = if (cachedExtractorMime != null) {
+                            if (cachedExtractorMime == MIME_NONE) null else cachedExtractorMime
+                        } else if (song.id == startSong?.id || index in (safeStartIndex - 2)..(safeStartIndex + 8)) {
+                            detectAudioMimeTypeViaExtractor(song)
+                        } else {
+                            null
+                        }
 
                         // Only override the MIME when the server will transcode (ALAC or FLAC → AAC ADTS).
-                        // For every other codec — including audio/mp4a-latm (AAC-LC in MP4 container) —
-                        // the server pipes the raw bytes as audio/mp4, which resolveCastContentType()
-                        // already returns correctly from the file extension / metadata.
                         if (rawExtractorMime == "audio/alac") {
-                            // Only declare audio/aac if the server can actually transcode.
-                            // If findDecoderForFormat returns null (e.g. device AudioCapabilities
-                            // rejects audio/alac at this sample rate), the server falls back to
-                            // serving the raw M4A, so we must declare audio/mp4 instead to avoid
-                            // a content-type mismatch that causes Cast to reject the item.
                             val alacDecoderAvailable = isAlacTranscodeSupported()
                             val forcedMime = if (alacDecoderAvailable) "audio/aac" else "audio/mp4"
                             forcedMimeBySongId[song.id] = forcedMime
@@ -301,11 +317,6 @@ class CastPlayer(
                         }
 
                         if (rawExtractorMime == "audio/flac") {
-                            // FLAC: Cast DMR can play FLAC natively but its duration estimate is
-                            // wrong (VBR without seektable → Cast reports wrong total time), so any
-                            // seek computes a bad byte offset, overshoots, and triggers an involuntary
-                            // track skip. The server transcodes FLAC → AAC-ADTS (CBR), which gives
-                            // Cast an accurate byte↔time mapping and reliable seeking.
                             val flacDecoderAvailable = isFlacTranscodeSupported()
                             val forcedMime = if (flacDecoderAvailable) "audio/aac" else "audio/flac"
                             forcedMimeBySongId[song.id] = forcedMime
@@ -317,16 +328,7 @@ class CastPlayer(
                         }
 
                         if (song.id == startSong?.id) {
-                            // ALAC is already caught by the rawExtractorMime == "audio/alac" branch above.
-                            // Do NOT feed rawExtractorMime into toCastSupportedMimeTypeOrNull() here:
-                            // MediaExtractor returns codec-level MIMEs (e.g. "audio/mp4a-latm" for
-                            // AAC-LC inside an MP4 container), which normalise to "audio/aac".
-                            // That would declare audio/aac while the server pipes the raw MP4 container
-                            // as audio/mp4 — a mismatch the Cast receiver rejects with status 2103.
-                            // MediaMetadataRetriever returns the container MIME ("audio/mp4") instead.
                             val retrieverMime = detectAudioMimeTypeViaMetadataRetriever(song)?.toCastSupportedMimeTypeOrNull()
-                            // Only consult signature when retriever failed; the framing scan can produce
-                            // false positives on binary container data (e.g. 0xFF bytes in moov atom).
                             val signatureMime = if (retrieverMime == null) {
                                 detectAudioMimeTypeBySignature(song)?.toCastSupportedMimeTypeOrNull()
                             } else null
@@ -341,8 +343,6 @@ class CastPlayer(
                                 "start_probe songId=${song.id} songMime=${song.mimeType} resolverMime=$resolverMime rawExtractorMime=$rawExtractorMime retrieverMime=$retrieverMime signatureMime=$signatureMime forcedMime=$forcedMime nonce=$queueLoadNonce"
                             )
                         }
-                        // Non-start, non-ALAC M4A: no forced override needed. resolveCastContentType()
-                        // correctly returns audio/mp4 from the file extension, matching what the server sends.
                     }
 
                     // Post back to Main thread — Cast SDK requires Main for queueLoad.
@@ -715,9 +715,12 @@ class CastPlayer(
     }
 
     private fun detectAudioMimeTypeBySignature(song: Song): String? {
-        signatureMimeCache[song.id]?.let { return it }
+        val cached = signatureMimeCache[song.id]
+        if (cached != null) {
+            return if (cached == MIME_NONE) null else cached
+        }
         val bytes = readAudioSignature(song) ?: run {
-            signatureMimeCache[song.id] = null
+            signatureMimeCache[song.id] = MIME_NONE
             return null
         }
 
@@ -726,7 +729,7 @@ class CastPlayer(
             ?: detectMimeAtOffset(bytes, 0)
             ?: detectFramedAudioMime(bytes, id3PayloadOffset)
             ?: detectFramedAudioMime(bytes, 0)
-        signatureMimeCache[song.id] = detected
+        signatureMimeCache[song.id] = detected ?: MIME_NONE
         return detected
     }
 
@@ -855,9 +858,13 @@ class CastPlayer(
     }
 
     private fun detectAudioMimeTypeViaExtractor(song: Song): String? {
+        val cached = extractorMimeCache[song.id]
+        if (cached != null) {
+            return if (cached == MIME_NONE) null else cached
+        }
         val resolver = contentResolver ?: return null
         val uri = song.contentUriString.toUri()
-        return runCatching {
+        val result = runCatching {
             val extractor = MediaExtractor()
             try {
                 val sourceAttached = runCatching {
@@ -910,10 +917,6 @@ class CastPlayer(
                                 }.also { runCatching { mmr.release() } }
                             }
                         }
-                        // MediaExtractor sometimes exposes the decoded PCM track of a FLAC file
-                        // as "audio/raw" instead of the container format "audio/flac".  Recover the
-                        // true format from the file extension / mime metadata so the FLAC → AAC
-                        // transcode path in the caller is correctly triggered.
                         if (trackMime == "audio/raw") {
                             val mimeL = song.mimeType?.lowercase(Locale.ROOT)
                             val isFlac = song.path.endsWith(".flac", true) ||
@@ -930,6 +933,9 @@ class CastPlayer(
                 runCatching { extractor.release() }
             }
         }.getOrNull()
+        
+        extractorMimeCache[song.id] = result ?: MIME_NONE
+        return result
     }
 
     private fun isMimeTypeDecoderSupported(mimeType: String): Boolean {
@@ -978,10 +984,14 @@ class CastPlayer(
     }
 
     private fun detectAudioMimeTypeViaMetadataRetriever(song: Song): String? {
+        val cached = retrieverMimeCache[song.id]
+        if (cached != null) {
+            return if (cached == MIME_NONE) null else cached
+        }
         val resolver = contentResolver ?: return null
         val uri = song.contentUriString.toUri()
         val retriever = MediaMetadataRetriever()
-        return runCatching {
+        val result = runCatching {
             val sourceConfigured = runCatching {
                 resolver.openAssetFileDescriptor(uri, "r")?.use { afd ->
                     val length = afd.length
@@ -1008,6 +1018,8 @@ class CastPlayer(
         }.getOrNull().also {
             runCatching { retriever.release() }
         }
+        retrieverMimeCache[song.id] = result ?: MIME_NONE
+        return result
     }
 
     private fun logQueueDiagnostics(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
@@ -89,6 +89,7 @@ class CastTransferStateHolder @Inject constructor(
 
     // State tracking variables
     private var lastRemoteMediaStatus: MediaStatus? = null
+    private var consecutiveErrorSkipCount = 0
     var lastRemoteQueue: List<Song> = emptyList()
         private set
     var lastRemoteSongId: String? = null
@@ -231,8 +232,14 @@ class CastTransferStateHolder @Inject constructor(
         castStateHolder.setRemotePlaybackActive(currentSession != null)
         
         if (currentSession != null) {
-            currentSession.remoteMediaClient?.registerCallback(remoteMediaClientCallback!!)
-            currentSession.remoteMediaClient?.addProgressListener(remoteProgressListener!!, 1000)
+            val callback = remoteMediaClientCallback
+            val progressListener = remoteProgressListener
+            if (callback != null) {
+                currentSession.remoteMediaClient?.registerCallback(callback)
+            }
+            if (progressListener != null) {
+                currentSession.remoteMediaClient?.addProgressListener(progressListener, 1000)
+            }
             startRemoteProgressObserver()
             playbackStateHolder.startProgressUpdates()
             currentSession.remoteMediaClient?.requestStatus()
@@ -385,6 +392,22 @@ class CastTransferStateHolder @Inject constructor(
                     "media title=${currentRemoteItem?.media?.metadata?.getString(com.google.android.gms.cast.MediaMetadata.KEY_TITLE)} contentType=${currentRemoteItem?.media?.contentType} contentId=${currentRemoteItem?.media?.contentId}"
                 )
             }
+
+            // Implement auto-skip logic to jump to the next track if available
+            val queueItems = mediaStatus.queueItems
+            val currentIndex = queueItems.indexOfFirst { it.itemId == currentItemId }
+            val nextItem = if (currentIndex >= 0) queueItems.getOrNull(currentIndex + 1) else null
+            if (nextItem != null) {
+                if (consecutiveErrorSkipCount < 3) {
+                    consecutiveErrorSkipCount++
+                    Timber.tag(CAST_LOG_TAG).w("Auto-skipping failed remote track. Consecutive failures: %d. Jumping to next item itemId=%d", consecutiveErrorSkipCount, nextItem.itemId)
+                    Log.w("PX_CAST_AUTO_SKIP", "consecutiveFailures=$consecutiveErrorSkipCount jumpingToItem=${nextItem.itemId}")
+                    castStateHolder.castPlayer?.jumpToItem(nextItem.itemId, 0L)
+                } else {
+                    Timber.tag(CAST_LOG_TAG).e("Max consecutive Cast failures reached (%d). Stopping skip loop.", consecutiveErrorSkipCount)
+                    Log.e("PX_CAST_AUTO_SKIP", "maxConsecutiveFailuresReached=$consecutiveErrorSkipCount stoppingSkipLoop")
+                }
+            }
         }
 
         val itemChanged = lastRemoteItemId != currentItemId
@@ -442,6 +465,9 @@ class CastTransferStateHolder @Inject constructor(
         val songChanged = currentSongFallback?.id != playbackStateHolder.stablePlayerState.value.currentSong?.id
 
         val isPlaying = mediaStatus.playerState == MediaStatus.PLAYER_STATE_PLAYING
+        if (isPlaying) {
+            consecutiveErrorSkipCount = 0
+        }
         lastKnownRemoteIsPlaying = isPlaying
         lastRemoteStreamPosition = streamPosition
         lastRemoteRepeatMode = mediaStatus.queueRepeatMode
@@ -625,8 +651,14 @@ class CastTransferStateHolder @Inject constructor(
 
             loadInitialQueueAttempt()
 
-            session.remoteMediaClient?.registerCallback(remoteMediaClientCallback!!)
-            session.remoteMediaClient?.addProgressListener(remoteProgressListener!!, 1000)
+            val callback = remoteMediaClientCallback
+            val progressListener = remoteProgressListener
+            if (callback != null) {
+                session.remoteMediaClient?.registerCallback(callback)
+            }
+            if (progressListener != null) {
+                session.remoteMediaClient?.addProgressListener(progressListener, 1000)
+            }
             
             startRemoteProgressObserver()
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -814,9 +814,12 @@ class PlayerViewModel @Inject constructor(
                 }
 
                 Timber.e(error, failureMessage, song.id)
+                val fallbackQueue = libraryStateHolder.allSongs.value.takeIf { songs ->
+                    songs.isNotEmpty() && songs.any { it.id == song.id }
+                } ?: listOf(song)
                 showAndPlaySong(
                     song = song,
-                    contextSongs = listOf(song),
+                    contextSongs = fallbackQueue,
                     queueName = queueName,
                     isVoluntaryPlay = isVoluntaryPlay,
                     cancelPendingQueueBuild = false
@@ -2221,8 +2224,15 @@ class PlayerViewModel @Inject constructor(
 
     fun showAndPlaySong(song: Song) {
         Log.d("ShuffleDebug", "showAndPlaySong (single song overload) called for '${song.title}'")
-        // Use the song directly without scanning allSongs — the caller provides up-to-date data
-        showAndPlaySong(song, listOf(song), "Library")
+        val castSession = castStateHolder.castSession.value
+        val contextSongs = if (castSession != null && castSession.remoteMediaClient != null) {
+            libraryStateHolder.allSongs.value.takeIf { songs ->
+                songs.isNotEmpty() && songs.any { it.id == song.id }
+            } ?: listOf(song)
+        } else {
+            listOf(song)
+        }
+        showAndPlaySong(song, contextSongs, "Library")
     }
 
     private fun List<Song>.matchesSongOrder(contextSongs: List<Song>): Boolean {


### PR DESCRIPTION
…layback errors

Refactors the Cast MIME detection logic to improve performance and reliability during queue loading. Introduces an auto-skip mechanism to handle intermittent remote playback failures.

- **CastPlayer Optimization**:
    - Implemented thread-safe class-level caches (`ConcurrentHashMap`) for extractor, retriever, and signature-based MIME detection.
    - Added a "sliding window" approach to MIME probing, limiting deep inspection to songs near the starting index to reduce overhead.
    - Optimized FLAC identification to bypass expensive extractor calls when file extensions are present.
- **Playback Reliability**:
    - Added auto-skip logic in `CastTransferStateHolder` to jump to the next track if the current item fails to load on the receiver.
    - Implemented a `consecutiveErrorSkipCount` to prevent infinite skip loops, capped at 3 consecutive failures.
- **Queue Improvements**:
    - Updated `PlayerViewModel` to provide the full library as context when initiating Cast playback for single songs, ensuring a continuous queue experience.
    - Added null-safety checks when registering `RemoteMediaClient` callbacks and listeners.