### PR TITLE
perf: optimize battery usage via audio offload and adaptive UI polling

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -198,7 +198,7 @@ class DualPlayerEngine @Inject constructor(
     }
 
     // Listener to attach to the active master player (playerA)
-    private val masterPlayerListener = object : Player.Listener, AnalyticsListener {
+    private val masterPlayerListener = object : Player.Listener, AnalyticsListener, ExoPlayer.AudioOffloadListener {
         override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
             if (playWhenReady) {
                 lastPlayWhenReadyAtMs = SystemClock.elapsedRealtime()
@@ -216,6 +216,46 @@ class DualPlayerEngine @Inject constructor(
             if (isPlaying) {
                 lastPlayingAtMs = SystemClock.elapsedRealtime()
                 cancelAudioOffloadFallback()
+            }
+        }
+
+        /**
+         * Fires when ExoPlayer believes the audio HAL is producing output via
+         * offload and the renderer thread can stop polling — at that point the
+         * CPU genuinely doesn't need a wake lock to keep playing audio. When
+         * [sleepingForOffload] flips back to false (track change, format
+         * mismatch, fallback path), restore [C.WAKE_MODE_LOCAL] so the
+         * non-offload PCM path keeps the CPU awake correctly.
+         *
+         * Battery: this is what actually lets the SoC race-to-sleep during
+         * music playback. The static [C.WAKE_MODE_LOCAL] we set at build time
+         * is the safe default; this callback is the dynamic optimisation.
+         */
+        @Suppress("UnsafeOptInUsageError")
+        override fun onSleepingForOffloadChanged(sleepingForOffload: Boolean) {
+            if (!::playerA.isInitialized) return
+            // Only override the wake mode for local media. Remote schemes need
+            // C.WAKE_MODE_NETWORK to keep the wifi lock; we never want to drop
+            // that to NONE.
+            val baseMode = wakeModeFor(playerA.currentMediaItem)
+            val desiredMode = if (sleepingForOffload && baseMode == C.WAKE_MODE_LOCAL) {
+                C.WAKE_MODE_NONE
+            } else {
+                baseMode
+            }
+            if (currentWakeMode == desiredMode) return
+
+            try {
+                playerA.setWakeMode(desiredMode)
+                playerB?.setWakeMode(desiredMode)
+                currentWakeMode = desiredMode
+                Timber.tag("DualPlayerEngine").d(
+                    "Wake mode -> %d (sleepingForOffload=%b)",
+                    desiredMode,
+                    sleepingForOffload
+                )
+            } catch (e: Exception) {
+                Timber.tag("DualPlayerEngine").w(e, "Failed to apply offload-aware wake mode")
             }
         }
 
@@ -339,6 +379,18 @@ class DualPlayerEngine @Inject constructor(
         }
     }
 
+    private fun addMasterPlayerListeners(player: ExoPlayer) {
+        player.addListener(masterPlayerListener)
+        player.addAnalyticsListener(masterPlayerListener)
+        player.addAudioOffloadListener(masterPlayerListener)
+    }
+
+    private fun removeMasterPlayerListeners(player: ExoPlayer) {
+        player.removeListener(masterPlayerListener)
+        player.removeAnalyticsListener(masterPlayerListener)
+        player.removeAudioOffloadListener(masterPlayerListener)
+    }
+
     fun addPlayerSwapListener(listener: (Player) -> Unit) {
         onPlayerSwappedListeners.add(listener)
     }
@@ -397,6 +449,7 @@ class DualPlayerEngine @Inject constructor(
         }
 
         if (::playerA.isInitialized) {
+            removeMasterPlayerListeners(playerA)
             onPlayerAboutToBeReleasedListener?.invoke(playerA)
             try { playerA.release() } catch (e: Exception) { /* Ignore */ }
         }
@@ -405,8 +458,7 @@ class DualPlayerEngine @Inject constructor(
 
         playerA = buildPlayer()
 
-        playerA.addListener(masterPlayerListener)
-        playerA.addAnalyticsListener(masterPlayerListener)
+        addMasterPlayerListeners(playerA)
 
         _activeAudioSessionId.value = playerA.audioSessionId
         isReleased = false
@@ -560,8 +612,7 @@ class DualPlayerEngine @Inject constructor(
         val pauseAtEnd = playerA.pauseAtEndOfMediaItems
         val playbackParameters: PlaybackParameters = playerA.playbackParameters
 
-        playerA.removeListener(masterPlayerListener)
-        playerA.removeAnalyticsListener(masterPlayerListener)
+        removeMasterPlayerListeners(playerA)
         onPlayerAboutToBeReleasedListener?.invoke(playerA)
         playerA.release()
         playerB?.release()
@@ -569,8 +620,7 @@ class DualPlayerEngine @Inject constructor(
 
         playerA = buildPlayer()
 
-        playerA.addListener(masterPlayerListener)
-        playerA.addAnalyticsListener(masterPlayerListener)
+        addMasterPlayerListeners(playerA)
         playerA.volume = volume
         playerA.pauseAtEndOfMediaItems = pauseAtEnd
         playerA.playbackParameters = playbackParameters
@@ -984,8 +1034,7 @@ class DualPlayerEngine @Inject constructor(
         incomingPlayer.volume = incomingTrackReplayGainVolume ?: 1f
         incomingTrackReplayGainVolume = null
 
-        outgoingPlayer.removeListener(masterPlayerListener)
-        outgoingPlayer.removeAnalyticsListener(masterPlayerListener)
+        removeMasterPlayerListeners(outgoingPlayer)
 
         playerA = incomingPlayer
         playerB = outgoingPlayer
@@ -995,8 +1044,7 @@ class DualPlayerEngine @Inject constructor(
 
         playerA.pauseAtEndOfMediaItems = false
         playerB?.pauseAtEndOfMediaItems = false
-        playerA.addListener(masterPlayerListener)
-        playerA.addAnalyticsListener(masterPlayerListener)
+        addMasterPlayerListeners(playerA)
         if (playerA.playWhenReady) requestAudioFocus()
 
         onPlayerSwappedListeners.forEach { it(playerA) }
@@ -1133,8 +1181,7 @@ class DualPlayerEngine @Inject constructor(
         scope.coroutineContext[Job]?.cancel()
         abandonAudioFocus()
         if (::playerA.isInitialized) {
-            playerA.removeListener(masterPlayerListener)
-            playerA.removeAnalyticsListener(masterPlayerListener)
+            removeMasterPlayerListeners(playerA)
             onPlayerAboutToBeReleasedListener?.invoke(playerA)
             playerA.release()
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerSheetV2.kt
@@ -293,6 +293,14 @@ fun UnifiedPlayerSheetV2(
     )
     val shouldRenderFullPlayer = fullPlayerCompositionPolicy.shouldRenderFullPlayer
 
+    // Battery: tell the PlaybackStateHolder when the slider-bearing UI is
+    // actually rendered. When it isn't (mini-player only), the position
+    // ticker drops from 250 ms to 1 s — slider precision isn't needed.
+    DisposableEffect(shouldRenderFullPlayer) {
+        playerViewModel.setSliderUiMounted(shouldRenderFullPlayer)
+        onDispose { playerViewModel.setSliderUiMounted(false) }
+    }
+
     suspend fun animatePlayerSheet(
         targetExpanded: Boolean,
         animationSpec: androidx.compose.animation.core.AnimationSpec<Float> = sheetAnimationSpec,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlaybackStateHolder.kt
@@ -51,13 +51,17 @@ class PlaybackStateHolder @Inject constructor(
         // assume the seek will not land and fall back to the reported position rather than
         // pinning the UI on a stale value forever.
         private const val PAUSED_OVERRIDE_MAX_AGE_MS = 4_000L
-        // 250 ms keeps the slider/time display visibly smooth. We tried 500 ms to lower
-        // Compose recomposition pressure, but the smooth-progress sampler does not actually
-        // interpolate between source samples — it polls — so a 500 ms source cadence made the
-        // slider stutter in half-second jumps. Background tick is throttled to 1 s since the
-        // screen is off and no slider is visible.
-        private const val FOREGROUND_PROGRESS_TICK_MS = 250L
-        private const val BACKGROUND_PROGRESS_TICK_MS = 1000L
+        // Tick rates:
+        //  - SLIDER_TICK_MS (250): keeps the player sheet's slider/time display visibly smooth.
+        //    We tried 500 ms once to lower Compose recomposition pressure, but the smooth-progress
+        //    sampler polls instead of interpolating, so a 500 ms source made the slider stutter
+        //    in half-second jumps. Used only when the player sheet is open (slider visible).
+        //  - MINIPLAYER_TICK_MS (1000): mini-player + lock screen / notification only need
+        //    second-level precision. Drops position-polling-driven CPU wakes 4x → 1x per second.
+        //  - BACKGROUND_TICK_MS (1000): screen off, no slider visible.
+        private const val SLIDER_TICK_MS = 250L
+        private const val MINIPLAYER_TICK_MS = 1000L
+        private const val BACKGROUND_TICK_MS = 1000L
         /**
          * Threshold above which we skip per-item moveMediaItem calls and use
          * a single setMediaItems call instead. moveMediaItem triggers an IPC
@@ -81,6 +85,14 @@ class PlaybackStateHolder @Inject constructor(
     val stablePlayerState: StateFlow<StablePlayerState> = _stablePlayerState.asStateFlow()
     private val _currentPosition = MutableStateFlow(0L)
     val currentPosition: StateFlow<Long> = _currentPosition.asStateFlow()
+
+    // True while the full player sheet (slider visible) is mounted. Set by the
+    // sheet via DisposableEffect. Controls whether the position ticker runs at
+    // slider-smooth resolution (250 ms) or mini-player resolution (1 s).
+    private val _sliderUiMounted = MutableStateFlow(false)
+    fun setSliderUiMounted(mounted: Boolean) {
+        _sliderUiMounted.value = mounted
+    }
 
     // Internal State
     private var isSeeking = false
@@ -729,11 +741,10 @@ class PlaybackStateHolder @Inject constructor(
     }
 
     private fun currentProgressTickMs(): Long {
-        return if (powerManager.isInteractive) {
-            FOREGROUND_PROGRESS_TICK_MS
-        } else {
-            BACKGROUND_PROGRESS_TICK_MS
-        }
+        if (!powerManager.isInteractive) return BACKGROUND_TICK_MS
+        // Interactive but the slider isn't mounted (mini-player / lock-screen
+        // notification only) — second-level precision is enough.
+        return if (_sliderUiMounted.value) SLIDER_TICK_MS else MINIPLAYER_TICK_MS
     }
 
     fun stopProgressUpdates() {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -4362,6 +4362,14 @@ class PlayerViewModel @Inject constructor(
         return remoteCurrentSongId == null || remoteCurrentSongId == expectedSongId
     }
 
+    /**
+     * Signal from the player sheet whether the slider-bearing UI is currently
+     * rendered. Drives the position-ticker's resolution (250 ms vs 1 s).
+     */
+    fun setSliderUiMounted(mounted: Boolean) {
+        playbackStateHolder.setSliderUiMounted(mounted)
+    }
+
     fun playPause() {
         val castSession = castStateHolder.castSession.value
         if (castSession != null && castSession.remoteMediaClient != null) {


### PR DESCRIPTION
Implements dynamic wake mode management during audio offload and reduces position-ticker resolution when high-precision UI elements are not visible. These changes reduce CPU wakeups and power consumption during playback.

- Implemented `ExoPlayer.AudioOffloadListener` in `DualPlayerEngine` to switch to `C.WAKE_MODE_NONE` when the hardware handles playback.
- Added `setSliderUiMounted` to `PlayerViewModel` and `PlaybackStateHolder` to track the visibility of the full player sheet.
- Updated `currentProgressTickMs` to throttle polling to 1000ms for the mini-player and background states, reserving 250ms precision only for the active slider UI.
- Refactored `DualPlayerEngine` to use helper methods for managing master player listeners.
- Integrated a `DisposableEffect` in `UnifiedPlayerSheetV2` to report UI mount status.