### PR TITLE
feat: enhance MediaStore delete requests and storage volume resolution

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -4078,13 +4078,20 @@ class PlayerViewModel @Inject constructor(
                 }
                 if (deleteRequests.size == deletableSongs.size) {
                     val uris = deleteRequests.map { it.second }.distinctBy { it.toString() }
-                    val intentSender = com.theveloper.pixelplay.utils.MediaStorePermissionHelper
-                        .createDeleteRequestIntentSender(activity, uris)
-                    if (intentSender != null) {
-                        pendingBatchDeleteSongs = deleteRequests.map { it.first }
-                        pendingBatchDeleteSkippedCount = skippedCount
+                    val deleteRequest = com.theveloper.pixelplay.utils.MediaStorePermissionHelper
+                        .createDeleteRequest(activity, uris)
+                    if (deleteRequest != null) {
+                        val acceptedUriStrings = deleteRequest.acceptedUris
+                            .mapTo(mutableSetOf()) { it.toString() }
+                        val acceptedSongs = deleteRequests
+                            .filter { (_, uri) -> uri.toString() in acceptedUriStrings }
+                            .map { it.first }
+                        val invalidRequestCount = deletableSongs.size - acceptedSongs.size
+
+                        pendingBatchDeleteSongs = acceptedSongs
+                        pendingBatchDeleteSkippedCount = skippedCount + invalidRequestCount
                         pendingBatchDeleteOnComplete = onComplete
-                        _deletePermissionRequest.emit(intentSender)
+                        _deletePermissionRequest.emit(deleteRequest.intentSender)
                         return@launch
                     }
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
@@ -19,6 +19,12 @@ import androidx.annotation.RequiresApi
 object MediaStorePermissionHelper {
     private const val MEDIASTORE_AUTHORITY = "media"
 
+    data class DeleteRequest(
+        val intentSender: IntentSender,
+        val acceptedUris: List<Uri>,
+        val rejectedUris: List<Uri>
+    )
+
     /**
      * Returns the MediaStore content URI for a given audio song ID.
      * Returns null for cloud songs (negative IDs).
@@ -30,6 +36,27 @@ object MediaStorePermissionHelper {
         } else {
             ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId)
         }
+    }
+
+    fun getAudioMediaStoreUris(context: Context, songId: Long): List<Uri> {
+        if (songId <= 0) return emptyList()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return listOf(ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId))
+        }
+
+        val specificVolumes = runCatching {
+            MediaStore.getExternalVolumeNames(context)
+        }.getOrDefault(emptySet())
+            .filterNot { it == MediaStore.VOLUME_EXTERNAL }
+            .sortedWith(compareBy<String> { it != MediaStore.VOLUME_EXTERNAL_PRIMARY }.thenBy { it })
+
+        return buildList {
+            specificVolumes.forEach { volumeName ->
+                add(MediaStore.Audio.Media.getContentUri(volumeName, songId))
+            }
+            add(MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY, songId))
+            add(MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL, songId))
+        }.distinctBy { it.toString() }
     }
 
     fun isMediaStoreItemUriString(contentUriString: String): Boolean {
@@ -52,13 +79,18 @@ object MediaStorePermissionHelper {
         contentUriString: String,
         filePath: String
     ): Uri? {
+        val parsedMediaStoreUri = parseMediaStoreItemUri(contentUriString)
+        val parsedSongId = parsedMediaStoreUri?.lastPathSegment?.toLongOrNull()
         val candidates = buildList {
-            parseMediaStoreItemUri(contentUriString)?.let(::add)
+            if (songId != null && canUseSongIdForMediaStoreRequest(contentUriString)) {
+                addAll(getAudioMediaStoreUris(context, songId))
+            }
+            if (parsedSongId != null) {
+                addAll(getAudioMediaStoreUris(context, parsedSongId))
+            }
+            parsedMediaStoreUri?.let(::add)
             if (filePath.isNotBlank()) {
                 getMediaStoreUri(context, filePath)?.let(::add)
-            }
-            if (songId != null && canUseSongIdForMediaStoreRequest(contentUriString)) {
-                getMediaStoreUri(songId)?.let(::add)
             }
         }.distinctBy { it.toString() }
 
@@ -122,12 +154,47 @@ object MediaStorePermissionHelper {
         context: Context,
         uris: Collection<Uri>
     ): IntentSender? {
-        if (uris.isEmpty()) return null
+        return createDeleteRequest(context, uris)?.intentSender
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun createDeleteRequest(
+        context: Context,
+        uris: Collection<Uri>
+    ): DeleteRequest? {
+        val distinctUris = uris.distinctBy { it.toString() }
+        if (distinctUris.isEmpty()) return null
+
+        createPlatformDeleteRequest(context, distinctUris)?.let { intentSender ->
+            return DeleteRequest(
+                intentSender = intentSender,
+                acceptedUris = distinctUris,
+                rejectedUris = emptyList()
+            )
+        }
+
+        val acceptedUris = distinctUris.filter { uri ->
+            createPlatformDeleteRequest(context, listOf(uri)) != null
+        }
+        if (acceptedUris.isEmpty()) return null
+
+        val intentSender = createPlatformDeleteRequest(context, acceptedUris) ?: return null
+        val acceptedUriStrings = acceptedUris.mapTo(mutableSetOf()) { it.toString() }
+        return DeleteRequest(
+            intentSender = intentSender,
+            acceptedUris = acceptedUris,
+            rejectedUris = distinctUris.filterNot { it.toString() in acceptedUriStrings }
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun createPlatformDeleteRequest(
+        context: Context,
+        uris: Collection<Uri>
+    ): IntentSender? {
         return try {
             MediaStore.createDeleteRequest(context.contentResolver, uris).intentSender
-        } catch (_: IllegalArgumentException) {
-            null
-        } catch (_: SecurityException) {
+        } catch (_: Exception) {
             null
         }
     }

--- a/app/src/test/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelperTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelperTest.kt
@@ -12,6 +12,11 @@ class MediaStorePermissionHelperTest {
                 "content://media/external/audio/media/9317"
             )
         ).isTrue()
+        assertThat(
+            MediaStorePermissionHelper.isMediaStoreItemUriString(
+                "content://media/external_primary/audio/media/9317"
+            )
+        ).isTrue()
     }
 
     @Test
@@ -19,6 +24,11 @@ class MediaStorePermissionHelperTest {
         assertThat(
             MediaStorePermissionHelper.isMediaStoreItemUriString(
                 "content://media/external/audio/media"
+            )
+        ).isFalse()
+        assertThat(
+            MediaStorePermissionHelper.isMediaStoreItemUriString(
+                "content://media/external/audio/media/not-a-number"
             )
         ).isFalse()
     }


### PR DESCRIPTION
Updates `MediaStorePermissionHelper` to improve the reliability of batch deletions and better handle multiple storage volumes on Android 10+.

- Added `getAudioMediaStoreUris` to resolve song IDs across all available storage volumes, including `external_primary` and specific volume names.
- Introduced `DeleteRequest` data class to track `IntentSender` along with successfully accepted and rejected URIs.
- Refactored `createDeleteRequest` to implement a fallback mechanism that filters out invalid URIs causing platform-level failures, allowing partial batch deletes.
- Updated `PlayerViewModel` to integrate with the new `DeleteRequest` logic and accurately track skipped items during deletion.
- Enhanced `findValidMediaStoreUri` to check for candidates across all discovered volume URIs.
- Added unit tests for `external_primary` URI patterns and malformed MediaStore path segments.