### PR TITLE
logic: use explicit queue indices for playback selection and transitions

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -765,7 +765,7 @@ class MusicService : MediaLibraryService() {
                 mediaItems: MutableList<MediaItem>
             ): ListenableFuture<MutableList<MediaItem>> {
                 return serviceScope.future {
-                    if (mediaItems.size == 1) {
+                    if (mediaItems.size == 1 && !controller.packageName.startsWith(APP_PACKAGE_PREFIX)) {
                         resolveContextQueueForRequestedItem(mediaItems.first(), controller)?.let { queue ->
                             grantArtworkUriPermissions(controller.packageName, queue.mediaItems)
                             return@future queue.mediaItems
@@ -791,8 +791,10 @@ class MusicService : MediaLibraryService() {
                     val requestedIndex = startIndex.coerceIn(0, (mediaItems.size - 1).coerceAtLeast(0))
                     val requestedItem = mediaItems.getOrNull(requestedIndex)
 
-                    val contextQueue = requestedItem?.let {
-                        resolveContextQueueForRequestedItem(it, controller)
+                    val contextQueue = if (requestedItem != null && !controller.packageName.startsWith(APP_PACKAGE_PREFIX)) {
+                        resolveContextQueueForRequestedItem(requestedItem, controller)
+                    } else {
+                        null
                     }
                     if (contextQueue != null) {
                         grantArtworkUriPermissions(controller.packageName, contextQueue.mediaItems)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
@@ -41,7 +41,7 @@ fun AlbumCarouselSection(
     expansionFraction: Float,
     currentMediaItemIndex: Int = -1,
     requestedScrollIndex: Int? = null,
-    onSongSelected: (Song) -> Unit,
+    onSongSelected: (Song, Int) -> Unit,
     onAlbumClick: (Song) -> Unit = {},
     modifier: Modifier = Modifier,
     carouselStyle: String = CarouselStyle.NO_PEEK,
@@ -140,7 +140,7 @@ fun AlbumCarouselSection(
                 }
                 if (settled != currentSongIndex) {
                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                    queue.getOrNull(settled)?.let(onSongSelected)
+                    queue.getOrNull(settled)?.let { onSongSelected(it, settled) }
                 }
             }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/QueueBottomSheet.kt
@@ -222,7 +222,7 @@ fun QueueBottomSheet(
     isShuffleOn: Boolean,
     onDismiss: () -> Unit,
     onSongInfoClick: (Song) -> Unit,
-    onPlaySong: (Song) -> Unit,
+    onPlaySong: (Song, Int) -> Unit,
     onRemoveSong: (String) -> Unit,
     onReorder: (from: Int, to: Int) -> Unit,
     onToggleRepeat: () -> Unit,
@@ -836,7 +836,7 @@ fun QueueBottomSheet(
                                                 scaleX = scale
                                                 scaleY = scale
                                             },
-                                        onClick = { onPlaySong(song) },
+                                        onClick = { onPlaySong(song, queueIndex) },
                                         song = song,
                                         isCurrentSong = index == currentSongDisplayIndex,
                                         isPlaying = isPlaying && isVisible,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/UnifiedPlayerOverlaysLayer.kt
@@ -67,7 +67,7 @@ internal fun UnifiedPlayerQueueLayer(
     isEndOfTrackTimerActive: State<Boolean>,
     onDismissQueue: () -> Unit,
     onSongInfoClick: (Song) -> Unit,
-    onPlaySong: (Song) -> Unit,
+    onPlaySong: (Song, Int) -> Unit,
     onRemoveSong: (String) -> Unit,
     onReorder: (Int, Int) -> Unit,
     onToggleRepeat: () -> Unit,
@@ -338,11 +338,12 @@ internal fun UnifiedPlayerQueueAndSongInfoHost(
                 { song: Song -> onSelectedSongForInfoChange(song) }
             }
             val onPlayQueueSong = remember(playerViewModel) {
-                { song: Song ->
+                { song: Song, index: Int ->
                     playerViewModel.showAndPlaySong(
                         song = song,
                         contextSongs = latestPlaybackQueue.value,
-                        queueName = latestQueueSourceName.value
+                        queueName = latestQueueSourceName.value,
+                        indexInQueue = index
                     )
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -385,11 +385,12 @@ fun FullPlayerContent(
         }
     }
 
-    val onAlbumSongSelected: (Song) -> Unit = { newSong ->
+    val onAlbumSongSelected: (Song, Int) -> Unit = { newSong, index ->
         playerViewModel.showAndPlaySong(
             song = newSong,
             contextSongs = currentPlaybackQueue,
-            queueName = currentQueueSourceName
+            queueName = currentQueueSourceName,
+            indexInQueue = index
         )
     }
 
@@ -1010,7 +1011,7 @@ private fun FullPlayerAlbumCoverSection(
     placeholderOnColor: Color,
     albumArtQuality: AlbumArtQuality,
     requestedScrollIndex: Int?,
-    onSongSelected: (Song) -> Unit,
+    onSongSelected: (Song, Int) -> Unit,
     onAlbumClick: (Song) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -1081,9 +1082,9 @@ private fun FullPlayerAlbumCoverSection(
                 expansionFraction = 1f,
                 currentMediaItemIndex = currentMediaItemIndex,
                 requestedScrollIndex = requestedScrollIndex,
-                onSongSelected = { newSong ->
-                    if (newSong.id != song.id) {
-                        onSongSelected(newSong)
+                onSongSelected = { newSong, index ->
+                    if (newSong.id != song.id || index != currentMediaItemIndex) {
+                        onSongSelected(newSong, index)
                     }
                 },
                 onAlbumClick = onAlbumClick,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -2221,7 +2221,8 @@ class PlayerViewModel @Inject constructor(
         queueName: String = "Current Context",
         isVoluntaryPlay: Boolean = true,
         cancelPendingQueueBuild: Boolean = true,
-        playlistId: String? = null
+        playlistId: String? = null,
+        indexInQueue: Int? = null
     ) {
         if (cancelPendingQueueBuild) {
             cancelPendingFullQueuePlayback()
@@ -2299,7 +2300,7 @@ class PlayerViewModel @Inject constructor(
         }    // Local playback logic
         val controller = mediaController
         val currentQueue = _playerUiState.value.currentPlaybackQueue
-        val songIndexInQueue = currentQueue.indexOfFirst { it.id == song.id }
+        val songIndexInQueue = indexInQueue ?: currentQueue.indexOfFirst { it.id == song.id }
         val queueMatchesContext = currentQueue.matchesSongOrder(playbackContext)
         val reusableTargetIndex = if (
             controller != null &&
@@ -2308,7 +2309,11 @@ class PlayerViewModel @Inject constructor(
             songIndexInQueue != -1 &&
             queueMatchesContext
         ) {
-            controller.resolveReusablePlaybackTargetIndex(songIndexInQueue, song.id)
+            controller.resolveReusablePlaybackTargetIndex(
+                songIndexInQueue = songIndexInQueue,
+                songId = song.id,
+                isExplicitQueueTarget = indexInQueue != null
+            )
         } else {
             null
         }
@@ -2349,10 +2354,13 @@ class PlayerViewModel @Inject constructor(
 
     private fun MediaController.resolveReusablePlaybackTargetIndex(
         songIndexInQueue: Int,
-        songId: String
+        songId: String,
+        isExplicitQueueTarget: Boolean = false
     ): Int? {
-        currentMediaItem?.takeIf { it.mediaId == songId }?.let {
-            return currentMediaItemIndex.takeIf { index -> index != C.INDEX_UNSET } ?: 0
+        if (!isExplicitQueueTarget) {
+            currentMediaItem?.takeIf { it.mediaId == songId }?.let {
+                return currentMediaItemIndex.takeIf { index -> index != C.INDEX_UNSET } ?: 0
+            }
         }
 
         if (songIndexInQueue !in 0 until mediaItemCount) return null
@@ -2872,7 +2880,8 @@ class PlayerViewModel @Inject constructor(
 
         val mediaItem = player.currentMediaItem ?: return
         val currentSongId = playbackStateHolder.stablePlayerState.value.currentSong?.id
-        if (currentSongId == mediaItem.mediaId) return
+        val currentIndex = playbackStateHolder.stablePlayerState.value.currentMediaItemIndex
+        if (currentSongId == mediaItem.mediaId && currentIndex == player.currentMediaItemIndex) return
 
         playbackStateHolder.onPlaybackOccurrenceTransition(mediaItem.mediaId)
         preparePlaybackAudioMetadataForMedia(mediaItem.mediaId)


### PR DESCRIPTION
Updates the playback logic and UI components to use explicit queue indices instead of relying solely on song IDs. This ensures correct behavior when the same song appears multiple times in a queue and allows for more reliable playback transitions.

- Modified `AlbumCarouselSelection`, `QueueBottomSheet`, and `FullPlayerContent` to pass the item index during song selection.
- Updated `PlayerViewModel.showAndPlaySong` to accept an optional `indexInQueue`, prioritizing it over ID-based index lookups.
- Enhanced `resolveReusablePlaybackTargetIndex` with an `isExplicitQueueTarget` flag to allow re-triggering playback of the current song when selected from the UI.
- Updated `MusicService` to bypass automated context queue resolution for requests originating from the app's own package.
- Refined playback transition detection in `PlayerViewModel` to consider index changes, ensuring state updates occur even when the same song ID repeats.