### PR TITLE
perf: optimize playback queue loading and improve progress sampling

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -1647,6 +1647,7 @@ private fun PlayerProgressBarSection(
         }
     }
     val shouldRunRealtimeUpdates = allowRealtimeUpdates && isVisible
+    val shouldSampleProgress = isVisible
 
     val reportedDuration = totalDurationValue.coerceAtLeast(0L)
     val hintDuration = songDurationHintMs.coerceAtLeast(0L)
@@ -1686,9 +1687,9 @@ private fun PlayerProgressBarSection(
         isPlayingProvider = isPlayingProvider,
         currentPositionProvider = currentPositionProvider,
         totalDuration = displayDurationValue,
-        sampleWhilePlayingMs = if (isExpanded) 180L else 320L,
+        sampleWhilePlayingMs = if (shouldRunRealtimeUpdates && isExpanded) 180L else 500L,
         sampleWhilePausedMs = 800L,
-        isVisible = shouldRunRealtimeUpdates
+        isVisible = shouldSampleProgress
     )
 
     var sliderDragValue by remember { mutableStateOf<Float?>(null) }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -577,8 +577,7 @@ class PlaybackStateHolder @Inject constructor(
                     }
                 } else {
                      val controller = mediaController
-                     // Media3: Check isPlaying or playbackState == READY/BUFFERING
-                     if (controller != null && controller.isPlaying && !isSeeking) {
+                     if (controller != null && shouldSampleLocalProgress(controller)) {
                          val visibleSong = _stablePlayerState.value.currentSong
                          val currentMediaId = controller.currentMediaItem?.mediaId
                          val hasMediaMismatch = visibleSong?.id != null &&
@@ -620,6 +619,16 @@ class PlaybackStateHolder @Inject constructor(
                 delay(tickMs)
             }
         }
+    }
+
+    private fun shouldSampleLocalProgress(controller: Player): Boolean {
+        if (isSeeking) return false
+        if (controller.mediaItemCount <= 0) return false
+        if (controller.isPlaying) return true
+
+        return controller.playWhenReady &&
+            controller.playbackState != Player.STATE_IDLE &&
+            controller.playbackState != Player.STATE_ENDED
     }
 
     private fun currentProgressTickMs(): Long {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -179,9 +179,10 @@ private data class AiUiSnapshot(
     val isGeneratingAiMetadata: Boolean,
 )
 
-private data class PreparedPlaybackQueue(
-    val mediaItems: List<MediaItem>,
-    val startIndex: Int
+private data class PreparedPlaybackQueueSegments(
+    val beforeCurrent: List<MediaItem>,
+    val afterCurrent: List<MediaItem>,
+    val currentIndex: Int
 )
 
 private data class PendingMetadataEdit(
@@ -2810,9 +2811,14 @@ class PlayerViewModel @Inject constructor(
                         playWhenReady = playerCtrl.playWhenReady
                     )
                 }
-                if (isPlaying) {
+                val shouldKeepSampling = playerCtrl.playWhenReady &&
+                    playerCtrl.playbackState != Player.STATE_IDLE &&
+                    playerCtrl.playbackState != Player.STATE_ENDED
+                if (isPlaying || shouldKeepSampling) {
                     _isSheetVisible.value = true
-                    clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
+                    if (isPlaying) {
+                        clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
+                    }
                     startProgressUpdates()
                 } else {
                     stopProgressUpdates()
@@ -2824,6 +2830,13 @@ class PlayerViewModel @Inject constructor(
             override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
                 if (isRemoteSessionControllingPlayback()) return
                 playbackStateHolder.updateStablePlayerState { it.copy(playWhenReady = playWhenReady) }
+                if (
+                    playWhenReady &&
+                    playerCtrl.playbackState != Player.STATE_IDLE &&
+                    playerCtrl.playbackState != Player.STATE_ENDED
+                ) {
+                    startProgressUpdates()
+                }
             }
 
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -3203,28 +3216,54 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    private suspend fun preparePlaybackQueue(
+    private suspend fun preparePlaybackQueueSegments(
         songsToPlay: List<Song>,
         startSongId: String,
         playlistId: String?
-    ): PreparedPlaybackQueue = withContext(Dispatchers.Default) {
-        val mediaItems = ArrayList<MediaItem>(songsToPlay.size)
-        var startIndex = 0
-        var foundStartIndex = false
+    ): PreparedPlaybackQueueSegments = withContext(Dispatchers.Default) {
+        val currentIndex = songsToPlay
+            .indexOfFirst { it.id == startSongId }
+            .takeIf { it >= 0 }
+            ?: 0
 
-        songsToPlay.forEachIndexed { index, song ->
-            if (!foundStartIndex && song.id == startSongId) {
-                startIndex = index
-                foundStartIndex = true
-            }
-
-            mediaItems += buildPlaybackMediaItem(song, playlistId)
+        val beforeCurrent = List(currentIndex) { index ->
+            buildPlaybackMediaItem(songsToPlay[index], playlistId)
+        }
+        val afterStartIndex = currentIndex + 1
+        val afterCurrent = List((songsToPlay.size - afterStartIndex).coerceAtLeast(0)) { offset ->
+            buildPlaybackMediaItem(songsToPlay[afterStartIndex + offset], playlistId)
         }
 
-        PreparedPlaybackQueue(
-            mediaItems = mediaItems,
-            startIndex = startIndex
+        PreparedPlaybackQueueSegments(
+            beforeCurrent = beforeCurrent,
+            afterCurrent = afterCurrent,
+            currentIndex = currentIndex
         )
+    }
+
+    private fun attachPreparedQueueSegmentsIfCurrent(
+        player: Player,
+        startSongId: String,
+        preparedSegments: PreparedPlaybackQueueSegments
+    ) {
+        if (player.currentMediaItem?.mediaId != startSongId) return
+        if (player.mediaItemCount != 1) return
+        if (player.getMediaItemAt(0).mediaId != startSongId) return
+
+        if (preparedSegments.beforeCurrent.isNotEmpty()) {
+            player.addMediaItems(0, preparedSegments.beforeCurrent)
+        }
+
+        if (preparedSegments.afterCurrent.isNotEmpty()) {
+            player.addMediaItems(
+                preparedSegments.beforeCurrent.size + 1,
+                preparedSegments.afterCurrent
+            )
+        }
+
+        playbackStateHolder.updateStablePlayerState {
+            it.copy(currentMediaItemIndex = preparedSegments.currentIndex)
+        }
     }
 
 
@@ -3264,6 +3303,7 @@ class PlayerViewModel @Inject constructor(
             playbackStateHolder.updateStablePlayerState {
                 it.copy(
                     currentSong = effectiveStartSong,
+                    currentMediaItemIndex = 0,
                     isPlaying = true,
                     playWhenReady = true,
                     totalDuration = effectiveStartSong.duration.coerceAtLeast(0L)
@@ -3280,6 +3320,7 @@ class PlayerViewModel @Inject constructor(
             playbackStateHolder.updateStablePlayerState {
                 it.copy(
                     currentSong = effectiveStartSong,
+                    currentMediaItemIndex = 0,
                     isPlaying = true,
                     playWhenReady = true,
                     totalDuration = effectiveStartSong.duration.coerceAtLeast(0L)
@@ -3287,45 +3328,33 @@ class PlayerViewModel @Inject constructor(
             }
             _isSheetVisible.value = true
 
-            // Pre-resolve the starting song's cloud URI before ExoPlayer touches it.
-            // This populates the resolvedUriCache so resolveDataSpec finds it instantly.
-            val startingUri = MediaItemBuilder.playbackUri(effectiveStartSong)
-            if (
-                startingUri.scheme == "telegram" ||
-                startingUri.scheme == "netease" ||
-                startingUri.scheme == "qqmusic" ||
-                startingUri.scheme == "navidrome" ||
-                startingUri.scheme == "jellyfin"
-            ) {
-                if (startingUri.scheme == "telegram") {
-                    ensureTelegramPlaybackObserversStarted()
-                }
-                dualPlayerEngine.resolveCloudUri(startingUri)
-            }
-
-            val preparedPlaybackQueue = preparePlaybackQueue(
-                songsToPlay = songsToPlay,
-                startSongId = effectiveStartSong.id,
-                playlistId = playlistId
-            )
+            val startMediaItem = buildResolvedPlaybackMediaItem(effectiveStartSong)
 
             val playSongsAction = {
                 // Use Direct Engine Access to avoid TransactionTooLargeException on Binder
                 val enginePlayer = dualPlayerEngine.masterPlayer
 
-                if (preparedPlaybackQueue.mediaItems.isNotEmpty()) {
-                    // Direct access: No IPC limit involved
-                    enginePlayer.setMediaItems(
-                        preparedPlaybackQueue.mediaItems,
-                        preparedPlaybackQueue.startIndex,
-                        0L
-                    )
-                    enginePlayer.prepare()
-                    enginePlayer.play()
-                } else {
-                    clearPreparingSongIfMatching(effectiveStartSong.id)
-                }
+                enginePlayer.setMediaItem(startMediaItem, 0L)
+                enginePlayer.prepare()
+                enginePlayer.play()
                 _playerUiState.update { it.copy(isLoadingInitialSongs = false) }
+
+                if (songsToPlay.size > 1) {
+                    viewModelScope.launch {
+                        val preparedSegments = preparePlaybackQueueSegments(
+                            songsToPlay = songsToPlay,
+                            startSongId = effectiveStartSong.id,
+                            playlistId = playlistId
+                        )
+                        withContext(Dispatchers.Main.immediate) {
+                            attachPreparedQueueSegmentsIfCurrent(
+                                player = dualPlayerEngine.masterPlayer,
+                                startSongId = effectiveStartSong.id,
+                                preparedSegments = preparedSegments
+                            )
+                        }
+                    }
+                }
             }
 
             // We still check for mediaController to ensure the Service is bound and active

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AlbumArtUtils.kt
@@ -16,7 +16,7 @@ import java.io.FileInputStream
 import java.io.InputStream
 
 object AlbumArtUtils {
-    private const val CACHE_VERSION_SUFFIX = "_v3"
+    private const val CACHE_VERSION_SUFFIX = "_v4"
 
     // P2-1: Dedicated app-level scope to replace GlobalScope.
     // SupervisorJob ensures child failures don't cancel sibling coroutines.
@@ -269,6 +269,8 @@ object AlbumArtUtils {
         listOf(
             getCachedAlbumArtFile(appContext, songId),
             noArtMarkerFile(appContext, songId),
+            legacyCachedAlbumArtFile(appContext, songId, "_v3"),
+            legacyNoArtMarkerFile(appContext, songId, "_v3"),
             legacyCachedAlbumArtFile(appContext, songId, "_v2"),
             legacyNoArtMarkerFile(appContext, songId, "_v2"),
             legacyCachedAlbumArtFile(appContext, songId),

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaMetadataRetrieverPool.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaMetadataRetrieverPool.kt
@@ -1,12 +1,15 @@
 package com.theveloper.pixelplay.utils
 
 import android.media.MediaMetadataRetriever
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * Thread-safe pool of MediaMetadataRetriever instances to avoid costly creation/destruction
- * during mass scanning operations. Each retriever is reset between uses.
+ * Thread-safe helper for MediaMetadataRetriever usage.
+ *
+ * MediaMetadataRetriever does not expose a reliable reset/clear-data-source API. Reusing an
+ * instance across files can leave stale native extractor state on some Android builds, which
+ * makes embedded artwork/metadata reads intermittently return null for valid local files. Keep
+ * the wrapper API for callers, but use a fresh retriever per operation.
  * 
  * Usage:
  * ```kotlin
@@ -17,9 +20,6 @@ import java.util.concurrent.atomic.AtomicInteger
  * ```
  */
 object MediaMetadataRetrieverPool {
-    
-    private const val MAX_POOL_SIZE = 4
-    private val pool = ConcurrentLinkedQueue<MediaMetadataRetriever>()
     private val createdCount = AtomicInteger(0)
     
     /**
@@ -28,10 +28,8 @@ object MediaMetadataRetrieverPool {
      */
     @PublishedApi
     internal fun acquire(): MediaMetadataRetriever {
-        return pool.poll() ?: run {
-            createdCount.incrementAndGet()
-            MediaMetadataRetriever()
-        }
+        createdCount.incrementAndGet()
+        return MediaMetadataRetriever()
     }
     
     /**
@@ -40,16 +38,11 @@ object MediaMetadataRetrieverPool {
      */
     @PublishedApi
     internal fun release(retriever: MediaMetadataRetriever) {
-        if (pool.size < MAX_POOL_SIZE) {
-            // Reset the retriever for reuse (best effort - setDataSource with null is not supported)
-            // The next setDataSource call will override the previous state
-            pool.offer(retriever)
-        } else {
-            try {
-                retriever.release()
-            } catch (_: Exception) {
-                // Ignore release errors
-            }
+        try {
+            retriever.release()
+        } catch (_: Exception) {
+            // Ignore release errors
+        } finally {
             createdCount.decrementAndGet()
         }
     }
@@ -76,22 +69,13 @@ object MediaMetadataRetrieverPool {
      * Clears all pooled retrievers. Call this when the app is low on memory.
      */
     fun clear() {
-        var retriever = pool.poll()
-        while (retriever != null) {
-            try {
-                retriever.release()
-            } catch (_: Exception) {
-                // Ignore release errors
-            }
-            createdCount.decrementAndGet()
-            retriever = pool.poll()
-        }
+        // No-op: retrievers are released immediately after each use.
     }
     
     /**
      * Returns the current number of retrievers held in the pool.
      */
-    fun poolSize(): Int = pool.size
+    fun poolSize(): Int = 0
     
     /**
      * Returns the total number of retrievers created (including those in use).


### PR DESCRIPTION
Optimizes playback initialization by loading the starting song immediately and attaching the remaining queue segments asynchronously. This reduces perceived latency when starting playback. Additionally, disables `MediaMetadataRetriever` pooling to resolve intermittent metadata failures caused by stale native state.

- Refactored queue preparation in `PlayerViewModel` to load the current item first and attach surrounding segments asynchronously.
- Removed instance pooling from `MediaMetadataRetrieverPool`; instances are now created and released per use to ensure fresh extractor state.
- Refined progress sampling logic in `PlaybackStateHolder` and `FullPlayerContent` to maintain UI updates during buffering (when `playWhenReady` is true).
- Incremented album art cache version to `_v4` and added cleanup logic for legacy `_v3` files.
- Added `currentMediaItemIndex` tracking to the stable player state.