### PR TITLE
perf: optimize QueueBottomSheet rendering and state management

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -124,7 +124,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
@@ -150,7 +149,6 @@ import com.theveloper.pixelplay.presentation.viewmodel.PlayerUiState
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
 import com.theveloper.pixelplay.presentation.viewmodel.PlaylistViewModel
 import com.theveloper.pixelplay.presentation.viewmodel.SettingsViewModel
-import com.theveloper.pixelplay.presentation.viewmodel.StablePlayerState
 import com.theveloper.pixelplay.presentation.utils.LocalAppHapticsConfig
 import com.theveloper.pixelplay.presentation.utils.performAppCompatHapticFeedback
 import com.theveloper.pixelplay.ui.theme.GoogleSansRounded
@@ -218,6 +216,8 @@ fun QueueBottomSheet(
     currentQueueSourceName: String,
     currentSongId: String?,
     currentMediaItemIndex: Int = -1,
+    isVisible: Boolean,
+    isPlaying: Boolean,
     repeatMode: Int,
     isShuffleOn: Boolean,
     onDismiss: () -> Unit,
@@ -256,19 +256,17 @@ fun QueueBottomSheet(
     var showClearQueueDialog by remember { mutableStateOf(false) }
     var isFabExpanded by rememberSaveable { mutableStateOf(false) }
 
-    BackHandler(enabled = isFabExpanded) {
+    LaunchedEffect(isVisible) {
+        if (!isVisible) {
+            showTimerOptions = false
+            showClearQueueDialog = false
+            isFabExpanded = false
+        }
+    }
+
+    BackHandler(enabled = isVisible && isFabExpanded) {
         isFabExpanded = false
     }
-
-    val infrequentPlayerState by viewModel.stablePlayerState.collectAsStateWithLifecycle()
-
-    val albumColorSchemePair by viewModel.currentAlbumArtColorSchemePair.collectAsStateWithLifecycle()
-    val isDark = isSystemInDarkTheme()
-    val albumColorScheme = remember(albumColorSchemePair, isDark) {
-        albumColorSchemePair?.let { pair -> if (isDark) pair.dark else pair.light }
-    }
-
-    val isPlaying = infrequentPlayerState.isPlaying
 
     // Use the real player index from MediaController if available to resolve duplicates.
     // Fall back to ID search only if index is invalid (-1).
@@ -316,9 +314,10 @@ fun QueueBottomSheet(
     var pendingReorderGraceUpdates by remember { mutableIntStateOf(0) }
 
     // Stable keys for queue rows to prevent state recycling glitches on remove/reorder.
-    var committedDisplaySongIds by remember { mutableStateOf(displaySongs.map { it.id }) }
-    var committedDisplayKeys by remember { mutableStateOf(List(displaySongCount) { it.toLong() }) }
-    var nextStableQueueItemKey by remember { mutableLongStateOf(displaySongCount.toLong()) }
+    // Start empty so opening the sheet does not eagerly allocate IDs/keys for the entire queue.
+    var committedDisplaySongIds by remember { mutableStateOf<List<String>>(emptyList()) }
+    var committedDisplayKeys by remember { mutableStateOf<List<Long>>(emptyList()) }
+    var nextStableQueueItemKey by remember { mutableLongStateOf(0L) }
 
     // Track queue order by content (not list identity) to avoid clearing preview
     // when upstream emits equivalent list instances during drag.
@@ -326,21 +325,36 @@ fun QueueBottomSheet(
     val displaySongsSignature = remember(displaySongs, queueIndexOffset) {
         (queueIndexOffset * 31) + System.identityHashCode(displaySongs)
     }
-    val defaultDisplayOrder = remember(displaySongCount, queueIndexOffset) {
-        List(displaySongCount) { queueIndexOffset + it }
-    }
-    val defaultDisplayKeys = remember(displaySongCount, queueIndexOffset) {
-        List(displaySongCount) { (queueIndexOffset + it).toLong() }
-    }
-    val activeOrder = reorderPreviewOrder ?: defaultDisplayOrder
     val activeKeys = reorderPreviewKeys
         ?: committedDisplayKeys.takeIf { it.size == displaySongCount }
-        ?: defaultDisplayKeys
     val activeSongSource = reorderPreviewBaseQueue ?: queue
-    val activeKeyToLocalIndex = remember(activeKeys) {
-        HashMap<Long, Int>(activeKeys.size).apply {
-            activeKeys.forEachIndexed { index, stableKey ->
-                put(stableKey, index)
+    fun activeQueueIndexAt(index: Int): Int =
+        reorderPreviewOrder?.getOrNull(index) ?: (queueIndexOffset + index)
+
+    fun activeKeyAt(index: Int): Long =
+        activeKeys?.getOrNull(index) ?: (queueIndexOffset + index).toLong()
+
+    // --- REORDER STATE ---
+    var lastMovedFrom by remember { mutableStateOf<Int?>(null) }
+    var lastMovedTo by remember { mutableStateOf<Int?>(null) }
+    var reorderHandleInUse by remember { mutableStateOf(false) }
+    val updatedReorderHandleInUse by rememberUpdatedState(reorderHandleInUse)
+
+    val shouldMapActiveKeys = reorderHandleInUse || reorderPreviewOrder != null
+    val activeKeyToLocalIndex = remember(
+        activeKeys,
+        displaySongCount,
+        queueIndexOffset,
+        shouldMapActiveKeys
+    ) {
+        if (!shouldMapActiveKeys) {
+            emptyMap()
+        } else {
+            HashMap<Long, Int>(displaySongCount).apply {
+                for (index in 0 until displaySongCount) {
+                    val stableKey = activeKeys?.getOrNull(index) ?: (queueIndexOffset + index).toLong()
+                    put(stableKey, index)
+                }
             }
         }
     }
@@ -373,6 +387,9 @@ fun QueueBottomSheet(
         }
 
         var nextKey = nextStableQueueItemKey
+        if (committedDisplaySongIds.isEmpty() && committedDisplayKeys.isEmpty()) {
+            nextKey = queueIndexOffset.toLong()
+        }
         val newKeys = ArrayList<Long>(newSongs.size)
         newSongs.forEach { song ->
             val bucket = reusableKeysBySongId[song.id]
@@ -436,15 +453,14 @@ fun QueueBottomSheet(
         reorderPreviewQueueSignature = displaySongsSignature
     }
 
-    // --- REORDER STATE ---
-    var lastMovedFrom by remember { mutableStateOf<Int?>(null) }
-    var lastMovedTo by remember { mutableStateOf<Int?>(null) }
-    var reorderHandleInUse by remember { mutableStateOf(false) }
-    val updatedReorderHandleInUse by rememberUpdatedState(reorderHandleInUse)
-
     fun mapKeyToLocalIndex(key: Any?, keyToLocalIndex: Map<Long, Int>): Int? {
         val stableKey = key as? Long ?: return null
-        return keyToLocalIndex[stableKey]
+        keyToLocalIndex[stableKey]?.let { return it }
+        activeKeys?.let { keys ->
+            return keys.indexOf(stableKey).takeIf { it >= 0 }
+        }
+        val defaultIndex = (stableKey - queueIndexOffset).toInt()
+        return defaultIndex.takeIf { it in 0 until displaySongCount }
     }
 
     val reorderableState = rememberReorderableLazyListState(
@@ -453,8 +469,10 @@ fun QueueBottomSheet(
             if (reorderPreviewOrder == null) {
                 reorderPreviewBaseQueue = queue
             }
-            val currentOrder = activeOrder
-            val currentKeys = activeKeys
+            val currentOrder = reorderPreviewOrder
+                ?: List(displaySongCount) { queueIndexOffset + it }
+            val currentKeys = reorderPreviewKeys
+                ?: List(displaySongCount) { activeKeyAt(it) }
 
             val fromLocalIndex = mapKeyToLocalIndex(from.key, activeKeyToLocalIndex) ?: return@rememberReorderableLazyListState
             val toLocalIndex = mapKeyToLocalIndex(to.key, activeKeyToLocalIndex) ?: return@rememberReorderableLazyListState
@@ -710,7 +728,6 @@ fun QueueBottomSheet(
                     onPrevious = { viewModel.previousSong() },
                     onPlayPause = { viewModel.playPause() },
                     onNext = { viewModel.nextSong() },
-                    colorScheme = albumColorScheme,
                     onLocateCurrentSong = {
                         if (currentSongDisplayIndex in 0..<displaySongCount) {
                             queueCoroutineScope.launch {
@@ -776,13 +793,12 @@ fun QueueBottomSheet(
 
                             items(
                                 count = displaySongCount,
-                                key = { index -> activeKeys[index] },
+                                key = { index -> activeKeyAt(index) },
                                 contentType = { "queue_song" }
                             ) { index ->
-                                if (index >= activeOrder.size || index >= activeKeys.size) return@items
-                                val queueIndex = activeOrder[index]
+                                val queueIndex = activeQueueIndexAt(index)
                                 if (queueIndex !in activeSongSource.indices) return@items
-                                val itemStableKey = activeKeys[index]
+                                val itemStableKey = activeKeyAt(index)
                                 val song = activeSongSource[queueIndex]
                                 val canReorder = index > currentSongDisplayIndex
                                 ReorderableItem(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -35,6 +37,7 @@ import com.theveloper.pixelplay.presentation.viewmodel.PlaylistViewModel
 import com.theveloper.pixelplay.presentation.viewmodel.StablePlayerState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.map
+import kotlin.math.roundToInt
 
 internal data class SaveQueueOverlayData(
     val songs: List<Song>,
@@ -45,6 +48,7 @@ internal data class SaveQueueOverlayData(
 @Composable
 internal fun UnifiedPlayerQueueLayer(
     shouldRenderLayer: Boolean,
+    keepQueueSheetWarm: Boolean,
     albumColorScheme: ColorScheme,
     queueScrimAlpha: Float,
     showQueueSheet: Boolean,
@@ -97,8 +101,8 @@ internal fun UnifiedPlayerQueueLayer(
             )
         }
 
-        val shouldRenderQueueSheet = remember(showQueueSheet, queueSheetHeightPx) {
-            showQueueSheet || queueSheetHeightPx == 0f
+        val shouldRenderQueueSheet = remember(showQueueSheet, keepQueueSheetWarm, queueSheetHeightPx) {
+            showQueueSheet || keepQueueSheetWarm || queueSheetHeightPx == 0f
         }
 
         if (shouldRenderQueueSheet) {
@@ -110,8 +114,8 @@ internal fun UnifiedPlayerQueueLayer(
                 QueueBottomSheet(
                     modifier = Modifier
                         .fillMaxSize()
+                        .offset { IntOffset(0, queueSheetOffset.value.roundToInt()) }
                         .graphicsLayer {
-                            translationY = queueSheetOffset.value
                             alpha = if (showQueueSheet) 1f else 0f
                         }
                         .onGloballyPositioned { coordinates ->
@@ -124,6 +128,8 @@ internal fun UnifiedPlayerQueueLayer(
                     currentQueueSourceName = currentQueueSourceName,
                     currentSongId = infrequentPlayerState.currentSong?.id,
                     currentMediaItemIndex = currentMediaItemIndex,
+                    isVisible = showQueueSheet,
+                    isPlaying = infrequentPlayerState.isPlaying,
                     onDismiss = onDismissQueue,
                     onSongInfoClick = onSongInfoClick,
                     onPlaySong = onPlaySong,
@@ -263,6 +269,7 @@ internal fun UnifiedPlayerSongInfoLayer(
 @Composable
 internal fun UnifiedPlayerQueueAndSongInfoHost(
     shouldRenderHost: Boolean,
+    keepQueueSheetWarm: Boolean,
     isQueueTelemetryActive: Boolean,
     albumColorScheme: ColorScheme,
     queueScrimAlpha: Float,
@@ -379,6 +386,7 @@ internal fun UnifiedPlayerQueueAndSongInfoHost(
 
             UnifiedPlayerQueueLayer(
                 shouldRenderLayer = true,
+                keepQueueSheetWarm = keepQueueSheetWarm,
                 albumColorScheme = albumColorScheme,
                 queueScrimAlpha = queueScrimAlpha,
                 showQueueSheet = showQueueSheet,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -713,6 +713,8 @@ fun UnifiedPlayerSheetV2(
 
             UnifiedPlayerQueueAndSongInfoHost(
                 shouldRenderHost = shouldRenderQueueHost,
+                keepQueueSheetWarm = currentSheetContentState == PlayerSheetState.EXPANDED &&
+                    !internalIsKeyboardVisible,
                 isQueueTelemetryActive = isQueueTelemetryActive,
                 albumColorScheme = albumColorScheme,
                 queueScrimAlpha = queueScrimAlpha,


### PR DESCRIPTION
Improves the performance and responsiveness of the player queue by implementing a "warming" strategy and optimizing layout calculations. The queue sheet is now kept rendered while the player is expanded to ensure smooth transitions, and stable keys are allocated lazily to reduce initial composition overhead.

- Implemented `keepQueueSheetWarm` logic in `UnifiedPlayerQueueLayer` to maintain the sheet in the composition tree when the player is expanded.
- Replaced `graphicsLayer { translationY }` with `Modifier.offset { IntOffset }` to avoid unnecessary recompositions during scroll and transition animations.
- Refactored `QueueBottomSheet` to use lazy initialization for stable keys and song IDs, reducing memory allocation when the sheet is not visible.
- Hoisted color scheme and playback state out of `QueueBottomSheet` to simplify the component's internal state.
- Added a `LaunchedEffect` to reset internal UI states (FAB expansion, dialogs, and timers) when the sheet is dismissed.
- Optimized reordering logic by introducing helper functions for index and key lookups, avoiding eager list allocations during drag operations.
- Updated `BackHandler` to only intercept events when the queue sheet is actively visible.