### PR TITLE
perf: improve audio offload stability and fallback logic

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -835,13 +835,7 @@ class MusicService : MediaLibraryService() {
         if (temporaryForegroundStartedInOnCreate) {
             serviceScope.launch {
                 delay(2_000L)
-                val player = mediaSession?.player
-                val isActivelyPlaying = player?.let {
-                    it.playWhenReady &&
-                        it.playbackState != Player.STATE_IDLE &&
-                        it.playbackState != Player.STATE_ENDED
-                } == true
-                if (!isActivelyPlaying) {
+                if (mediaSession?.player?.hasForegroundPlaybackIntent() != true) {
                     stopForeground(STOP_FOREGROUND_REMOVE)
                 }
             }
@@ -1004,9 +998,14 @@ class MusicService : MediaLibraryService() {
 
     private fun isServiceAlreadyForeground(): Boolean {
         val player = mediaSession?.player ?: return false
-        return player.playWhenReady &&
-            player.playbackState != Player.STATE_IDLE &&
-            player.playbackState != Player.STATE_ENDED
+        return player.hasForegroundPlaybackIntent()
+    }
+
+    private fun Player.hasForegroundPlaybackIntent(): Boolean {
+        return playWhenReady &&
+            mediaItemCount > 0 &&
+            playbackState != Player.STATE_IDLE &&
+            playbackState != Player.STATE_ENDED
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -1115,13 +1114,7 @@ class MusicService : MediaLibraryService() {
         }
         val startCommandResult = super.onStartCommand(intent, flags, startId)
         if (needsTemporaryForeground || startedTemporaryForegroundInOnCreate) {
-            val player = mediaSession?.player
-            val isActivelyPlaying = player?.let {
-                it.playWhenReady &&
-                    it.playbackState != Player.STATE_IDLE &&
-                    it.playbackState != Player.STATE_ENDED
-            } == true
-            if (!isActivelyPlaying) {
+            if (mediaSession?.player?.hasForegroundPlaybackIntent() != true) {
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 if (needsTemporaryForeground) {
                     stopSelfResult(startId)
@@ -1677,7 +1670,7 @@ class MusicService : MediaLibraryService() {
             return
         }
 
-        if (player == null || !player.playWhenReady || player.mediaItemCount == 0 || player.playbackState == Player.STATE_ENDED) {
+        if (player?.hasForegroundPlaybackIntent() != true) {
             stopPlaybackAndUnload(
                 reason = "task_removed_not_playing"
             )
@@ -2841,15 +2834,14 @@ class MusicService : MediaLibraryService() {
     }
 
     override fun onUpdateNotification(session: MediaSession, startInForegroundRequired: Boolean) {
-        val playWhenReady = session.player.playWhenReady
-        val playbackState = session.player.playbackState
+        val hasPlaybackIntent = session.player.hasForegroundPlaybackIntent()
 
-        // Android 12+ (API 31+): Only request foreground when actively playing.
-        // This prevents requesting foreground start when player is idle/ended.
+        // Android 12+ (API 31+): keep the service foreground while playback is intended,
+        // even if an OEM offload path reports READY/BUFFERING without audio for a moment.
+        // That gives the generic offload fallback time to rebuild the player instead of
+        // letting task removal/backgrounding tear the session down first.
         val shouldStartInForeground = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            startInForegroundRequired && playWhenReady
-                    && playbackState != Player.STATE_IDLE
-                    && playbackState != Player.STATE_ENDED
+            startInForegroundRequired || hasPlaybackIntent
         } else {
             startInForegroundRequired
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -74,6 +74,58 @@ internal fun shouldResumeAfterTransientAudioFocusLoss(
         (transitionRunning && (auxiliaryPlayWhenReady || auxiliaryIsPlaying))
 }
 
+internal fun shouldDisableAudioOffloadByDefaultForDevice(
+    manufacturer: String,
+    brand: String,
+    model: String,
+    hardware: String,
+    sdkInt: Int
+): Boolean {
+    val manufacturerName = manufacturer.trim().lowercase()
+    val brandName = brand.trim().lowercase()
+    val modelName = model.trim().lowercase()
+    val hardwareName = hardware.trim().lowercase()
+
+    val isXiaomiFamilyDevice = manufacturerName == "xiaomi" ||
+        brandName == "xiaomi" ||
+        brandName == "redmi" ||
+        brandName == "poco"
+    if (isXiaomiFamilyDevice && sdkInt >= 36) return true
+
+    val isLavaDevice =
+        manufacturerName == "lava" ||
+            brandName == "lava"
+    val looksLikeMtkHardware =
+        hardwareName.startsWith("mt") ||
+            hardwareName.contains("mediatek") ||
+            hardwareName.contains("mtk")
+    val isReportedLxxFamily = modelName.startsWith("lxx") && isLavaDevice
+    val isMtkLavaVariant = isLavaDevice && looksLikeMtkHardware
+
+    return sdkInt >= 35 && (isReportedLxxFamily || isMtkLavaVariant)
+}
+
+internal fun shouldTriggerAudioOffloadStallFallback(
+    audioOffloadEnabled: Boolean,
+    transitionRunning: Boolean,
+    isCurrentMasterPlayer: Boolean,
+    mediaIdMatches: Boolean,
+    playbackState: Int,
+    isPlaying: Boolean,
+    playWhenReady: Boolean,
+    playbackSuppressionReason: Int
+): Boolean {
+    return audioOffloadEnabled &&
+        !transitionRunning &&
+        isCurrentMasterPlayer &&
+        mediaIdMatches &&
+        playWhenReady &&
+        !isPlaying &&
+        playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_NONE &&
+        playbackState != Player.STATE_IDLE &&
+        playbackState != Player.STATE_ENDED
+}
+
 /**
  * Manages two ExoPlayer instances (A and B) to enable seamless transitions.
  *
@@ -97,7 +149,7 @@ class DualPlayerEngine @Inject constructor(
     private val connectivityStateHolder: com.theveloper.pixelplay.presentation.viewmodel.ConnectivityStateHolder
 ) {
     private companion object {
-        private const val AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS = 4_000L
+        private const val AUDIO_OFFLOAD_STALL_FALLBACK_MS = 4_000L
         private const val MAX_AUXILIARY_TIMELINE_ITEMS = 200
         private val LOCAL_MEDIA_SCHEMES = setOf("content", "file", "android.resource")
         private val REMOTE_MEDIA_SCHEMES = setOf("http", "https", "telegram", "netease", "qqmusic", "navidrome", "jellyfin", "gdrive")
@@ -203,6 +255,7 @@ class DualPlayerEngine @Inject constructor(
             if (playWhenReady) {
                 lastPlayWhenReadyAtMs = SystemClock.elapsedRealtime()
                 requestAudioFocus()
+                scheduleAudioOffloadFallbackIfNeeded(playerA)
             } else {
                 cancelAudioOffloadFallback()
                 // Keep focus across user pauses so a quick resume doesn't have to re-acquire it.
@@ -362,7 +415,8 @@ class DualPlayerEngine @Inject constructor(
                         scheduleAudioOffloadFallbackIfNeeded(playerA)
                     }
                 }
-                Player.STATE_READY, Player.STATE_IDLE, Player.STATE_ENDED -> cancelAudioOffloadFallback()
+                Player.STATE_READY -> scheduleAudioOffloadFallbackIfNeeded(playerA)
+                Player.STATE_IDLE, Player.STATE_ENDED -> cancelAudioOffloadFallback()
             }
         }
 
@@ -512,20 +566,30 @@ class DualPlayerEngine @Inject constructor(
 
     private fun scheduleAudioOffloadFallbackIfNeeded(player: ExoPlayer) {
         cancelAudioOffloadFallback()
-        if (!audioOffloadEnabled || transitionRunning || !player.playWhenReady) return
+        if (!audioOffloadEnabled || transitionRunning || !player.playWhenReady || player.isPlaying) return
         if (!isLikelyLocalMedia(player.currentMediaItem)) return
 
         val watchedMediaId = player.currentMediaItem?.mediaId ?: return
+        if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) return
         bufferingFallbackJob = scope.launch {
-            delay(AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS)
+            delay(AUDIO_OFFLOAD_STALL_FALLBACK_MS)
 
             val currentMediaId = player.currentMediaItem?.mediaId
-            if (!audioOffloadEnabled || transitionRunning || player !== playerA) return@launch
-            if (currentMediaId != watchedMediaId) return@launch
-            if (player.playbackState != Player.STATE_BUFFERING || player.isPlaying || !player.playWhenReady) return@launch
+            val shouldFallback = shouldTriggerAudioOffloadStallFallback(
+                audioOffloadEnabled = audioOffloadEnabled,
+                transitionRunning = transitionRunning,
+                isCurrentMasterPlayer = player === playerA,
+                mediaIdMatches = currentMediaId == watchedMediaId,
+                playbackState = player.playbackState,
+                isPlaying = player.isPlaying,
+                playWhenReady = player.playWhenReady,
+                playbackSuppressionReason = player.playbackSuppressionReason
+            )
+            if (!shouldFallback) return@launch
 
             disableAudioOffloadForSession(
-                reason = "Local media stayed buffering for ${AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS}ms"
+                reason = "Local media did not produce audio for " +
+                    "${AUDIO_OFFLOAD_STALL_FALLBACK_MS}ms (state=${player.playbackState})"
             )
         }
     }
@@ -567,22 +631,13 @@ class DualPlayerEngine @Inject constructor(
     }
 
     private fun shouldDisableAudioOffloadByDefault(): Boolean {
-        val manufacturer = Build.MANUFACTURER.lowercase()
-        val brand = Build.BRAND.lowercase()
-        // Xiaomi-family devices on SDK 36+ still need the static disable: their
-        // HAL offload path has its own quirks that the runtime fallback below
-        // hasn't been validated against.
-        val isXiaomiFamilyDevice = manufacturer == "xiaomi" || brand == "xiaomi" || brand == "redmi" || brand == "poco"
-        if (isXiaomiFamilyDevice && Build.VERSION.SDK_INT >= 36) return true
-
-        // Pixel blacklist (previously: SDK >= 34) removed. The original "playback
-        // does not start with offload" symptom is now caught by
-        // scheduleAudioOffloadFallbackIfNeeded() + disableAudioOffloadForSession(),
-        // which rebuild the player to PCM if the HAL stays in STATE_BUFFERING
-        // for more than AUDIO_OFFLOAD_BUFFERING_FALLBACK_MS. Leaving offload on
-        // by default reclaims the 30–50% battery savings the DSP path provides
-        // for the common case where the HAL works correctly.
-        return false
+        return shouldDisableAudioOffloadByDefaultForDevice(
+            manufacturer = Build.MANUFACTURER,
+            brand = Build.BRAND,
+            model = Build.MODEL,
+            hardware = Build.HARDWARE,
+            sdkInt = Build.VERSION.SDK_INT
+        )
     }
 
     private fun disableAudioOffloadForSession(reason: String) {

--- a/app/src/test/java/com/theveloper/pixelplay/data/service/player/AudioOffloadPolicyTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/service/player/AudioOffloadPolicyTest.kt
@@ -1,0 +1,108 @@
+package com.theveloper.pixelplay.data.service.player
+
+import androidx.media3.common.Player
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class AudioOffloadPolicyTest {
+
+    @Test
+    fun defaultPolicy_disablesOffloadForReportedLavaMtkDeviceOnAndroid15() {
+        val disabled = shouldDisableAudioOffloadByDefaultForDevice(
+            manufacturer = "LAVA",
+            brand = "LAVA",
+            model = "LXX521",
+            hardware = "k69v1_64",
+            sdkInt = 35
+        )
+
+        assertThat(disabled).isTrue()
+    }
+
+    @Test
+    fun defaultPolicy_keepsOffloadForPixelOnAndroid15() {
+        val disabled = shouldDisableAudioOffloadByDefaultForDevice(
+            manufacturer = "Google",
+            brand = "google",
+            model = "Pixel 9",
+            hardware = "tokay",
+            sdkInt = 35
+        )
+
+        assertThat(disabled).isFalse()
+    }
+
+    @Test
+    fun defaultPolicy_keepsOffloadForUnrelatedLavaDeviceWithoutMtkSignal() {
+        val disabled = shouldDisableAudioOffloadByDefaultForDevice(
+            manufacturer = "LAVA",
+            brand = "LAVA",
+            model = "Agni",
+            hardware = "generic",
+            sdkInt = 35
+        )
+
+        assertThat(disabled).isFalse()
+    }
+
+    @Test
+    fun defaultPolicy_preservesExistingXiaomiAndroid16Disable() {
+        val disabled = shouldDisableAudioOffloadByDefaultForDevice(
+            manufacturer = "Xiaomi",
+            brand = "Redmi",
+            model = "25010PN30G",
+            hardware = "qcom",
+            sdkInt = 36
+        )
+
+        assertThat(disabled).isTrue()
+    }
+
+    @Test
+    fun stallFallback_triggersForBufferingPlaybackIntentWithoutAudio() {
+        val shouldFallback = shouldTriggerAudioOffloadStallFallback(
+            audioOffloadEnabled = true,
+            transitionRunning = false,
+            isCurrentMasterPlayer = true,
+            mediaIdMatches = true,
+            playbackState = Player.STATE_BUFFERING,
+            isPlaying = false,
+            playWhenReady = true,
+            playbackSuppressionReason = Player.PLAYBACK_SUPPRESSION_REASON_NONE
+        )
+
+        assertThat(shouldFallback).isTrue()
+    }
+
+    @Test
+    fun stallFallback_triggersForReadyPlaybackIntentWithoutAudio() {
+        val shouldFallback = shouldTriggerAudioOffloadStallFallback(
+            audioOffloadEnabled = true,
+            transitionRunning = false,
+            isCurrentMasterPlayer = true,
+            mediaIdMatches = true,
+            playbackState = Player.STATE_READY,
+            isPlaying = false,
+            playWhenReady = true,
+            playbackSuppressionReason = Player.PLAYBACK_SUPPRESSION_REASON_NONE
+        )
+
+        assertThat(shouldFallback).isTrue()
+    }
+
+    @Test
+    fun stallFallback_doesNotTriggerForSuppressedPlayback() {
+        val shouldFallback = shouldTriggerAudioOffloadStallFallback(
+            audioOffloadEnabled = true,
+            transitionRunning = false,
+            isCurrentMasterPlayer = true,
+            mediaIdMatches = true,
+            playbackState = Player.STATE_READY,
+            isPlaying = false,
+            playWhenReady = true,
+            playbackSuppressionReason = 1
+        )
+
+        assertThat(shouldFallback).isFalse()
+    }
+}


### PR DESCRIPTION
Refines the audio offload policy to handle hardware-specific stalls and ensures consistent foreground service behavior during playback transitions. These changes prevent premature session teardown on certain devices where the hardware offload path may report a ready state without actually producing audio.

- Implemented `shouldDisableAudioOffloadByDefaultForDevice` to blacklist specific Lava/MTK (Android 15+) and Xiaomi (Android 16+) configurations known for offload issues.
- Expanded the offload stall fallback mechanism to trigger during `STATE_READY` if audio is not actively playing, in addition to `STATE_BUFFERING`.
- Introduced a `Player.hasForegroundPlaybackIntent()` extension to unify playback state checks across `MusicService`.
- Updated `onUpdateNotification` to maintain foreground status as long as a playback intent exists, giving the offload fallback logic time to rebuild the player if a stall occurs.
- Added `AudioOffloadPolicyTest` to validate device-specific blacklisting and stall detection logic.