### PR TITLE
feat: enhance playlist cover adjustment and management

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ImageCropView.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ImageCropView.kt
@@ -8,8 +8,9 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -33,6 +34,11 @@ fun ImageCropView(
 ) {
     val density = LocalDensity.current
     
+    // Use updated state to avoid stale closure in pointerInput
+    val currentScaleState by rememberUpdatedState(scale)
+    val currentPanState by rememberUpdatedState(pan)
+    val currentOnCropState by rememberUpdatedState(onCrop)
+
     BoxWithConstraints(
         modifier = modifier
             .aspectRatio(1f) // Enforce square container
@@ -67,12 +73,6 @@ fun ImageCropView(
         val currentW = baseW * scale
         val currentH = baseH * scale
         
-        // Calculate Pan Limits (Center is 0,0 relative to Viewport center)
-        // If image is larger than viewport, we can pan.
-        // Limit is: (ContentSize - ViewportSize) / 2
-        val maxPanX = max(0f, (currentW - viewportWidth) / 2f)
-        val maxPanY = max(0f, (currentH - viewportHeight) / 2f)
-        
         // Current Pan in Pixels
         // pan input is normalized: panX * viewportWidth
         val currentPanX = pan.x * viewportWidth
@@ -85,8 +85,8 @@ fun ImageCropView(
                     if (enabled) {
                         Modifier.pointerInput(baseW, baseH, viewportWidth, viewportHeight) {
                             detectTransformGestures { _, panDelta, zoom, _ ->
-                                // 1. Update Scale
-                                val newScale = (scale * zoom).coerceAtLeast(1f).coerceAtMost(5f)
+                                // 1. Update Scale using non-stale value
+                                val newScale = (currentScaleState * zoom).coerceAtLeast(1f).coerceAtMost(5f)
                                 
                                 // 2. Update Pan
                                 // We need to re-calculate limits based on new scale
@@ -95,16 +95,18 @@ fun ImageCropView(
                                 val newMaxPanX = max(0f, (newW - viewportWidth) / 2f)
                                 val newMaxPanY = max(0f, (newH - viewportHeight) / 2f)
                                 
-                                // Apply delta to current pixels
-                                // Note: Pan delta implies translation.
-                                val newPanPxX = (currentPanX + panDelta.x).coerceIn(-newMaxPanX, newMaxPanX)
-                                val newPanPxY = (currentPanY + panDelta.y).coerceIn(-newMaxPanY, newMaxPanY)
+                                // Apply delta to current pixels (non-stale)
+                                val panPxX = currentPanState.x * viewportWidth
+                                val panPxY = currentPanState.y * viewportHeight
+
+                                val newPanPxX = (panPxX + panDelta.x).coerceIn(-newMaxPanX, newMaxPanX)
+                                val newPanPxY = (panPxY + panDelta.y).coerceIn(-newMaxPanY, newMaxPanY)
                                 
                                 // Normalize
                                 val normX = if(viewportWidth > 0) newPanPxX / viewportWidth else 0f
                                 val normY = if(viewportHeight > 0) newPanPxY / viewportHeight else 0f
                                 
-                                onCrop(newScale, Offset(normX, normY))
+                                currentOnCropState(newScale, Offset(normX, normY))
                             }
                         }
                     } else Modifier

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/CreatePlaylistScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
@@ -30,6 +31,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -60,6 +62,8 @@ import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Piano
 import androidx.compose.material.icons.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Speaker
+import androidx.compose.material.icons.rounded.Crop
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -67,6 +71,7 @@ import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -81,6 +86,12 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -100,6 +111,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -119,7 +131,6 @@ import androidx.compose.material3.FilterChipDefaults
 import com.theveloper.pixelplay.utils.shapes.RoundedStarShape
 import com.theveloper.pixelplay.utils.resolvePlaylistCoverContentColor
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.LayoutDirection
@@ -135,10 +146,8 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.rounded.Clear
 import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.ui.graphics.TransformOrigin
@@ -351,29 +360,36 @@ private fun CreatePlaylistContent(
     ) { uri: Uri? ->
         uri?.let {
             selectedImageUri = it
+            cropScale = 1f
+            cropOffset = androidx.compose.ui.geometry.Offset.Zero
             showCropUi = true
         }
     }
     
-    // Back Handler for Step 2
-    BackHandler(enabled = currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL) {
-        currentStep = 0
+    // Back Handler for navigation flow
+    BackHandler(enabled = showCropUi || (currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL)) {
+        when {
+            showCropUi -> showCropUi = false
+            currentStep == 1 -> currentStep = 0
+        }
     }
 
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
-                    AnimatedContent(targetState = currentStep, label = "Title Animation") { step ->
+                    AnimatedContent(targetState = if (showCropUi) 2 else currentStep, label = "Title Animation") { displayStep ->
                         Text(
-                            if (step == 0) {
-                                if (creationMode == PlaylistCreationMode.SMART) {
-                                    stringResource(R.string.presentation_batch_f_new_smart_playlist)
-                                } else {
-                                    stringResource(R.string.presentation_batch_f_new_playlist)
+                            when (displayStep) {
+                                2 -> stringResource(R.string.presentation_batch_f_edit_cover_title)
+                                0 -> {
+                                    if (creationMode == PlaylistCreationMode.SMART) {
+                                        stringResource(R.string.presentation_batch_f_new_smart_playlist)
+                                    } else {
+                                        stringResource(R.string.presentation_batch_f_new_playlist)
+                                    }
                                 }
-                            } else {
-                                stringResource(R.string.presentation_batch_f_add_songs)
+                                else -> stringResource(R.string.presentation_batch_f_add_songs)
                             },
                             style = MaterialTheme.typography.titleMedium.copy(
                                 fontSize = 24.sp,
@@ -392,11 +408,15 @@ private fun CreatePlaylistContent(
                             contentColor = MaterialTheme.colorScheme.onSurface
                         ),
                         onClick = {
-                            if (currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL) currentStep = 0 else onDismiss()
+                            when {
+                                showCropUi -> showCropUi = false
+                                currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL -> currentStep = 0
+                                else -> onDismiss()
+                            }
                         }
                     ) {
                         Icon(
-                            if (currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL) {
+                            if (showCropUi || (currentStep == 1 && creationMode == PlaylistCreationMode.MANUAL)) {
                                 Icons.AutoMirrored.Rounded.ArrowBack
                             } else {
                                 Icons.Rounded.Close
@@ -680,7 +700,8 @@ private fun CreatePlaylistContent(
                      onCreationModeChange = { creationMode = it },
                      selectedSmartRule = selectedSmartRule,
                      onSmartRuleChange = { selectedSmartRule = it },
-                     onGenerateClick = onGenerateClick
+                     onGenerateClick = onGenerateClick,
+                     onImageUriChange = { selectedImageUri = it }
                  )
             } else {
                 SongPickerSelectionPane(
@@ -784,9 +805,15 @@ fun EditPlaylistContent(
     ) { uri: Uri? ->
         uri?.let {
             selectedImageUri = it
+            cropScale = 1f
+            cropOffset = androidx.compose.ui.geometry.Offset.Zero
             showCropUi = true
             selectedTab = 1 // Force switch to image tab
         }
+    }
+
+    BackHandler(enabled = showCropUi) {
+        showCropUi = false
     }
 
     Scaffold(
@@ -810,9 +837,14 @@ fun EditPlaylistContent(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
                             contentColor = MaterialTheme.colorScheme.onSurface
                         ),
-                        onClick = onDismiss
+                        onClick = {
+                            if (showCropUi) showCropUi = false else onDismiss()
+                        }
                     ) {
-                        Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.presentation_batch_f_cd_close))
+                        Icon(
+                            if (showCropUi) Icons.AutoMirrored.Rounded.ArrowBack else Icons.Rounded.Close,
+                            contentDescription = stringResource(if (showCropUi) R.string.presentation_batch_f_cd_back_or_cancel else R.string.presentation_batch_f_cd_close)
+                        )
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -904,7 +936,8 @@ fun EditPlaylistContent(
              creationMode = PlaylistCreationMode.MANUAL,
              onCreationModeChange = { },
              selectedSmartRule = SmartPlaylistRule.TOP_PLAYED,
-             onSmartRuleChange = { }
+             onSmartRuleChange = { },
+             onImageUriChange = { selectedImageUri = it }
          )
     }
 }
@@ -949,30 +982,75 @@ private fun PlaylistFormContent(
     onCreationModeChange: (PlaylistCreationMode) -> Unit,
     selectedSmartRule: SmartPlaylistRule,
     onSmartRuleChange: (SmartPlaylistRule) -> Unit,
-    onGenerateClick: (() -> Unit)? = null
+    onGenerateClick: (() -> Unit)? = null,
+    onImageUriChange: (Uri?) -> Unit
 ) {
-    if (showCropUi && imageBitmap != null) {
+    if (showCropUi) {
          // Fullscreen Crop UI overrides normal content
-         Box(modifier = modifier.fillMaxSize().padding(16.dp).clip(RoundedCornerShape(24.dp))) {
-             ImageCropView(
-                 imageBitmap = imageBitmap,
-                 modifier = Modifier.fillMaxSize(),
-                 scale = cropScale,
-                 pan = cropOffset,
-                 enabled = true,
-                 onCrop = { scale, pan -> 
-                     onCropScaleChange(scale)
-                     onCropOffsetChange(pan)
+         Box(
+             modifier = modifier
+                 .fillMaxSize()
+                 .padding(16.dp)
+                 .clip(RoundedCornerShape(24.dp))
+                 .background(MaterialTheme.colorScheme.surface)
+         ) {
+             if (imageBitmap != null) {
+                 Column(
+                     modifier = Modifier.fillMaxSize(),
+                     horizontalAlignment = Alignment.CenterHorizontally
+                 ) {
+                     Spacer(Modifier.height(32.dp))
+                     Text(
+                         text = stringResource(R.string.presentation_batch_f_adjust_cover_title),
+                         style = MaterialTheme.typography.headlineSmall,
+                         textAlign = TextAlign.Center,
+                         modifier = Modifier.padding(horizontal = 24.dp)
+                     )
+                     Spacer(Modifier.height(8.dp))
+                     Text(
+                         text = stringResource(R.string.presentation_batch_f_adjust_cover_hint),
+                         style = MaterialTheme.typography.bodySmall,
+                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                         textAlign = TextAlign.Center,
+                         modifier = Modifier.padding(horizontal = 32.dp)
+                     )
+                     Spacer(Modifier.weight(1f))
+                     Box(
+                         modifier = Modifier
+                             .fillMaxWidth()
+                             .aspectRatio(1f)
+                             .padding(16.dp)
+                             .clip(RoundedCornerShape(32.dp))
+                     ) {
+                         ImageCropView(
+                             imageBitmap = imageBitmap,
+                             modifier = Modifier.fillMaxSize(),
+                             scale = cropScale,
+                             pan = cropOffset,
+                             enabled = true,
+                             onCrop = { scale, pan -> 
+                                 onCropScaleChange(scale)
+                                 onCropOffsetChange(pan)
+                             }
+                         )
+                     }
+                     Spacer(Modifier.weight(1f))
+                     Button(
+                        onClick = { onShowCropUiChange(false) },
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .padding(24.dp)
+                            .height(56.dp),
+                        shape = CircleShape
+                    ) {
+                        Icon(Icons.Rounded.Check, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.presentation_batch_f_done))
+                    }
                  }
-             )
-             FilledIconButton(
-                onClick = { onShowCropUiChange(false) },
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp)
-            ) {
-                Icon(Icons.Rounded.Check, contentDescription = stringResource(R.string.presentation_batch_f_cd_confirm_crop))
-            }
+             } else {
+                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+             }
          }
          return
     }
@@ -1024,22 +1102,15 @@ private fun PlaylistFormContent(
                         }
                     }
                     1 -> { // Image
-                         // Image Preview (Read Only)
+                         // Image Preview
                          if (imageBitmap != null) {
-                             Box(
-                                modifier = Modifier
-                                    .size(180.dp)
-                                    .clip(RoundedCornerShape(32.dp))
-                                    .clickable { imagePickerLauncher.launch("image/*") }
-                             ) {
-                                 if (cropScale == 1f && cropOffset == androidx.compose.ui.geometry.Offset.Zero) {
-                                     AsyncImage(
-                                         model = selectedImageUri,
-                                         contentDescription = null,
-                                         modifier = Modifier.fillMaxSize(),
-                                         contentScale = ContentScale.Crop
-                                     )
-                                 } else {
+                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                 Box(
+                                    modifier = Modifier
+                                        .size(180.dp)
+                                        .clip(RoundedCornerShape(32.dp))
+                                        .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                                 ) {
                                      ImageCropView(
                                          imageBitmap = imageBitmap,
                                          modifier = Modifier.fillMaxSize(),
@@ -1048,6 +1119,34 @@ private fun PlaylistFormContent(
                                          enabled = false,
                                          onCrop = { _, _ -> }
                                      )
+                                 }
+                                 Spacer(Modifier.height(12.dp))
+                                 Row(
+                                     horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                     modifier = Modifier.padding(horizontal = 16.dp)
+                                 ) {
+                                     FilledTonalButton(
+                                         onClick = { imagePickerLauncher.launch("image/*") },
+                                         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                                         modifier = Modifier.height(40.dp).weight(1f)
+                                     ) {
+                                         Icon(Icons.Rounded.AddPhotoAlternate, contentDescription = null, modifier = Modifier.size(18.dp))
+                                         Spacer(Modifier.width(8.dp))
+                                         Text(stringResource(R.string.presentation_batch_f_change), style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                     }
+                                     Button(
+                                         onClick = { onImageUriChange(null) },
+                                         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                                         modifier = Modifier.height(40.dp).weight(1f),
+                                         colors = ButtonDefaults.buttonColors(
+                                             containerColor = MaterialTheme.colorScheme.error,
+                                             contentColor = MaterialTheme.colorScheme.onError
+                                         )
+                                     ) {
+                                         Icon(Icons.Rounded.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                                         Spacer(Modifier.width(8.dp))
+                                         Text(stringResource(R.string.presentation_batch_f_remove), style = MaterialTheme.typography.labelLarge, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                     }
                                  }
                              }
                          } else {
@@ -1494,11 +1593,11 @@ fun ExpressiveButtonGroup(
         items.forEachIndexed { index, title ->
             val isSelected = selectedIndex == index
             val shape = if (isSelected) CircleShape else RoundedCornerShape(10.dp) // Pill vs RoundedRect
-            val containerColor by androidx.compose.animation.animateColorAsState(
+            val containerColor by animateColorAsState(
                 if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerHigh,
                 label = "ButtonColor"
             )
-            val contentColor by androidx.compose.animation.animateColorAsState(
+            val contentColor by animateColorAsState(
                 if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
                 label = "ContentColor"
             )
@@ -1513,7 +1612,7 @@ fun ExpressiveButtonGroup(
                 contentAlignment = Alignment.Center
             ) {
                  Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center) {
-                     androidx.compose.animation.AnimatedVisibility(visible = isSelected) {
+                     AnimatedVisibility(visible = isSelected) {
                          Icon(
                              Icons.Rounded.Check, 
                              contentDescription = null, 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaylistViewModel.kt
@@ -430,18 +430,28 @@ class PlaylistViewModel @Inject constructor(
     ): String? {
         return withContext(Dispatchers.IO) {
             try {
-                // Load original bitmap
+                // Robust bitmap loading (Content URI or Local File)
                 val originalBitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri)) { decoder, _, _ ->
-                        // Optimization: Mutable to support software rendering if needed
+                    val source = when {
+                        uri.scheme == "content" -> ImageDecoder.createSource(context.contentResolver, uri)
+                        uri.scheme == "file" || uri.path?.startsWith("/") == true -> {
+                            ImageDecoder.createSource(File(uri.path ?: ""))
+                        }
+                        else -> ImageDecoder.createSource(context.contentResolver, uri)
+                    }
+                    ImageDecoder.decodeBitmap(source) { decoder, _, _ ->
                         decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
-                        // Use HARWARE if possible but need to copy for Canvas?
-                        // Software is safer for manual Canvas drawing.
                     }
                 } else {
                     @Suppress("DEPRECATION")
-                    MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
+                    if (uri.scheme == "content") {
+                        MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
+                    } else {
+                        android.graphics.BitmapFactory.decodeFile(uri.path)
+                    }
                 }
+
+                if (originalBitmap == null) return@withContext null
 
                 // Target dimensions (Square)
                 val targetSize = 1024
@@ -583,50 +593,36 @@ class PlaylistViewModel @Inject constructor(
         viewModelScope.launch {
             var savedCoverPath: String? = currentPlaylist.coverImageUri
 
-            // If a new URI is provided and it's different from the existing one (and not null)
-            // Or if we need to re-save because crop params changed?
-            // For simplicity, if coverImageUri is passed and it's a content URI, we save it.
-            // If it's the same string as savedCoverPath, we assume it's unchanged unless we want to force re-crop.
-            // The UI will pass the Uri string. If it's a local file path, it's likely already saved.
-            // But if the user selected a new image, it will be a content content:// uri.
+            val isNewImage = coverImageUri != null && coverImageUri != currentPlaylist.coverImageUri
+            val isAdjusted = cropScale != 1f || cropPanX != 0f || cropPanY != 0f
 
-            if (coverImageUri != null && coverImageUri != currentPlaylist.coverImageUri) {
-                // Check if it is a content URI or a file path that is NOT the existing saved path
-                if (coverImageUri.startsWith("content://") || (coverImageUri.startsWith("/") && coverImageUri != currentPlaylist.coverImageUri)) {
-                    val imageId = UUID.randomUUID().toString()
-                    val newPath = saveCoverImageToInternalStorage(
-                        Uri.parse(coverImageUri),
-                        imageId,
-                        cropScale,
-                        cropPanX,
-                        cropPanY
-                    )
-                    if (newPath != null) {
-                        savedCoverPath = newPath
+            if (coverImageUri != null && (isNewImage || isAdjusted)) {
+                // Save new image or re-crop existing one
+                val imageId = UUID.randomUUID().toString()
+                val newPath = saveCoverImageToInternalStorage(
+                    Uri.parse(coverImageUri),
+                    imageId,
+                    cropScale,
+                    cropPanX,
+                    cropPanY
+                )
+                if (newPath != null) {
+                    // Optional: Delete old file if it was a local file managed by us
+                    currentPlaylist.coverImageUri?.let { oldPath ->
+                        if (oldPath.contains("playlist_cover_")) {
+                            try { File(oldPath).delete() } catch (e: Exception) {}
+                        }
                     }
+                    savedCoverPath = newPath
                 }
             } else if (coverImageUri == null) {
-                // If passed null, it might mean remove cover? Or just no change?
-                // For this implementation let's assume if the user cleared it, the UI passes null.
-                // But we need to distinguish "no change" vs "remove".
-                // In CreatePlaylist we have "selectedImageUri".
-                // Let's assume the UI sends the desired final state.
-                // NOTE: If the user didn't change the image, the UI might send the existing coverImageUri (which is a file path).
-                // Or if they removed it, they send null.
-
-                // However, we also have crop parameters. If image is unchanged but crop changed, we should re-save (re-crop)
-                // if we have the original source. But we don't have the original source for the existing cover (we only have the cropped result).
-                // So, we can only re-crop if we have a source URI.
-                // This limitation implies: We can only update crop if we pick an image.
-                // So if coverImageUri is the existing path, we ignore crop params.
-                savedCoverPath = null // If explicit null passed, we remove it.
-            }
-            // Logic correction: 
-            // If the UI passes the EXISTING file path, implies NO CHANGE to image.
-            // If the UI passes a NEW content URI, implies NEW IMAGE (and we use crop params).
-            // If the UI passes NULL, implies REMOVE IMAGE.
-            if (coverImageUri == currentPlaylist.coverImageUri) {
-                savedCoverPath = currentPlaylist.coverImageUri
+                // Explicitly removed
+                currentPlaylist.coverImageUri?.let { oldPath ->
+                    if (oldPath.contains("playlist_cover_")) {
+                        try { File(oldPath).delete() } catch (e: Exception) {}
+                    }
+                }
+                savedCoverPath = null
             }
 
 

--- a/app/src/main/res/values/strings_presentation_batch_f.xml
+++ b/app/src/main/res/values/strings_presentation_batch_f.xml
@@ -52,8 +52,13 @@
     <string name="presentation_batch_f_auto_generated_collage">Auto-generated collage</string>
     <string name="presentation_batch_f_cd_add_photo">Add Photo</string>
     <string name="presentation_batch_f_pick_image">Pick Image</string>
+    <string name="presentation_batch_f_change">Change</string>
+    <string name="presentation_batch_f_remove">Remove</string>
     <string name="presentation_batch_f_playlist_name_label">Playlist Name</string>
     <string name="presentation_batch_f_playlist_name_placeholder">My awesome mix</string>
+    <string name="presentation_batch_f_edit_cover_title">Edit Cover</string>
+    <string name="presentation_batch_f_adjust_cover_title">Adjust your cover art</string>
+    <string name="presentation_batch_f_adjust_cover_hint">Use pinch and drag gestures to find the perfect framing</string>
     <string name="presentation_batch_f_creation_mode_manual">Manual</string>
     <string name="presentation_batch_f_creation_mode_smart">Smart</string>
     <string name="presentation_batch_f_generate_with_ai">Generate with AI</string>


### PR DESCRIPTION
- **Improved Cover Workflow:** Integrated image cropping and panning directly into the selection process, automatically opening the adjustment view when a cover is added or changed.

- **Enhanced Adjustment UI:** Added guided instructions, a dedicated 'Adjust your cover art' title, and a clear 'Done' action button for better usability.

- **Better Cover Actions:** Added a high-visibility red 'Remove' button and improved the 'Change' workflow in the Image tab.

- **Reliable Saving:** Fixed logic in PlaylistViewModel to ensure framing adjustments are correctly processed and saved for both new and existing playlists.

- **Refined Navigation:** Improved back-button handling to return to the edit form from the adjustment screen instead of closing the dialog.