### PR TITLE
feat: improve MediaStore URI resolution for file deletions

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -4038,16 +4038,23 @@ class PlayerViewModel @Inject constructor(
 
             // On Android 11+, use system batch delete dialog
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                val uris = deletableSongs.mapNotNull { song ->
-                    song.id.toLongOrNull()?.let { id ->
-                        com.theveloper.pixelplay.utils.MediaStorePermissionHelper.getMediaStoreUri(id)
+                val deleteRequests = withContext(Dispatchers.IO) {
+                    deletableSongs.mapNotNull { song ->
+                        com.theveloper.pixelplay.utils.MediaStorePermissionHelper
+                            .resolveDeleteRequestUri(
+                                context = activity,
+                                songId = song.id.toLongOrNull(),
+                                contentUriString = song.contentUriString,
+                                filePath = song.path,
+                            )?.let { uri -> song to uri }
                     }
                 }
-                if (uris.isNotEmpty()) {
+                if (deleteRequests.size == deletableSongs.size) {
+                    val uris = deleteRequests.map { it.second }.distinctBy { it.toString() }
                     val intentSender = com.theveloper.pixelplay.utils.MediaStorePermissionHelper
                         .createDeleteRequestIntentSender(activity, uris)
                     if (intentSender != null) {
-                        pendingBatchDeleteSongs = deletableSongs
+                        pendingBatchDeleteSongs = deleteRequests.map { it.first }
                         pendingBatchDeleteSkippedCount = skippedCount
                         pendingBatchDeleteOnComplete = onComplete
                         _deletePermissionRequest.emit(intentSender)
@@ -4153,11 +4160,18 @@ class PlayerViewModel @Inject constructor(
             // On Android 11+, use the system delete confirmation dialog via MediaStore.createDeleteRequest()
             // which both confirms AND handles deletion in one step (no MANAGE_EXTERNAL_STORAGE needed).
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                val songLongId = song.id.toLongOrNull()
-                val intentSender = if (songLongId != null && songLongId > 0) {
+                val intentSender = withContext(Dispatchers.IO) {
                     com.theveloper.pixelplay.utils.MediaStorePermissionHelper
-                        .createDeleteRequestForSong(activity, songLongId)
-                } else null
+                        .resolveDeleteRequestUri(
+                            context = activity,
+                            songId = song.id.toLongOrNull(),
+                            contentUriString = song.contentUriString,
+                            filePath = song.path,
+                        )?.let { uri ->
+                            com.theveloper.pixelplay.utils.MediaStorePermissionHelper
+                                .createDeleteRequestIntentSender(activity, listOf(uri))
+                        }
+                }
                 if (intentSender != null) {
                     pendingDeleteSong = song
                     pendingDeleteCallback = onResult

--- a/app/src/main/java/com/theveloper/pixelplay/utils/FileDeletionUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/FileDeletionUtils.kt
@@ -1,10 +1,6 @@
 package com.theveloper.pixelplay.utils
-import android.content.ContentUris
 import android.content.Context
-import android.net.Uri
 import android.os.Build
-import android.os.Environment
-import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -73,7 +69,7 @@ object FileDeletionUtils {
     @RequiresApi(Build.VERSION_CODES.R)
     fun getDeleteRequestIntentSender(context: Context, filePath: String): android.content.IntentSender? {
         val uri = MediaStorePermissionHelper.getMediaStoreUri(context, filePath) ?: return null
-        return MediaStore.createDeleteRequest(context.contentResolver, listOf(uri)).intentSender
+        return MediaStorePermissionHelper.createDeleteRequestIntentSender(context, listOf(uri))
     }
 
     /**

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
@@ -1,11 +1,11 @@
 package com.theveloper.pixelplay.utils
 
-import android.app.Activity
 import android.content.ContentUris
 import android.content.Context
 import android.content.IntentSender
 import android.net.Uri
 import android.os.Build
+import android.provider.BaseColumns
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi
  * raw file-path operations are allowed (thanks to the FUSE virtual filesystem).
  */
 object MediaStorePermissionHelper {
+    private const val MEDIASTORE_AUTHORITY = "media"
 
     /**
      * Returns the MediaStore content URI for a given audio song ID.
@@ -24,7 +25,55 @@ object MediaStorePermissionHelper {
      */
     fun getMediaStoreUri(songId: Long): Uri? {
         if (songId <= 0) return null
-        return ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL, songId)
+        } else {
+            ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId)
+        }
+    }
+
+    fun isMediaStoreItemUriString(contentUriString: String): Boolean {
+        val normalized = contentUriString.trim().lowercase()
+        if (!normalized.startsWith("content://$MEDIASTORE_AUTHORITY/")) return false
+        return normalized.substringAfterLast('/').toLongOrNull()?.let { it > 0 } == true
+    }
+
+    fun canUseSongIdForMediaStoreRequest(contentUriString: String): Boolean {
+        val normalized = contentUriString.trim().lowercase()
+        return normalized.isBlank() ||
+            normalized.startsWith("/") ||
+            normalized.startsWith("file://") ||
+            isMediaStoreItemUriString(normalized)
+    }
+
+    fun resolveDeleteRequestUri(
+        context: Context,
+        songId: Long?,
+        contentUriString: String,
+        filePath: String
+    ): Uri? {
+        val candidates = buildList {
+            parseMediaStoreItemUri(contentUriString)?.let(::add)
+            if (filePath.isNotBlank()) {
+                getMediaStoreUri(context, filePath)?.let(::add)
+            }
+            if (songId != null && canUseSongIdForMediaStoreRequest(contentUriString)) {
+                getMediaStoreUri(songId)?.let(::add)
+            }
+        }.distinctBy { it.toString() }
+
+        return candidates.firstOrNull { uri ->
+            runCatching {
+                context.contentResolver.query(uri, arrayOf(BaseColumns._ID), null, null, null)?.use { cursor ->
+                    cursor.moveToFirst()
+                } == true
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun parseMediaStoreItemUri(contentUriString: String): Uri? {
+        if (!isMediaStoreItemUriString(contentUriString)) return null
+        return runCatching { Uri.parse(contentUriString.trim()) }.getOrNull()
     }
 
     /**
@@ -74,7 +123,13 @@ object MediaStorePermissionHelper {
         uris: Collection<Uri>
     ): IntentSender? {
         if (uris.isEmpty()) return null
-        return MediaStore.createDeleteRequest(context.contentResolver, uris).intentSender
+        return try {
+            MediaStore.createDeleteRequest(context.contentResolver, uris).intentSender
+        } catch (_: IllegalArgumentException) {
+            null
+        } catch (_: SecurityException) {
+            null
+        }
     }
 
     /**

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelperTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelperTest.kt
@@ -1,0 +1,50 @@
+package com.theveloper.pixelplay.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MediaStorePermissionHelperTest {
+
+    @Test
+    fun isMediaStoreItemUriString_acceptsSpecificMediaStoreItems() {
+        assertThat(
+            MediaStorePermissionHelper.isMediaStoreItemUriString(
+                "content://media/external/audio/media/9317"
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun isMediaStoreItemUriString_rejectsCollectionUris() {
+        assertThat(
+            MediaStorePermissionHelper.isMediaStoreItemUriString(
+                "content://media/external/audio/media"
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun canUseSongIdForMediaStoreRequest_rejectsCloudProviderUris() {
+        assertThat(
+            MediaStorePermissionHelper.canUseSongIdForMediaStoreRequest("netease://9317")
+        ).isFalse()
+        assertThat(
+            MediaStorePermissionHelper.canUseSongIdForMediaStoreRequest("telegram://123/456")
+        ).isFalse()
+    }
+
+    @Test
+    fun canUseSongIdForMediaStoreRequest_acceptsLocalFallbacks() {
+        assertThat(MediaStorePermissionHelper.canUseSongIdForMediaStoreRequest("")).isTrue()
+        assertThat(
+            MediaStorePermissionHelper.canUseSongIdForMediaStoreRequest(
+                "/storage/emulated/0/Music/song.mp3"
+            )
+        ).isTrue()
+        assertThat(
+            MediaStorePermissionHelper.canUseSongIdForMediaStoreRequest(
+                "content://media/external/audio/media/42"
+            )
+        ).isTrue()
+    }
+}


### PR DESCRIPTION
Enhances the reliability of `MediaStore.createDeleteRequest` on Android 11+ by implementing a robust URI resolution strategy. Instead of relying solely on song IDs, the system now validates candidate URIs against the `ContentResolver` using IDs, file paths, and existing URI strings to ensure they are valid for system deletion prompts.

- Added `MediaStorePermissionHelper.resolveDeleteRequestUri` to verify URI existence via `contentResolver.query`.
- Updated `PlayerViewModel` to perform URI resolution on `Dispatchers.IO` before triggering deletion intents.
- Refactored `getMediaStoreUri` to use `MediaStore.Audio.Media.getContentUri` with `VOLUME_EXTERNAL` for Android R+.
- Added error handling for `IllegalArgumentException` and `SecurityException` when creating delete requests.
- Introduced `MediaStorePermissionHelperTest` to validate URI string parsing and fallback logic.
- Cleaned up unused imports and centralized intent sender creation in `FileDeletionUtils`.