### PR TITLE
feat: add Google Drive support and improve player lifecycle management

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -266,28 +266,20 @@ class MusicService : MediaLibraryService() {
     }
 
     private val playerSwapListener: (Player) -> Unit = { newPlayer ->
-        serviceScope.launch(Dispatchers.Main) {
-            publishMediaSessionPlayer(newPlayer, "Swapped MediaSession player to new instance.")
-            prepareReplayGainForTransitionPlayer(newPlayer)
-        }
+        publishMediaSessionPlayer(newPlayer, "Swapped MediaSession player to new instance.")
+        prepareReplayGainForTransitionPlayer(newPlayer)
     }
 
     private val transitionDisplayPlayerListener: (Player) -> Unit = { displayPlayer ->
-        serviceScope.launch(Dispatchers.Main) {
-            publishMediaSessionPlayer(
-                displayPlayer,
-                "Published incoming crossfade player to MediaSession."
-            )
-            prepareReplayGainForTransitionPlayer(displayPlayer)
-        }
+        publishMediaSessionPlayer(
+            displayPlayer,
+            "Published incoming crossfade player to MediaSession."
+        )
+        prepareReplayGainForTransitionPlayer(displayPlayer)
     }
 
     private val transitionFinishedListener: () -> Unit = {
-        // Dispatch to Main so it runs after any pending playerSwapListener coroutine
-        // has completed — otherwise onTransitionFinished() may see stale state.
-        serviceScope.launch(Dispatchers.Main) {
-            onTransitionFinished()
-        }
+        onTransitionFinished()
     }
 
     private fun publishMediaSessionPlayer(player: Player, logMessage: String) {
@@ -404,6 +396,9 @@ class MusicService : MediaLibraryService() {
         engine.masterPlayer.addListener(playerListener)
 
         // Handle player swaps (crossfade) to keep MediaSession in sync
+        engine.setOnPlayerAboutToBeReleasedListener { oldPlayer ->
+            oldPlayer.removeListener(playerListener)
+        }
         engine.addPlayerSwapListener(playerSwapListener)
         engine.addTransitionDisplayPlayerListener(transitionDisplayPlayerListener)
         engine.addTransitionFinishedListener(transitionFinishedListener)
@@ -1704,6 +1699,7 @@ class MusicService : MediaLibraryService() {
         engine.removePlayerSwapListener(playerSwapListener)
         engine.removeTransitionDisplayPlayerListener(transitionDisplayPlayerListener)
         engine.removeTransitionFinishedListener(transitionFinishedListener)
+        engine.setOnPlayerAboutToBeReleasedListener {}
         mediaSession?.player?.removeListener(playerListener)
         engine.masterPlayer.removeListener(playerListener)
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -129,6 +129,12 @@ class DualPlayerEngine @Inject constructor(
     private val onPlayerSwappedListeners = mutableListOf<(Player) -> Unit>()
     private val onTransitionDisplayPlayerListeners = mutableListOf<(Player) -> Unit>()
     private val onTransitionFinishedListeners = mutableListOf<() -> Unit>()
+
+    private var onPlayerAboutToBeReleasedListener: ((Player) -> Unit)? = null
+
+    fun setOnPlayerAboutToBeReleasedListener(listener: (Player) -> Unit) {
+        onPlayerAboutToBeReleasedListener = listener
+    }
     
     // Active Audio Session ID Flow
     private val _activeAudioSessionId = MutableStateFlow(0)
@@ -386,6 +392,7 @@ class DualPlayerEngine @Inject constructor(
         }
 
         if (::playerA.isInitialized) {
+            onPlayerAboutToBeReleasedListener?.invoke(playerA)
             try { playerA.release() } catch (e: Exception) { /* Ignore */ }
         }
         playerB?.let { try { it.release() } catch (e: Exception) { /* Ignore */ } }
@@ -459,10 +466,7 @@ class DualPlayerEngine @Inject constructor(
             if (!audioOffloadEnabled || transitionRunning || player !== playerA) return@launch
             if (currentMediaId != watchedMediaId) return@launch
             if (player.playbackState != Player.STATE_BUFFERING || player.isPlaying || !player.playWhenReady) return@launch
-            if (player.currentPosition > 1_000L || player.bufferedPosition <= 0L) return@launch
-
-            val timeSincePlayRequestMs = (SystemClock.elapsedRealtime() - lastPlayWhenReadyAtMs).coerceAtLeast(0L)
-            if (timeSincePlayRequestMs < AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS) return@launch
+            if (player.currentPosition > 1_000L) return@launch
 
             disableAudioOffloadForSession(
                 reason = "Local media stayed buffering for ${AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS}ms"
@@ -546,6 +550,7 @@ class DualPlayerEngine @Inject constructor(
 
         playerA.removeListener(masterPlayerListener)
         playerA.removeAnalyticsListener(masterPlayerListener)
+        onPlayerAboutToBeReleasedListener?.invoke(playerA)
         playerA.release()
         playerB?.release()
         playerB = null
@@ -1118,6 +1123,7 @@ class DualPlayerEngine @Inject constructor(
         if (::playerA.isInitialized) {
             playerA.removeListener(masterPlayerListener)
             playerA.removeAnalyticsListener(masterPlayerListener)
+            onPlayerAboutToBeReleasedListener?.invoke(playerA)
             playerA.release()
         }
         playerB?.release()

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -3565,7 +3565,8 @@ class PlayerViewModel @Inject constructor(
             scheme != "netease" &&
             scheme != "qqmusic" &&
             scheme != "navidrome" &&
-            scheme != "jellyfin"
+            scheme != "jellyfin" &&
+            scheme != "gdrive"
         ) {
             return mediaItem
         }


### PR DESCRIPTION
Adds `gdrive` to the list of recognized URI schemes and introduces a mechanism to safely detach listeners before player instances are released during transitions.

- Add `gdrive` URI scheme support in `PlayerViewModel`.
- Introduce `onPlayerAboutToBeReleasedListener` in `DualPlayerEngine` to notify when a player instance is about to be released.
- Update `MusicService` to remove `playerListener` from old players using the new release callback, preventing potential leaks during crossfades.
- Remove redundant coroutine dispatches in `MusicService` for player transition events to ensure synchronous state updates.
- Simplify audio offload fallback logic in `DualPlayerEngine` by removing unnecessary timing and buffering checks.