### PR TITLE
ui: add "Save New" action to Equalizer and improve layout

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/EqualizerScreen.kt
@@ -559,8 +559,11 @@ private fun BandSlidersSection(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Row(
+                modifier = Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
             ) {
                  val isCustomOrSaved = editingPresetName != null || currentPreset.name == "custom" || currentPreset.isCustom
                  val displayLabel = editingPresetName ?: currentPreset.displayName
@@ -599,7 +602,7 @@ private fun BandSlidersSection(
                         shape = CircleShape,
                         onClick = onSaveClick
                     ) {
-                         Row(
+                          Row(
                             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
@@ -615,11 +618,12 @@ private fun BandSlidersSection(
                                  color = MaterialTheme.colorScheme.onTertiaryContainer,
                                  fontWeight = FontWeight.Bold
                              )
-                         }
+                          }
                      }
                 }
                 
                 if (editingPresetName != null) {
+                    // Update Option
                     Surface(
                         color = MaterialTheme.colorScheme.primaryContainer,
                         shape = CircleShape,
@@ -639,6 +643,31 @@ private fun BandSlidersSection(
                             Text(
                                 text = stringResource(R.string.presentation_batch_d_action_update),
                                 color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+
+                    // Save New Option
+                    Surface(
+                        color = MaterialTheme.colorScheme.tertiaryContainer,
+                        shape = CircleShape,
+                        onClick = onSaveClick
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Save,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.onTertiaryContainer
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = stringResource(R.string.equalizer_action_save_new),
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
                                 fontWeight = FontWeight.Bold
                             )
                         }

--- a/app/src/main/res/values-de/strings_components.xml
+++ b/app/src/main/res/values-de/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Preset umbenennen</string>
     <string name="error_name_empty">Name darf nicht leer sein</string>
     <string name="action_save">Speichern</string>
+    <string name="equalizer_action_save_new">Neu speichern</string>
     <string name="action_rename">Umbenennen</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-es/strings_components.xml
+++ b/app/src/main/res/values-es/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Renombrar preset</string>
     <string name="error_name_empty">El nombre no puede estar vacío</string>
     <string name="action_save">Guardar</string>
+    <string name="equalizer_action_save_new">Guardar nuevo</string>
     <string name="action_rename">Renombrar</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-fr/strings_components.xml
+++ b/app/src/main/res/values-fr/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Renommer le préréglage</string>
     <string name="error_name_empty">Le nom ne peut pas être vide</string>
     <string name="action_save">Enregistrer</string>
+    <string name="equalizer_action_save_new">Enregistrer nouveau</string>
     <string name="action_rename">Renommer</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-in/strings_components.xml
+++ b/app/src/main/res/values-in/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Ubah nama preset</string>
     <string name="error_name_empty">Nama tidak boleh kosong</string>
     <string name="action_save">Simpan</string>
+    <string name="equalizer_action_save_new">Simpan baru</string>
     <string name="action_rename">Ubah Nama</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-it/strings_components.xml
+++ b/app/src/main/res/values-it/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Rinomina preset</string>
     <string name="error_name_empty">Il nome non può essere vuoto</string>
     <string name="action_save">Salva</string>
+    <string name="equalizer_action_save_new">Salva nuovo</string>
     <string name="action_rename">Rinomina</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-ko/strings_components.xml
+++ b/app/src/main/res/values-ko/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">프리셋 이름 변경</string>
     <string name="error_name_empty">이름은 비워둘 수 없습니다</string>
     <string name="action_save">저장</string>
+    <string name="equalizer_action_save_new">새로 저장</string>
     <string name="action_rename">이름 변경</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-nb/strings_components.xml
+++ b/app/src/main/res/values-nb/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Endre navn på forhåndsinnstilling</string>
     <string name="error_name_empty">Navnet kan ikke være tomt</string>
     <string name="action_save">Lagre</string>
+    <string name="equalizer_action_save_new">Lagre ny</string>
     <string name="action_rename">Endre navn</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-ru/strings_components.xml
+++ b/app/src/main/res/values-ru/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Переименовать пресет</string>
     <string name="error_name_empty">Имя не может быть пустым</string>
     <string name="action_save">Сохранить</string>
+    <string name="equalizer_action_save_new">Сохранить как новый</string>
     <string name="action_rename">Переименовать</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values-zh-rCN/strings_components.xml
+++ b/app/src/main/res/values-zh-rCN/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">重命名预设</string>
     <string name="error_name_empty">名称不能为空</string>
     <string name="action_save">保存</string>
+    <string name="equalizer_action_save_new">保存新预设</string>
     <string name="action_rename">重命名</string>
 
     <!-- AI metadata sheet -->

--- a/app/src/main/res/values/strings_components.xml
+++ b/app/src/main/res/values/strings_components.xml
@@ -41,6 +41,7 @@
     <string name="equalizer_rename_preset_title">Rename preset</string>
     <string name="error_name_empty">Name cannot be empty</string>
     <string name="action_save">Save</string>
+    <string name="equalizer_action_save_new">Save New</string>
     <string name="action_rename">Rename</string>
 
     <!-- AI metadata sheet -->


### PR DESCRIPTION
Updates the Equalizer screen to allow saving a new preset while editing and improves the responsiveness of the action button container.

- Added a "Save New" button to the equalizer action row when a preset is being edited.
- Implemented horizontal scrolling and adjusted padding/alignment for the action button `Row` to prevent overflow on smaller screens.
- Added the `equalizer_action_save_new` string resource across multiple locales (ES, IT, RU, DE, ZH, FR, NB, KO, IN).