### PR TITLE
Fix AI provider errors and media service startup

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/AiPlaylistGenerator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/AiPlaylistGenerator.kt
@@ -123,12 +123,14 @@ class AiPlaylistGenerator @Inject constructor(
                 "Airplane mode is active. Please turn it off to use AI."
 
             combinedMessages.contains("401", ignoreCase = true) ||
+            combinedMessages.contains("unauthorized", ignoreCase = true) ->
+                "Permission Denied. Your API key might be invalid or restricted."
+
             combinedMessages.contains("403", ignoreCase = true) ||
             combinedMessages.contains("permission", ignoreCase = true) ||
             combinedMessages.contains("denied", ignoreCase = true) ||
-            combinedMessages.contains("forbidden", ignoreCase = true) ||
-            combinedMessages.contains("unauthorized", ignoreCase = true) ->
-                "Permission Denied. Your API key might be invalid or restricted."
+            combinedMessages.contains("forbidden", ignoreCase = true) ->
+                "Permission denied by the AI provider. Check that this API key has access to the selected model and that the provider API is enabled."
             
             combinedMessages.contains("safety", ignoreCase = true) ||
             combinedMessages.contains("blocked", ignoreCase = true) ->

--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/GeminiModelService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/GeminiModelService.kt
@@ -86,9 +86,8 @@ class GeminiModelService @Inject constructor(
                 val fullName = match.groupValues[1]
                 val modelName = fullName.removePrefix("models/")
 
-                // Filter for generative models (gemini, gemini-pro, gemini-flash, etc.)
-                if (modelName.startsWith("gemini", ignoreCase = true) &&
-                    !modelName.contains("embedding", ignoreCase = true)) {
+                // Keep the UI focused on the cheapest/fastest Gemini family: Flash only.
+                if (isSupportedFlashModel(modelName)) {
                     models.add(GeminiModel(
                         name = modelName,
                         displayName = formatDisplayName(modelName)
@@ -97,7 +96,7 @@ class GeminiModelService @Inject constructor(
             }
 
             return if (models.isNotEmpty()) {
-                models.sortedBy { it.displayName.lowercase() }
+                sortFlashModels(models)
             } else {
                 getDefaultModels()
             }
@@ -147,6 +146,22 @@ class GeminiModelService @Inject constructor(
         }
     }
 
+    private fun isSupportedFlashModel(modelName: String): Boolean {
+        return modelName.startsWith("gemini", ignoreCase = true) &&
+            modelName.contains("flash", ignoreCase = true) &&
+            !modelName.contains("embedding", ignoreCase = true) &&
+            !modelName.contains("image", ignoreCase = true)
+    }
+
+    private fun sortFlashModels(models: List<GeminiModel>): List<GeminiModel> {
+        val preferred = getDefaultModels().map { it.name }
+        return models.distinctBy { it.name }.sortedWith(
+            compareBy<GeminiModel> { model ->
+                preferred.indexOf(model.name).takeIf { it >= 0 } ?: Int.MAX_VALUE
+            }.thenBy { it.displayName.lowercase() }
+        )
+    }
+
     private fun formatDisplayName(modelName: String): String {
         // Convert "gemini-2.5-flash" to "Gemini 2.5 Flash"
         return modelName
@@ -157,22 +172,13 @@ class GeminiModelService @Inject constructor(
     }
 
     private fun getDefaultModels(): List<GeminiModel> {
-        // Full curated list derived from latest supported JSON spec
         return listOf(
-            GeminiModel("gemini-3-flash-preview", "Gemini 3.0 Flash (Free Default)"),
-            GeminiModel("gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview"),
-            GeminiModel("gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash Lite"),
-            GeminiModel("gemini-3-pro-preview", "Gemini 3.0 Pro"),
-            GeminiModel("gemini-flash-latest", "Gemini Flash Latest"),
-            GeminiModel("gemini-flash-lite-latest", "Gemini Flash-Lite Latest"),
-            GeminiModel("gemini-pro-latest", "Gemini Pro Latest"),
+            GeminiModel("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite (Cheapest/Fastest Default)"),
             GeminiModel("gemini-2.5-flash", "Gemini 2.5 Flash"),
-            GeminiModel("gemini-2.5-pro", "Gemini 2.5 Pro"),
-            GeminiModel("gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
-            GeminiModel("gemini-2.0-flash", "Gemini 2.0 Flash"),
-            GeminiModel("gemini-2.0-flash-lite", "Gemini 2.0 Flash-Lite"),
-            GeminiModel("gemma-3-12b-it", "Gemma 3 12B"),
-            GeminiModel("gemma-3-27b-it", "Gemma 3 27B")
+            GeminiModel("gemini-flash-lite-latest", "Gemini Flash Lite Latest"),
+            GeminiModel("gemini-flash-latest", "Gemini Flash Latest"),
+            GeminiModel("gemini-2.0-flash-lite", "Gemini 2.0 Flash Lite"),
+            GeminiModel("gemini-2.0-flash", "Gemini 2.0 Flash")
         )
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/provider/AiProviderSupport.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/provider/AiProviderSupport.kt
@@ -46,11 +46,13 @@ internal class AiProviderException(
     fun isApiKeyIssue(): Boolean {
         val text = buildSearchText()
         return statusCode == 401 ||
-            statusCode == 403 ||
-            text.contains("api key") ||
+            text.contains("api_key_invalid") ||
+            text.contains("api key not valid") ||
+            text.contains("invalid api key") ||
             text.contains("invalid key") ||
-            text.contains("unauthorized") ||
-            text.contains("forbidden")
+            text.contains("incorrect api key") ||
+            text.contains("authentication failed") ||
+            text.contains("unauthorized")
     }
 
     fun shouldCooldown(): Boolean {

--- a/app/src/main/java/com/theveloper/pixelplay/data/ai/provider/GeminiAiClient.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/ai/provider/GeminiAiClient.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.withContext
 class GeminiAiClient(private val apiKey: String) : AiClient {
     
     companion object {
-        // Updated: Using the free tier model exactly as named in the spec
-        private const val DEFAULT_GEMINI_MODEL = "gemini-3-flash-preview"
+        // Cheapest/fastest Gemini family default. Keep Gemini choices Flash-only.
+        private const val DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"
     }
     
     private fun createModel(modelName: String, systemPrompt: String, temp: Float = 0.7f): GenerativeModel {
@@ -123,27 +123,40 @@ class GeminiAiClient(private val apiKey: String) : AiClient {
                 val fullName = match.groupValues[1]
                 val modelName = fullName.removePrefix("models/")
                 
-                if (modelName.startsWith("gemini", ignoreCase = true) &&
-                    !modelName.contains("embedding", ignoreCase = true)) {
+                if (isSupportedFlashModel(modelName)) {
                     models.add(modelName)
                 }
             }
             
-            return if (models.isNotEmpty()) models else getDefaultModels()
+            return if (models.isNotEmpty()) sortFlashModels(models) else getDefaultModels()
         } catch (e: Exception) {
             return getDefaultModels()
         }
     }
     
+    private fun isSupportedFlashModel(modelName: String): Boolean {
+        return modelName.startsWith("gemini", ignoreCase = true) &&
+            modelName.contains("flash", ignoreCase = true) &&
+            !modelName.contains("embedding", ignoreCase = true) &&
+            !modelName.contains("image", ignoreCase = true)
+    }
+
+    private fun sortFlashModels(models: List<String>): List<String> {
+        val preferred = getDefaultModels()
+        return models.distinct().sortedWith(
+            compareBy<String> { model ->
+                preferred.indexOf(model).takeIf { it >= 0 } ?: Int.MAX_VALUE
+            }.thenBy { it.lowercase() }
+        )
+    }
+
     private fun getDefaultModels(): List<String> {
-        // Updated fallback list: prioritize free tiers & latest 3.x models
         return listOf(
-            "gemini-3-flash-preview",
-            "gemini-3.1-pro-preview",
-            "gemini-3.1-flash-lite-preview",
-            "gemini-flash-latest",
+            "gemini-2.5-flash-lite",
             "gemini-2.5-flash",
-            "gemini-2.5-pro",
+            "gemini-flash-lite-latest",
+            "gemini-flash-latest",
+            "gemini-2.0-flash-lite",
             "gemini-2.0-flash"
         )
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/AiPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/AiPreferencesRepository.kt
@@ -43,7 +43,7 @@ class AiPreferencesRepository @Inject constructor(
 
     // Generic accessors for AiOrchestrator
     fun getApiKey(provider: AiProvider): Flow<String> =
-        dataStore.data.map { preferences -> preferences[Keys.getApiKey(provider)] ?: "" }
+        dataStore.data.map { preferences -> preferences[Keys.getApiKey(provider)]?.trim() ?: "" }
 
     fun getModel(provider: AiProvider): Flow<String> =
         dataStore.data.map { preferences -> preferences[Keys.getModel(provider)] ?: "" }
@@ -54,7 +54,7 @@ class AiPreferencesRepository @Inject constructor(
         }
 
     suspend fun setApiKey(provider: AiProvider, apiKey: String) {
-        dataStore.edit { preferences -> preferences[Keys.getApiKey(provider)] = apiKey }
+        dataStore.edit { preferences -> preferences[Keys.getApiKey(provider)] = apiKey.trim() }
     }
 
     suspend fun setModel(provider: AiProvider, model: String) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -382,12 +382,13 @@ class MusicService : MediaLibraryService() {
             }
         }
 
-        // A MEDIA_BUTTON broadcast starts the 5-second foreground-service timeout
-        // BEFORE MusicService is created. Promote to foreground before super.onCreate()
-        // — Hilt injection plus MediaLibraryService.onCreate() can otherwise consume
-        // most of the budget on a slow cold-start. The temporary notification only uses
-        // Context/resources, no injected fields, so it is safe before super.onCreate().
-        temporaryForegroundStartedInOnCreate = consumePendingMediaButtonForegroundStart()
+        // A media-button startForegroundService() can reach MusicService directly (not always
+        // through PixelPlayMediaButtonReceiver), so the pending counter is only a hint. Promote
+        // immediately on cold start before super.onCreate(): Hilt injection and MediaLibraryService
+        // startup can otherwise consume Android's 5-second FGS deadline before onStartCommand()
+        // receives the media-button intent.
+        temporaryForegroundStartedInOnCreate =
+            consumePendingMediaButtonForegroundStart() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         if (temporaryForegroundStartedInOnCreate) {
             startTemporaryForegroundForCommand()
         }
@@ -834,6 +835,20 @@ class MusicService : MediaLibraryService() {
             it.setSmallIcon(R.drawable.monochrome_player)
         }
         setMediaNotificationProvider(localOnlyProvider)
+        if (temporaryForegroundStartedInOnCreate) {
+            serviceScope.launch {
+                delay(2_000L)
+                val player = mediaSession?.player
+                val isActivelyPlaying = player?.let {
+                    it.playWhenReady &&
+                        it.playbackState != Player.STATE_IDLE &&
+                        it.playbackState != Player.STATE_ENDED
+                } == true
+                if (!isActivelyPlaying) {
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                }
+            }
+        }
         serviceScope.launch {
             restorePlaybackQueueSnapshotIfNeeded()
             mediaSession?.let { refreshMediaSessionUi(it) }
@@ -1102,7 +1117,7 @@ class MusicService : MediaLibraryService() {
             }
         }
         val startCommandResult = super.onStartCommand(intent, flags, startId)
-        if (needsTemporaryForeground) {
+        if (needsTemporaryForeground || startedTemporaryForegroundInOnCreate) {
             val player = mediaSession?.player
             val isActivelyPlaying = player?.let {
                 it.playWhenReady &&
@@ -1111,7 +1126,9 @@ class MusicService : MediaLibraryService() {
             } == true
             if (!isActivelyPlaying) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
-                stopSelfResult(startId)
+                if (needsTemporaryForeground) {
+                    stopSelfResult(startId)
+                }
             }
         }
         return startCommandResult

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/AiStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/AiStateHolder.kt
@@ -353,7 +353,11 @@ class AiStateHolder @Inject constructor(
         val detail = extractAiErrorDetail(error)
 
         return when {
-            providerFailure?.isApiKeyIssue() == true || detail.contains("api key", ignoreCase = true) ->
+            providerFailure?.isApiKeyIssue() == true ||
+                detail.contains("api key not valid", ignoreCase = true) ||
+                detail.contains("invalid api key", ignoreCase = true) ||
+                detail.contains("incorrect api key", ignoreCase = true) ||
+                detail.contains("invalid key", ignoreCase = true) ->
                 context.getString(R.string.ai_error_api_key)
 
             providerFailure?.isBillingIssue() == true ->
@@ -385,10 +389,12 @@ class AiStateHolder @Inject constructor(
             detail.contains("permission", ignoreCase = true) ||
             detail.contains("denied", ignoreCase = true) ||
             detail.contains("forbidden", ignoreCase = true) ||
-            detail.contains("unauthorized", ignoreCase = true) ||
-            detail.contains("401", ignoreCase = true) ||
             detail.contains("403", ignoreCase = true) ->
-                "Permission Denied. Your API key might be invalid, or it lacks the necessary permissions for this model."
+                "Permission denied by the AI provider. Check that this API key has access to the selected model and that the provider API is enabled."
+
+            detail.contains("unauthorized", ignoreCase = true) ||
+            detail.contains("401", ignoreCase = true) ->
+                context.getString(R.string.ai_error_api_key)
 
             // Rate limiting
             detail.contains("rate limit", ignoreCase = true) ||

--- a/app/src/test/java/com/theveloper/pixelplay/data/ai/provider/AiProviderSupportTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/ai/provider/AiProviderSupportTest.kt
@@ -29,10 +29,10 @@ class AiProviderSupportTest {
         val recovered = AiProviderSupport.selectRecoveryModel(
             currentModel = "removed-model",
             defaultModel = "missing-default",
-            availableModels = listOf("gemini-2.5-flash", "gemini-2.5-pro")
+            availableModels = listOf("gemini-2.5-flash-lite", "gemini-2.5-flash")
         )
 
-        assertThat(recovered).isEqualTo("gemini-2.5-flash")
+        assertThat(recovered).isEqualTo("gemini-2.5-flash-lite")
     }
 
     @Test
@@ -54,5 +54,26 @@ class AiProviderSupportTest {
 
         assertThat(notFound.isModelUnavailable()).isTrue()
         assertThat(billing.isBillingIssue()).isTrue()
+    }
+
+    @Test
+    fun `provider exception distinguishes invalid key from provider permission denied`() {
+        val invalidKey = AiProviderSupport.createException(
+            providerName = "Gemini",
+            statusCode = 400,
+            transportMessage = "Bad Request",
+            responseBody = """{"error":{"message":"API key not valid. Please pass a valid API key."}}""",
+            requestedModel = "gemini-2.5-flash"
+        )
+        val permissionDenied = AiProviderSupport.createException(
+            providerName = "Gemini",
+            statusCode = 403,
+            transportMessage = "Forbidden",
+            responseBody = """{"error":{"message":"Generative Language API has not been used in this project."}}""",
+            requestedModel = "gemini-2.5-flash"
+        )
+
+        assertThat(invalidKey.isApiKeyIssue()).isTrue()
+        assertThat(permissionDenied.isApiKeyIssue()).isFalse()
     }
 }


### PR DESCRIPTION
## Summary
- trim AI API keys and improve provider error classification so valid keys are not reported as invalid for model/API access failures
- keep Gemini choices focused on cheap/fast Flash models, defaulting to `gemini-2.5-flash-lite`
- promote `MusicService` to a temporary foreground service immediately on cold start to avoid media-button foreground-service timeout crashes

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :app:testDebugUnitTest --tests "com.theveloper.pixelplay.data.ai.provider.AiProviderSupportTest"`

Closes #2100
Closes #2099