### PR TITLE
fix: resolve verified findings from master-branch code review

### DIFF
--- a/app/schemas/com.theveloper.pixelplay.data.database.PixelPlayDatabase/42.json
+++ b/app/schemas/com.theveloper.pixelplay.data.database.PixelPlayDatabase/42.json
@@ -1,0 +1,2750 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 42,
+    "identityHash": "0077364dc30d6413be4923af8a80ec91",
+    "entities": [
+      {
+        "tableName": "album_art_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumArtUriString` TEXT NOT NULL, `paletteStyle` TEXT NOT NULL, `light_primary` TEXT NOT NULL, `light_onPrimary` TEXT NOT NULL, `light_primaryContainer` TEXT NOT NULL, `light_onPrimaryContainer` TEXT NOT NULL, `light_secondary` TEXT NOT NULL, `light_onSecondary` TEXT NOT NULL, `light_secondaryContainer` TEXT NOT NULL, `light_onSecondaryContainer` TEXT NOT NULL, `light_tertiary` TEXT NOT NULL, `light_onTertiary` TEXT NOT NULL, `light_tertiaryContainer` TEXT NOT NULL, `light_onTertiaryContainer` TEXT NOT NULL, `light_background` TEXT NOT NULL, `light_onBackground` TEXT NOT NULL, `light_surface` TEXT NOT NULL, `light_onSurface` TEXT NOT NULL, `light_surfaceVariant` TEXT NOT NULL, `light_onSurfaceVariant` TEXT NOT NULL, `light_error` TEXT NOT NULL, `light_onError` TEXT NOT NULL, `light_outline` TEXT NOT NULL, `light_errorContainer` TEXT NOT NULL, `light_onErrorContainer` TEXT NOT NULL, `light_inversePrimary` TEXT NOT NULL, `light_inverseSurface` TEXT NOT NULL, `light_inverseOnSurface` TEXT NOT NULL, `light_surfaceTint` TEXT NOT NULL, `light_outlineVariant` TEXT NOT NULL, `light_scrim` TEXT NOT NULL, `light_surfaceBright` TEXT NOT NULL, `light_surfaceDim` TEXT NOT NULL, `light_surfaceContainer` TEXT NOT NULL, `light_surfaceContainerHigh` TEXT NOT NULL, `light_surfaceContainerHighest` TEXT NOT NULL, `light_surfaceContainerLow` TEXT NOT NULL, `light_surfaceContainerLowest` TEXT NOT NULL, `light_primaryFixed` TEXT NOT NULL, `light_primaryFixedDim` TEXT NOT NULL, `light_onPrimaryFixed` TEXT NOT NULL, `light_onPrimaryFixedVariant` TEXT NOT NULL, `light_secondaryFixed` TEXT NOT NULL, `light_secondaryFixedDim` TEXT NOT NULL, `light_onSecondaryFixed` TEXT NOT NULL, `light_onSecondaryFixedVariant` TEXT NOT NULL, `light_tertiaryFixed` TEXT NOT NULL, `light_tertiaryFixedDim` TEXT NOT NULL, `light_onTertiaryFixed` TEXT NOT NULL, `light_onTertiaryFixedVariant` TEXT NOT NULL, `dark_primary` TEXT NOT NULL, `dark_onPrimary` TEXT NOT NULL, `dark_primaryContainer` TEXT NOT NULL, `dark_onPrimaryContainer` TEXT NOT NULL, `dark_secondary` TEXT NOT NULL, `dark_onSecondary` TEXT NOT NULL, `dark_secondaryContainer` TEXT NOT NULL, `dark_onSecondaryContainer` TEXT NOT NULL, `dark_tertiary` TEXT NOT NULL, `dark_onTertiary` TEXT NOT NULL, `dark_tertiaryContainer` TEXT NOT NULL, `dark_onTertiaryContainer` TEXT NOT NULL, `dark_background` TEXT NOT NULL, `dark_onBackground` TEXT NOT NULL, `dark_surface` TEXT NOT NULL, `dark_onSurface` TEXT NOT NULL, `dark_surfaceVariant` TEXT NOT NULL, `dark_onSurfaceVariant` TEXT NOT NULL, `dark_error` TEXT NOT NULL, `dark_onError` TEXT NOT NULL, `dark_outline` TEXT NOT NULL, `dark_errorContainer` TEXT NOT NULL, `dark_onErrorContainer` TEXT NOT NULL, `dark_inversePrimary` TEXT NOT NULL, `dark_inverseSurface` TEXT NOT NULL, `dark_inverseOnSurface` TEXT NOT NULL, `dark_surfaceTint` TEXT NOT NULL, `dark_outlineVariant` TEXT NOT NULL, `dark_scrim` TEXT NOT NULL, `dark_surfaceBright` TEXT NOT NULL, `dark_surfaceDim` TEXT NOT NULL, `dark_surfaceContainer` TEXT NOT NULL, `dark_surfaceContainerHigh` TEXT NOT NULL, `dark_surfaceContainerHighest` TEXT NOT NULL, `dark_surfaceContainerLow` TEXT NOT NULL, `dark_surfaceContainerLowest` TEXT NOT NULL, `dark_primaryFixed` TEXT NOT NULL, `dark_primaryFixedDim` TEXT NOT NULL, `dark_onPrimaryFixed` TEXT NOT NULL, `dark_onPrimaryFixedVariant` TEXT NOT NULL, `dark_secondaryFixed` TEXT NOT NULL, `dark_secondaryFixedDim` TEXT NOT NULL, `dark_onSecondaryFixed` TEXT NOT NULL, `dark_onSecondaryFixedVariant` TEXT NOT NULL, `dark_tertiaryFixed` TEXT NOT NULL, `dark_tertiaryFixedDim` TEXT NOT NULL, `dark_onTertiaryFixed` TEXT NOT NULL, `dark_onTertiaryFixedVariant` TEXT NOT NULL, PRIMARY KEY(`albumArtUriString`, `paletteStyle`))",
+        "fields": [
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "albumArtUriString",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paletteStyle",
+            "columnName": "paletteStyle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primary",
+            "columnName": "light_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimary",
+            "columnName": "light_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryContainer",
+            "columnName": "light_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryContainer",
+            "columnName": "light_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondary",
+            "columnName": "light_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondary",
+            "columnName": "light_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryContainer",
+            "columnName": "light_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryContainer",
+            "columnName": "light_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiary",
+            "columnName": "light_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiary",
+            "columnName": "light_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryContainer",
+            "columnName": "light_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryContainer",
+            "columnName": "light_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.background",
+            "columnName": "light_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onBackground",
+            "columnName": "light_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surface",
+            "columnName": "light_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurface",
+            "columnName": "light_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceVariant",
+            "columnName": "light_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSurfaceVariant",
+            "columnName": "light_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.error",
+            "columnName": "light_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onError",
+            "columnName": "light_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outline",
+            "columnName": "light_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.errorContainer",
+            "columnName": "light_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onErrorContainer",
+            "columnName": "light_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inversePrimary",
+            "columnName": "light_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseSurface",
+            "columnName": "light_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.inverseOnSurface",
+            "columnName": "light_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceTint",
+            "columnName": "light_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.outlineVariant",
+            "columnName": "light_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.scrim",
+            "columnName": "light_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceBright",
+            "columnName": "light_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceDim",
+            "columnName": "light_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainer",
+            "columnName": "light_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHigh",
+            "columnName": "light_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerHighest",
+            "columnName": "light_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLow",
+            "columnName": "light_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.surfaceContainerLowest",
+            "columnName": "light_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixed",
+            "columnName": "light_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.primaryFixedDim",
+            "columnName": "light_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixed",
+            "columnName": "light_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onPrimaryFixedVariant",
+            "columnName": "light_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixed",
+            "columnName": "light_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.secondaryFixedDim",
+            "columnName": "light_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixed",
+            "columnName": "light_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onSecondaryFixedVariant",
+            "columnName": "light_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixed",
+            "columnName": "light_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.tertiaryFixedDim",
+            "columnName": "light_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixed",
+            "columnName": "light_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightThemeValues.onTertiaryFixedVariant",
+            "columnName": "light_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primary",
+            "columnName": "dark_primary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimary",
+            "columnName": "dark_onPrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryContainer",
+            "columnName": "dark_primaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryContainer",
+            "columnName": "dark_onPrimaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondary",
+            "columnName": "dark_secondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondary",
+            "columnName": "dark_onSecondary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryContainer",
+            "columnName": "dark_secondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryContainer",
+            "columnName": "dark_onSecondaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiary",
+            "columnName": "dark_tertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiary",
+            "columnName": "dark_onTertiary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryContainer",
+            "columnName": "dark_tertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryContainer",
+            "columnName": "dark_onTertiaryContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.background",
+            "columnName": "dark_background",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onBackground",
+            "columnName": "dark_onBackground",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surface",
+            "columnName": "dark_surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurface",
+            "columnName": "dark_onSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceVariant",
+            "columnName": "dark_surfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSurfaceVariant",
+            "columnName": "dark_onSurfaceVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.error",
+            "columnName": "dark_error",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onError",
+            "columnName": "dark_onError",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outline",
+            "columnName": "dark_outline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.errorContainer",
+            "columnName": "dark_errorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onErrorContainer",
+            "columnName": "dark_onErrorContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inversePrimary",
+            "columnName": "dark_inversePrimary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseSurface",
+            "columnName": "dark_inverseSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.inverseOnSurface",
+            "columnName": "dark_inverseOnSurface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceTint",
+            "columnName": "dark_surfaceTint",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.outlineVariant",
+            "columnName": "dark_outlineVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.scrim",
+            "columnName": "dark_scrim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceBright",
+            "columnName": "dark_surfaceBright",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceDim",
+            "columnName": "dark_surfaceDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainer",
+            "columnName": "dark_surfaceContainer",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHigh",
+            "columnName": "dark_surfaceContainerHigh",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerHighest",
+            "columnName": "dark_surfaceContainerHighest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLow",
+            "columnName": "dark_surfaceContainerLow",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.surfaceContainerLowest",
+            "columnName": "dark_surfaceContainerLowest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixed",
+            "columnName": "dark_primaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.primaryFixedDim",
+            "columnName": "dark_primaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixed",
+            "columnName": "dark_onPrimaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onPrimaryFixedVariant",
+            "columnName": "dark_onPrimaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixed",
+            "columnName": "dark_secondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.secondaryFixedDim",
+            "columnName": "dark_secondaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixed",
+            "columnName": "dark_onSecondaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onSecondaryFixedVariant",
+            "columnName": "dark_onSecondaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixed",
+            "columnName": "dark_tertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.tertiaryFixedDim",
+            "columnName": "dark_tertiaryFixedDim",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixed",
+            "columnName": "dark_onTertiaryFixed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkThemeValues.onTertiaryFixedVariant",
+            "columnName": "dark_onTertiaryFixedVariant",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumArtUriString",
+            "paletteStyle"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_art_themes_albumArtUriString_paletteStyle",
+            "unique": false,
+            "columnNames": [
+              "albumArtUriString",
+              "paletteStyle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_art_themes_albumArtUriString_paletteStyle` ON `${TABLE_NAME}` (`albumArtUriString`, `paletteStyle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_artist` TEXT, `album_name` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `content_uri_string` TEXT NOT NULL, `album_art_uri_string` TEXT, `duration` INTEGER NOT NULL, `genre` TEXT, `file_path` TEXT NOT NULL, `parent_directory_path` TEXT NOT NULL, `is_favorite` INTEGER NOT NULL DEFAULT 0, `lyrics` TEXT DEFAULT null, `track_number` INTEGER NOT NULL DEFAULT 0, `disc_number` INTEGER DEFAULT null, `year` INTEGER NOT NULL DEFAULT 0, `date_added` INTEGER NOT NULL DEFAULT 0, `mime_type` TEXT, `bitrate` INTEGER, `sample_rate` INTEGER, `telegram_chat_id` INTEGER, `telegram_file_id` INTEGER, `artists_json` TEXT, `source_type` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`album_id`) REFERENCES `albums`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "album_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentUriString",
+            "columnName": "content_uri_string",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentDirectoryPath",
+            "columnName": "parent_directory_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sample_rate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "telegramChatId",
+            "columnName": "telegram_chat_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "telegramFileId",
+            "columnName": "telegram_file_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "artistsJson",
+            "columnName": "artists_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceType",
+            "columnName": "source_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_songs_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_songs_album_id",
+            "unique": false,
+            "columnNames": [
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_album_id` ON `${TABLE_NAME}` (`album_id`)"
+          },
+          {
+            "name": "index_songs_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_songs_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_songs_genre",
+            "unique": false,
+            "columnNames": [
+              "genre"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_genre` ON `${TABLE_NAME}` (`genre`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path` ON `${TABLE_NAME}` (`parent_directory_path`)"
+          },
+          {
+            "name": "index_songs_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_songs_content_uri_string",
+            "unique": false,
+            "columnNames": [
+              "content_uri_string"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_content_uri_string` ON `${TABLE_NAME}` (`content_uri_string`)"
+          },
+          {
+            "name": "index_songs_date_added",
+            "unique": false,
+            "columnNames": [
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_date_added` ON `${TABLE_NAME}` (`date_added`)"
+          },
+          {
+            "name": "index_songs_duration",
+            "unique": false,
+            "columnNames": [
+              "duration"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_duration` ON `${TABLE_NAME}` (`duration`)"
+          },
+          {
+            "name": "index_songs_source_type",
+            "unique": false,
+            "columnNames": [
+              "source_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_source_type` ON `${TABLE_NAME}` (`source_type`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_album_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "album_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_album_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `album_id`)"
+          },
+          {
+            "name": "index_songs_parent_directory_path_source_type_id",
+            "unique": false,
+            "columnNames": [
+              "parent_directory_path",
+              "source_type",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_songs_parent_directory_path_source_type_id` ON `${TABLE_NAME}` (`parent_directory_path`, `source_type`, `id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "albums",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "album_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "songs_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, tokenize=unicode61)",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": []
+      },
+      {
+        "tableName": "albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist_name` TEXT NOT NULL, `artist_id` INTEGER NOT NULL, `album_art_uri_string` TEXT, `song_count` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `year` INTEGER NOT NULL, `album_artist` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri_string",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtist",
+            "columnName": "album_artist",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_albums_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_albums_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_albums_artist_name",
+            "unique": false,
+            "columnNames": [
+              "artist_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_artist_name` ON `${TABLE_NAME}` (`artist_name`)"
+          },
+          {
+            "name": "index_albums_album_artist",
+            "unique": false,
+            "columnNames": [
+              "album_artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_albums_album_artist` ON `${TABLE_NAME}` (`album_artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `track_count` INTEGER NOT NULL, `image_url` TEXT, `custom_image_uri` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customImageUri",
+            "columnName": "custom_image_uri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_artists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_artists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "transition_rules",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `fromTrackId` TEXT, `toTrackId` TEXT, `mode` TEXT NOT NULL, `durationMs` INTEGER NOT NULL, `curveIn` TEXT NOT NULL, `curveOut` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromTrackId",
+            "columnName": "fromTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toTrackId",
+            "columnName": "toTrackId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "settings.mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveIn",
+            "columnName": "curveIn",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings.curveOut",
+            "columnName": "curveOut",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_transition_rules_playlistId_fromTrackId_toTrackId",
+            "unique": true,
+            "columnNames": [
+              "playlistId",
+              "fromTrackId",
+              "toTrackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_transition_rules_playlistId_fromTrackId_toTrackId` ON `${TABLE_NAME}` (`playlistId`, `fromTrackId`, `toTrackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "song_artist_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `is_primary` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`song_id`, `artist_id`), FOREIGN KEY(`song_id`) REFERENCES `songs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artist_id`) REFERENCES `artists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrimary",
+            "columnName": "is_primary",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id",
+            "artist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_cross_ref_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_artist_id",
+            "unique": false,
+            "columnNames": [
+              "artist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_artist_id` ON `${TABLE_NAME}` (`artist_id`)"
+          },
+          {
+            "name": "index_song_artist_cross_ref_is_primary",
+            "unique": false,
+            "columnNames": [
+              "is_primary"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_cross_ref_is_primary` ON `${TABLE_NAME}` (`is_primary`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "songs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "song_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "telegram_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chat_id` INTEGER NOT NULL, `message_id` INTEGER NOT NULL, `file_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `duration` INTEGER NOT NULL, `file_path` TEXT NOT NULL, `mime_type` TEXT NOT NULL, `date_added` INTEGER NOT NULL, `album_art_uri` TEXT, `thread_id` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileId",
+            "columnName": "file_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUriString",
+            "columnName": "album_art_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "thread_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_telegram_songs_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_songs_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          },
+          {
+            "name": "index_telegram_songs_message_id",
+            "unique": false,
+            "columnNames": [
+              "message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_songs_message_id` ON `${TABLE_NAME}` (`message_id`)"
+          },
+          {
+            "name": "index_telegram_songs_file_id",
+            "unique": false,
+            "columnNames": [
+              "file_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_songs_file_id` ON `${TABLE_NAME}` (`file_id`)"
+          },
+          {
+            "name": "index_telegram_songs_chat_id_message_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id",
+              "message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_songs_chat_id_message_id` ON `${TABLE_NAME}` (`chat_id`, `message_id`)"
+          },
+          {
+            "name": "index_telegram_songs_thread_id",
+            "unique": false,
+            "columnNames": [
+              "thread_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_songs_thread_id` ON `${TABLE_NAME}` (`thread_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "telegram_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `username` TEXT, `song_count` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, `photo_path` TEXT, PRIMARY KEY(`chat_id`))",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoPath",
+            "columnName": "photo_path",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_engagements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` TEXT NOT NULL, `play_count` INTEGER NOT NULL, `total_play_duration_ms` INTEGER NOT NULL, `last_played_timestamp` INTEGER NOT NULL, PRIMARY KEY(`song_id`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayDurationMs",
+            "columnName": "total_play_duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedTimestamp",
+            "columnName": "last_played_timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_engagements_play_count",
+            "unique": false,
+            "columnNames": [
+              "play_count"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_engagements_play_count` ON `${TABLE_NAME}` (`play_count`)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` INTEGER NOT NULL, `content` TEXT NOT NULL, `isSynced` INTEGER NOT NULL, `source` TEXT, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSynced",
+            "columnName": "isSynced",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        }
+      },
+      {
+        "tableName": "netease_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `netease_id` INTEGER NOT NULL, `playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `album_art_url` TEXT, `mime_type` TEXT NOT NULL, `bitrate` INTEGER, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "neteaseId",
+            "columnName": "netease_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_netease_songs_netease_id",
+            "unique": false,
+            "columnNames": [
+              "netease_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_netease_songs_netease_id` ON `${TABLE_NAME}` (`netease_id`)"
+          },
+          {
+            "name": "index_netease_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_netease_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_netease_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_netease_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "netease_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `song_count` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "gdrive_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `drive_file_id` TEXT NOT NULL, `folder_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `album_art_url` TEXT, `mime_type` TEXT NOT NULL, `bitrate` INTEGER, `file_size` INTEGER NOT NULL, `date_added` INTEGER NOT NULL, `date_modified` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "driveFileId",
+            "columnName": "drive_file_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "date_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_gdrive_songs_drive_file_id",
+            "unique": false,
+            "columnNames": [
+              "drive_file_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_gdrive_songs_drive_file_id` ON `${TABLE_NAME}` (`drive_file_id`)"
+          },
+          {
+            "name": "index_gdrive_songs_folder_id",
+            "unique": false,
+            "columnNames": [
+              "folder_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_gdrive_songs_folder_id` ON `${TABLE_NAME}` (`folder_id`)"
+          },
+          {
+            "name": "index_gdrive_songs_folder_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "folder_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_gdrive_songs_folder_id_date_added` ON `${TABLE_NAME}` (`folder_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "gdrive_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `song_count` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `last_modified` INTEGER NOT NULL, `is_ai_generated` INTEGER NOT NULL, `is_queue_generated` INTEGER NOT NULL, `cover_image_uri` TEXT, `cover_color_argb` INTEGER, `cover_icon_name` TEXT, `cover_shape_type` TEXT, `cover_shape_detail_1` REAL, `cover_shape_detail_2` REAL, `cover_shape_detail_3` REAL, `cover_shape_detail_4` REAL, `source` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAiGenerated",
+            "columnName": "is_ai_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isQueueGenerated",
+            "columnName": "is_queue_generated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverImageUri",
+            "columnName": "cover_image_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverColorArgb",
+            "columnName": "cover_color_argb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coverIconName",
+            "columnName": "cover_icon_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeType",
+            "columnName": "cover_shape_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverShapeDetail1",
+            "columnName": "cover_shape_detail_1",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail2",
+            "columnName": "cover_shape_detail_2",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail3",
+            "columnName": "cover_shape_detail_3",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverShapeDetail4",
+            "columnName": "cover_shape_detail_4",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_last_modified",
+            "unique": false,
+            "columnNames": [
+              "last_modified"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_last_modified` ON `${TABLE_NAME}` (`last_modified`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` TEXT NOT NULL, `song_id` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `song_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "song_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_songs_playlist_id_sort_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "sort_order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_playlist_id_sort_order` ON `${TABLE_NAME}` (`playlist_id`, `sort_order`)"
+          },
+          {
+            "name": "index_playlist_songs_song_id",
+            "unique": false,
+            "columnNames": [
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_songs_song_id` ON `${TABLE_NAME}` (`song_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "qqmusic_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `song_mid` TEXT NOT NULL, `playlist_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_mid` TEXT, `duration` INTEGER NOT NULL, `album_art_url` TEXT, `mime_type` TEXT NOT NULL, `bitrate` INTEGER, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songMid",
+            "columnName": "song_mid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumMid",
+            "columnName": "album_mid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumArtUrl",
+            "columnName": "album_art_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qqmusic_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `song_count` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "navidrome_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `navidrome_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `cover_art_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `suffix` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "navidromeId",
+            "columnName": "navidrome_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "suffix",
+            "columnName": "suffix",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_navidrome_songs_navidrome_id",
+            "unique": false,
+            "columnNames": [
+              "navidrome_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_navidrome_id` ON `${TABLE_NAME}` (`navidrome_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_navidrome_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_navidrome_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "navidrome_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `comment` TEXT, `owner` TEXT, `cover_art_id` TEXT, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `public` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtId",
+            "columnName": "cover_art_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "public",
+            "columnName": "public",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "telegram_topics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `chat_id` INTEGER NOT NULL, `thread_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `song_count` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, `icon_emoji` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "threadId",
+            "columnName": "thread_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconEmoji",
+            "columnName": "icon_emoji",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_telegram_topics_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_telegram_topics_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "jellyfin_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `jellyfin_id` TEXT NOT NULL, `playlist_id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `artist_id` TEXT, `album` TEXT NOT NULL, `album_id` TEXT, `duration` INTEGER NOT NULL, `track_number` INTEGER NOT NULL, `disc_number` INTEGER NOT NULL, `year` INTEGER NOT NULL, `genre` TEXT, `bitRate` INTEGER, `mime_type` TEXT, `path` TEXT NOT NULL, `date_added` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jellyfinId",
+            "columnName": "jellyfin_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackNumber",
+            "columnName": "track_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discNumber",
+            "columnName": "disc_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bitRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateAdded",
+            "columnName": "date_added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_jellyfin_songs_jellyfin_id",
+            "unique": false,
+            "columnNames": [
+              "jellyfin_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_jellyfin_id` ON `${TABLE_NAME}` (`jellyfin_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_jellyfin_songs_playlist_id_date_added",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "date_added"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_jellyfin_songs_playlist_id_date_added` ON `${TABLE_NAME}` (`playlist_id`, `date_added`)"
+          }
+        ]
+      },
+      {
+        "tableName": "jellyfin_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `song_count` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `last_sync_time` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "song_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncTime",
+            "columnName": "last_sync_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`promptHash` TEXT NOT NULL, `responseJson` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`promptHash`))",
+        "fields": [
+          {
+            "fieldPath": "promptHash",
+            "columnName": "promptHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "responseJson",
+            "columnName": "responseJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "promptHash"
+          ]
+        }
+      },
+      {
+        "tableName": "ai_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `provider` TEXT NOT NULL, `model` TEXT NOT NULL, `promptType` TEXT NOT NULL, `promptTokens` INTEGER NOT NULL, `outputTokens` INTEGER NOT NULL, `thoughtTokens` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptType",
+            "columnName": "promptType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptTokens",
+            "columnName": "promptTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outputTokens",
+            "columnName": "outputTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thoughtTokens",
+            "columnName": "thoughtTokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0077364dc30d6413be4923af8a80ec91')"
+    ]
+  }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/ExternalPlayerActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ExternalPlayerActivity.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import com.theveloper.pixelplay.presentation.viewmodel.PlayerViewModel
 import com.theveloper.pixelplay.presentation.components.external.ExternalPlayerOverlay
 import com.theveloper.pixelplay.ui.theme.PixelPlayTheme
+import timber.log.Timber
 import android.content.Intent.EXTRA_STREAM
 import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.data.preferences.AppThemeMode
@@ -72,7 +73,10 @@ class ExternalPlayerActivity : ComponentActivity() {
         if (intent == null) return
 
         when {
-            intent.action == Intent.ACTION_VIEW && intent.data != null -> {
+            // Reject an explicitly non-audio MIME type (intent spoofing), but still allow a null/absent
+            // type, which is common when file managers open a local audio file via a content:// URI.
+            intent.action == Intent.ACTION_VIEW && intent.data != null &&
+                (intent.type == null || intent.type?.startsWith("audio/") == true) -> {
                 intent.data?.let { uri ->
                     persistUriPermissionIfNeeded(intent, uri)
                     playerViewModel.playExternalUri(uri)
@@ -124,6 +128,7 @@ class ExternalPlayerActivity : ComponentActivity() {
                 val takeFlags = intent.flags and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                 if (takeFlags != 0) {
                     runCatching { contentResolver.takePersistableUriPermission(uri, takeFlags) }
+                        .onFailure { Timber.w(it, "Unable to persist URI permission for %s", uri) }
                 }
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -430,7 +430,7 @@ class MainActivity : ComponentActivity() {
                 val takeFlags = intent.flags and (android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION or android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                 if (takeFlags != 0) {
                     try {
-                        contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        contentResolver.takePersistableUriPermission(uri, takeFlags)
                     } catch (securityException: SecurityException) {
                         android.util.Log.w("MainActivity", "Unable to persist URI permission for $uri", securityException)
                     } catch (illegalArgumentException: IllegalArgumentException) {

--- a/app/src/main/java/com/theveloper/pixelplay/data/backup/module/PlaylistsModuleHandler.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/backup/module/PlaylistsModuleHandler.kt
@@ -149,6 +149,10 @@ class PlaylistsModuleHandler @Inject constructor(
         return try {
             val file = File(path)
             if (!file.exists() || file.length() == 0L) return null
+            if (file.length() > MAX_COVER_IMAGE_BYTES) {
+                Log.w(TAG, "Cover image too large (${file.length()} bytes), skipping: $path")
+                return null
+            }
             val bytes = file.readBytes()
             Base64.encodeToString(bytes, Base64.NO_WRAP)
         } catch (e: Exception) {
@@ -165,7 +169,10 @@ class PlaylistsModuleHandler @Inject constructor(
             val base64 = coverImages[playlist.id] ?: return@map playlist
             try {
                 val bytes = Base64.decode(base64, Base64.NO_WRAP)
-                val fileName = "playlist_cover_${playlist.id}.jpg"
+                // Sanitize the (untrusted) playlist id before using it in a filename to prevent
+                // path traversal (e.g. an id containing "../") into arbitrary app-private paths.
+                val safeId = playlist.id.replace(Regex("[^A-Za-z0-9_-]"), "_")
+                val fileName = "playlist_cover_${safeId}.jpg"
                 val file = File(context.filesDir, fileName)
                 file.writeBytes(bytes)
                 playlist.copy(coverImageUri = file.absolutePath)
@@ -372,6 +379,8 @@ class PlaylistsModuleHandler @Inject constructor(
     companion object {
         private const val TAG = "PlaylistsModuleHandler"
         private const val DURATION_TOLERANCE_MS = 2000L
+        /** Upper bound for a playlist cover image we will read into memory / Base64-encode. */
+        private const val MAX_COVER_IMAGE_BYTES = 10L * 1024 * 1024
 
         /** Playlist sources that are backed up. Cloud-sourced playlists are excluded. */
         private val LOCAL_SOURCES = setOf("LOCAL", "AI")

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumArtThemeEntity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/AlbumArtThemeEntity.kt
@@ -3,7 +3,6 @@ package com.theveloper.pixelplay.data.database
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.Index
-import androidx.room.PrimaryKey
 
 // Para simplificar, almacenaremos los colores como Strings hexadecimales.
 // Almacena los valores de color para UN esquema (sea light o dark)
@@ -60,12 +59,15 @@ data class StoredColorSchemeValues(
 
 @Entity(
     tableName = "album_art_themes",
+    // Composite key: the same artwork URI can have distinct cached schemes per palette style
+    // (TONAL_SPOT, VIBRANT, …). With a single-column PK they overwrote each other.
+    primaryKeys = ["albumArtUriString", "paletteStyle"],
     indices = [
         Index(value = ["albumArtUriString", "paletteStyle"])
     ]
 )
 data class AlbumArtThemeEntity(
-    @PrimaryKey val albumArtUriString: String,
+    val albumArtUriString: String,
     val paletteStyle: String,
     @Embedded(prefix = "light_") val lightThemeValues: StoredColorSchemeValues,
     @Embedded(prefix = "dark_") val darkThemeValues: StoredColorSchemeValues

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/PixelPlayDatabase.kt
@@ -36,7 +36,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AiCacheEntity::class,
         AiUsageEntity::class
     ],
-    version = 41,
+    version = 42,
     exportSchema = true
 )
 abstract class PixelPlayDatabase : RoomDatabase() {
@@ -621,6 +621,51 @@ abstract class PixelPlayDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS index_songs_parent_directory_path_source_type_id " +
                         "ON songs(parent_directory_path, source_type, id)"
+                )
+            }
+        }
+
+        /**
+         * Give album_art_themes a COMPOSITE primary key (albumArtUriString, paletteStyle) so cached
+         * schemes for different palette styles of the same artwork no longer overwrite each other.
+         * The table is a regenerable cache, so we drop and recreate (matches the 14→15/15→16 pattern).
+         */
+        val MIGRATION_41_42 = object : Migration(41, 42) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("DROP TABLE IF EXISTS album_art_themes")
+
+                val colorColumns = listOf(
+                    "primary", "onPrimary", "primaryContainer", "onPrimaryContainer",
+                    "secondary", "onSecondary", "secondaryContainer", "onSecondaryContainer",
+                    "tertiary", "onTertiary", "tertiaryContainer", "onTertiaryContainer",
+                    "background", "onBackground", "surface", "onSurface",
+                    "surfaceVariant", "onSurfaceVariant", "error", "onError",
+                    "outline", "errorContainer", "onErrorContainer",
+                    "inversePrimary", "inverseSurface", "inverseOnSurface",
+                    "surfaceTint", "outlineVariant", "scrim",
+                    "surfaceBright", "surfaceDim",
+                    "surfaceContainer", "surfaceContainerHigh", "surfaceContainerHighest", "surfaceContainerLow", "surfaceContainerLowest",
+                    "primaryFixed", "primaryFixedDim", "onPrimaryFixed", "onPrimaryFixedVariant",
+                    "secondaryFixed", "secondaryFixedDim", "onSecondaryFixed", "onSecondaryFixedVariant",
+                    "tertiaryFixed", "tertiaryFixedDim", "onTertiaryFixed", "onTertiaryFixedVariant"
+                )
+
+                val themePrefixes = listOf("light_", "dark_")
+                val columnDefinitions = StringBuilder()
+                columnDefinitions.append("albumArtUriString TEXT NOT NULL, ")
+                columnDefinitions.append("paletteStyle TEXT NOT NULL, ")
+                themePrefixes.forEach { prefix ->
+                    colorColumns.forEach { column ->
+                        columnDefinitions.append("${prefix}${column} TEXT NOT NULL, ")
+                    }
+                }
+                val columnsSql = columnDefinitions.toString().trimEnd(',', ' ')
+
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS album_art_themes ($columnsSql, PRIMARY KEY(albumArtUriString, paletteStyle))"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_album_art_themes_albumArtUriString_paletteStyle ON album_art_themes(albumArtUriString, paletteStyle)"
                 )
             }
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataReader.kt
@@ -3,7 +3,6 @@ package com.theveloper.pixelplay.data.media
 import android.content.Context
 import android.net.Uri
 import android.os.ParcelFileDescriptor
-import android.util.Log
 import com.kyant.taglib.TagLib
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
@@ -69,7 +68,7 @@ object AudioMetadataReader {
                 val propertyMap = metadata?.propertyMap ?: emptyMap()
 
                 // Log ALL keys TagLib returned so we can diagnose mapping issues
-                Log.w(TAG, "TagLib propertyMap keys for ${file.name}: ${propertyMap.keys}")
+                Timber.tag(TAG).w("TagLib propertyMap keys for ${file.name}: ${propertyMap.keys}")
 
                 val title = propertyMap["TITLE"]?.firstOrNull()?.takeIf { it.isNotBlank() }
                 val artist = propertyMap["ARTIST"]?.firstOrNull()?.takeIf { it.isNotBlank() }
@@ -99,7 +98,7 @@ object AudioMetadataReader {
                     keys = listOf("REPLAYGAIN_ALBUM_GAIN", "REPLAYGAIN_ALBUM_GAIN_DB", "R128_ALBUM_GAIN")
                 )
 
-                Log.w(TAG, "TagLib result for ${file.name}: title=$title, artist=$artist, album=$album, genre=$genre")
+                Timber.tag(TAG).w("TagLib result for ${file.name}: title=$title, artist=$artist, album=$album, genre=$genre")
 
                 // Get artwork only when requested to avoid allocating large ByteArrays unnecessarily
                 val artwork = if (readArtwork) {
@@ -120,7 +119,7 @@ object AudioMetadataReader {
                 // on some MP3s. If essential fields or requested artwork are missing, try
                 // JAudioTagger before giving up so we preserve full metadata when possible.
                 val fallback = if (title == null || artist == null || (readArtwork && artwork == null)) {
-                    Log.w(TAG, "TagLib incomplete for ${file.name}, trying JAudioTagger fallback...")
+                    Timber.tag(TAG).w("TagLib incomplete for ${file.name}, trying JAudioTagger fallback...")
                     readWithJAudioTagger(file)
                 } else null
 
@@ -162,7 +161,7 @@ object AudioMetadataReader {
             val tag = audioFile.tag
             val header = audioFile.audioHeader
 
-            Log.w(TAG, "JAudioTagger: tag class=${tag?.javaClass?.simpleName}, " +
+            Timber.tag(TAG).w("JAudioTagger: tag class=${tag?.javaClass?.simpleName}, " +
                     "header=${header?.format}, sampleRate=${header?.sampleRateAsNumber}")
 
             val title = tag?.getFirst(FieldKey.TITLE)?.takeIf { it.isNotBlank() }
@@ -193,7 +192,7 @@ object AudioMetadataReader {
                 }
             }
 
-            Log.w(TAG, "JAudioTagger result for ${file.name}: title=$title, artist=$artist, " +
+            Timber.tag(TAG).w("JAudioTagger result for ${file.name}: title=$title, artist=$artist, " +
                     "album=$album, genre=$genre, artwork=${artwork != null}")
 
             AudioMetadata(
@@ -213,7 +212,7 @@ object AudioMetadataReader {
                 artwork = artwork
             )
         } catch (e: Exception) {
-            Log.e(TAG, "JAudioTagger fallback FAILED for: ${file.name}", e)
+            Timber.tag(TAG).e(e, "JAudioTagger fallback FAILED for: ${file.name}")
             null
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/AudioMetadataUtils.kt
@@ -15,16 +15,17 @@ import timber.log.Timber
 internal fun createTempAudioFileFromUri(context: Context, uri: Uri): File? {
     return try {
         val fileExtension = resolveAudioFileExtension(context, uri)
-        val inputStream = context.contentResolver.openInputStream(uri)
-        val tempFile = File.createTempFile("pixelplay_audio_", fileExtension, context.cacheDir)
-        tempFile.deleteOnExit()
-        val outputStream = FileOutputStream(tempFile)
-        inputStream?.use { input ->
-            outputStream.use { output ->
+        // Open the input first and nest everything inside its use{} so the output stream is only
+        // created (and always closed) once we have a valid input — avoids an FD leak when
+        // openInputStream returns null or createTempFile throws.
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            val tempFile = File.createTempFile("pixelplay_audio_", fileExtension, context.cacheDir)
+            tempFile.deleteOnExit()
+            FileOutputStream(tempFile).use { output ->
                 input.copyTo(output)
             }
+            tempFile
         }
-        tempFile
     } catch (error: Exception) {
         Timber.tag("AudioMetadataUtils").e(error, "Error creating temp file from URI: $uri")
         null

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -559,9 +559,36 @@ class SongMetadataEditor(
                 Timber.tag(TAG).e("METADATA_EDIT: Writer failed on temp file ${tempFile.absolutePath}")
                 return false
             }
-            // Stream edited bytes back to the original path (truncate + overwrite).
-            tempFile.inputStream().use { input ->
-                FileOutputStream(originalFile, false).use { out -> input.copyTo(out) }
+            // Back up the original before truncating it so an interrupted write-back can be rolled
+            // back — otherwise a mid-write failure leaves the source audio irrecoverably corrupted.
+            val backupFile = File("${originalFile.absolutePath}.metabak_${System.nanoTime()}")
+            val backupOk = runCatching {
+                originalFile.inputStream().use { input ->
+                    FileOutputStream(backupFile).use { out -> input.copyTo(out) }
+                }
+            }.isSuccess
+            if (!backupOk) {
+                Timber.tag(TAG).w("METADATA_EDIT: Could not back up original before write-back: $originalPath")
+            }
+            try {
+                // Stream edited bytes back to the original path (truncate + overwrite).
+                tempFile.inputStream().use { input ->
+                    FileOutputStream(originalFile, false).use { out -> input.copyTo(out) }
+                }
+            } catch (writeError: Exception) {
+                if (backupOk) {
+                    Timber.tag(TAG).w(writeError, "METADATA_EDIT: write-back failed; restoring original from backup")
+                    runCatching {
+                        backupFile.inputStream().use { input ->
+                            FileOutputStream(originalFile, false).use { out -> input.copyTo(out) }
+                        }
+                    }
+                }
+                throw writeError
+            } finally {
+                if (backupFile.exists() && !backupFile.delete()) {
+                    Timber.tag(TAG).w("METADATA_EDIT: Could not delete backup file ${backupFile.absolutePath}")
+                }
             }
             Timber.tag(TAG).d(
                 "METADATA_EDIT: Restored ${tempFile.length()} edited bytes back to $originalPath"
@@ -1041,10 +1068,37 @@ class SongMetadataEditor(
             Timber.tag(TAG)
                 .e("VORBISJAVA: Temp file size: ${tempFile.length()} bytes, original: ${audioFile.length()} bytes")
             
-            tempFile.inputStream().use { input ->
-                FileOutputStream(audioFile, false).use { output ->
-                    input.copyTo(output)
-                    output.fd.sync()
+            // Back up the original before truncating it so an interrupted write-back can be rolled
+            // back — otherwise a mid-write failure leaves the source Opus file irrecoverably corrupted.
+            val backupFile = File("${audioFile.absolutePath}.metabak_${System.nanoTime()}")
+            val backupOk = runCatching {
+                audioFile.inputStream().use { input ->
+                    FileOutputStream(backupFile).use { out -> input.copyTo(out) }
+                }
+            }.isSuccess
+            if (!backupOk) {
+                Timber.tag(TAG).w("VORBISJAVA: Could not back up original before write-back: ${audioFile.path}")
+            }
+            try {
+                tempFile.inputStream().use { input ->
+                    FileOutputStream(audioFile, false).use { output ->
+                        input.copyTo(output)
+                        output.fd.sync()
+                    }
+                }
+            } catch (writeError: Exception) {
+                if (backupOk) {
+                    Timber.tag(TAG).w(writeError, "VORBISJAVA: write-back failed; restoring original from backup")
+                    runCatching {
+                        backupFile.inputStream().use { input ->
+                            FileOutputStream(audioFile, false).use { out -> input.copyTo(out) }
+                        }
+                    }
+                }
+                throw writeError
+            } finally {
+                if (backupFile.exists() && !backupFile.delete()) {
+                    Timber.tag(TAG).w("VORBISJAVA: Could not delete backup file ${backupFile.absolutePath}")
                 }
             }
 
@@ -1154,6 +1208,8 @@ class SongMetadataEditor(
     }
     private fun saveCoverArtPreview(songId: Long, coverArtUpdate: CoverArtUpdate): String? {
         return try {
+            // bytes is nullable (e.g. a deletion update); guard before write to avoid an NPE.
+            val artBytes = coverArtUpdate.bytes ?: return null
             val extension = imageExtensionFromMimeType(coverArtUpdate.mimeType) ?: "jpg"
             val directory = File(context.cacheDir, "").apply {
                 if (!exists()) mkdirs()
@@ -1167,7 +1223,7 @@ class SongMetadataEditor(
             // Save new cover art
             val file = File(directory, "song_art_${songId}_${System.currentTimeMillis()}.$extension")
             FileOutputStream(file).use { outputStream ->
-                outputStream.write(coverArtUpdate.bytes)
+                outputStream.write(artBytes)
             }
 
             file.toUri().toString()
@@ -1367,6 +1423,7 @@ data class CoverArtUpdate(
 
         if (!bytes.contentEquals(other.bytes)) return false
         if (mimeType != other.mimeType) return false
+        if (isDeletion != other.isDeletion) return false
 
         return true
     }
@@ -1374,6 +1431,7 @@ data class CoverArtUpdate(
     override fun hashCode(): Int {
         var result = bytes.contentHashCode()
         result = 31 * result + mimeType.hashCode()
+        result = 31 * result + isDeletion.hashCode()
         return result
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/EqualizerPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/EqualizerPreferencesRepository.kt
@@ -216,60 +216,77 @@ class EqualizerPreferencesRepository @Inject constructor(
             preferences[Keys.PINNED_PRESETS] = json.encodeToString(presetNames)
         }
 
+    // Decode the persisted preset lists from a Preferences snapshot, mirroring the public flows.
+    // Used inside dataStore.edit{} so the read-modify-write is a single atomic transaction.
+    private fun Preferences.decodeCustomPresets(): List<EqualizerPreset> {
+        val jsonString = this[Keys.CUSTOM_PRESETS] ?: return emptyList()
+        return try {
+            json.decodeFromString<List<EqualizerPreset>>(jsonString)
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun Preferences.decodePinnedPresets(): List<String> {
+        val jsonString = this[Keys.PINNED_PRESETS] ?: return EqualizerPreset.ALL_PRESETS.map { it.name }
+        return try {
+            json.decodeFromString<List<String>>(jsonString)
+        } catch (_: Exception) {
+            EqualizerPreset.ALL_PRESETS.map { it.name }
+        }
+    }
+
     suspend fun saveCustomPreset(preset: EqualizerPreset) {
-        val current = customPresetsFlow.first().toMutableList()
-        current.removeAll { it.name == preset.name }
-        current.add(preset)
         dataStore.edit { preferences ->
+            val current = preferences.decodeCustomPresets().toMutableList()
+            current.removeAll { it.name == preset.name }
+            current.add(preset)
             preferences[Keys.CUSTOM_PRESETS] = json.encodeToString(current)
         }
     }
 
     suspend fun deleteCustomPreset(presetName: String) {
-        val current = customPresetsFlow.first().toMutableList()
-        current.removeAll { it.name == presetName }
         dataStore.edit { preferences ->
+            val current = preferences.decodeCustomPresets().toMutableList()
+            current.removeAll { it.name == presetName }
             preferences[Keys.CUSTOM_PRESETS] = json.encodeToString(current)
-        }
 
-        val pinned = pinnedPresetsFlow.first().toMutableList()
-        if (pinned.remove(presetName)) {
-            setPinnedPresets(pinned)
+            val pinned = preferences.decodePinnedPresets().toMutableList()
+            if (pinned.remove(presetName)) {
+                preferences[Keys.PINNED_PRESETS] = json.encodeToString(pinned)
+            }
         }
     }
 
     suspend fun renameCustomPreset(oldName: String, newName: String) {
-        val current = customPresetsFlow.first().toMutableList()
-        val index = current.indexOfFirst { it.name == oldName }
-        if (index == -1) return
-
-        current[index] = current[index].copy(name = newName, displayName = newName)
         dataStore.edit { preferences ->
+            val current = preferences.decodeCustomPresets().toMutableList()
+            val index = current.indexOfFirst { it.name == oldName }
+            if (index == -1) return@edit
+
+            current[index] = current[index].copy(name = newName, displayName = newName)
             preferences[Keys.CUSTOM_PRESETS] = json.encodeToString(current)
-        }
 
-        val pinned = pinnedPresetsFlow.first().toMutableList()
-        val pinnedIndex = pinned.indexOf(oldName)
-        if (pinnedIndex != -1) {
-            pinned[pinnedIndex] = newName
-            setPinnedPresets(pinned)
-        }
+            val pinned = preferences.decodePinnedPresets().toMutableList()
+            val pinnedIndex = pinned.indexOf(oldName)
+            if (pinnedIndex != -1) {
+                pinned[pinnedIndex] = newName
+                preferences[Keys.PINNED_PRESETS] = json.encodeToString(pinned)
+            }
 
-        val activePreset = dataStore.data.first()[Keys.EQUALIZER_PRESET]
-        if (activePreset == oldName) {
-            dataStore.edit { preferences ->
+            if (preferences[Keys.EQUALIZER_PRESET] == oldName) {
                 preferences[Keys.EQUALIZER_PRESET] = newName
             }
         }
     }
 
     suspend fun updateCustomPresetBands(presetName: String, bandLevels: List<Int>) {
-        val current = customPresetsFlow.first().toMutableList()
-        val index = current.indexOfFirst { it.name == presetName }
-        if (index == -1) return
-
-        current[index] = current[index].copy(bandLevels = bandLevels)
         dataStore.edit { preferences ->
+            val current = preferences.decodeCustomPresets().toMutableList()
+            val index = current.indexOfFirst { it.name == presetName }
+            if (index == -1) return@edit
+
+            current[index] = current[index].copy(bandLevels = bandLevels)
             preferences[Keys.CUSTOM_PRESETS] = json.encodeToString(current)
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.media3.common.Player
+import com.theveloper.pixelplay.data.ai.provider.AiProvider
 import com.theveloper.pixelplay.data.model.PlaybackQueueSnapshot
 import com.theveloper.pixelplay.data.model.Playlist
 import com.theveloper.pixelplay.data.model.SortOption // Added import
@@ -78,7 +79,9 @@ constructor(
 
     private val backupExcludedKeyNames = setOf(
         PreferencesKeys.INITIAL_SETUP_DONE.name
-    )
+    ) + AiProvider.entries.map { "${it.name.lowercase()}_api_key" }
+    // ^ AI provider API keys are stored in this shared DataStore; never serialize them into backups
+    //   (they would be exported in cleartext). Derived from the enum so new providers are covered.
 
     private object PreferencesKeys {
         val APP_REBRAND_DIALOG_SHOWN = booleanPreferencesKey("app_rebrand_dialog_shown")
@@ -973,22 +976,6 @@ constructor(
         }
     }
 
-    suspend fun toggleFavoriteSong(
-            songId: String,
-            removing: Boolean = false
-    ) { // Nueva función para favoritos
-        dataStore.edit { preferences ->
-            val currentFavorites = preferences[PreferencesKeys.FAVORITE_SONG_IDS] ?: emptySet()
-            val contains = currentFavorites.contains(songId)
-
-            if (contains) preferences[PreferencesKeys.FAVORITE_SONG_IDS] = currentFavorites - songId
-            else {
-                if (removing)
-                        preferences[PreferencesKeys.FAVORITE_SONG_IDS] = currentFavorites - songId
-                else preferences[PreferencesKeys.FAVORITE_SONG_IDS] = currentFavorites + songId
-            }
-        }
-    }
 
     suspend fun setFavoriteSong(songId: String, isFavorite: Boolean) {
         dataStore.edit { preferences ->

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -885,15 +885,14 @@ class MusicService : MediaLibraryService() {
             return true
         }
 
+        // If hints identify a Wear/remote controller and it's not our app package,
+        // reject to avoid the default Wear system media player hijacking the session.
         val hasWearHints = controller.connectionHints.keySet().any { key ->
             WEAR_HINT_KEY_MARKERS.any { marker ->
                 key.contains(marker, ignoreCase = true)
             }
         }
         return hasWearHints
-        // If hints identify a Wear/remote controller and it's not our app package,
-        // reject to avoid the default Wear system media player hijacking the session.
-        return true
     }
 
     private fun createSleepTimerPendingIntent(): PendingIntent {
@@ -2502,10 +2501,17 @@ class MusicService : MediaLibraryService() {
     private var cachedSchemePaletteStyle: AlbumArtPaletteStyle? = null
     private var cachedSchemeColorAccuracy: Int = AlbumArtColorAccuracy.DEFAULT
     private var cachedColorSchemePair: ColorSchemePair? = null
+    // Written from getAlbumArtForWidget (Dispatchers.IO) and read/cleared from the main thread
+    // (onTrimMemory / serviceScope). @Volatile rules out torn reads / stale-visibility across threads.
+    @Volatile
     private var cachedWidgetArtSourceKey: String? = null
+    @Volatile
     private var cachedWidgetArtResolvedUri: String? = null
+    @Volatile
     private var cachedWidgetArtBytes: ByteArray? = null
+    @Volatile
     private var cachedWidgetArtLoadFailureKey: String? = null
+    @Volatile
     private var cachedWidgetArtLoadFailureAtMs: Long = 0L
 
     private fun invalidateCachedWidgetArtwork() {

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/SleepTimerReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/SleepTimerReceiver.kt
@@ -12,7 +12,9 @@ class SleepTimerReceiver : BroadcastReceiver() {
             action = MusicService.ACTION_SLEEP_TIMER_EXPIRED
         }
         try {
-            context.startService(serviceIntent)
+            // The alarm fires while the app is typically backgrounded; startService() throws on
+            // API 26+ in that state. MusicService is a foreground media service, so start it as one.
+            context.startForegroundService(serviceIntent)
         } catch (e: Exception) {
             Timber.tag("SleepTimerReceiver").e(e, "Failed to start service for sleep timer")
         }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/auto/AutoMediaBrowseTree.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/auto/AutoMediaBrowseTree.kt
@@ -52,6 +52,11 @@ class AutoMediaBrowseTree @Inject constructor(
 
         private const val MAX_RECENT_SONGS = 50
         private const val MAX_SEARCH_RESULTS = 30
+        // Per-category caps so album/artist results are never crowded out by song hits.
+        // These sum to MAX_SEARCH_RESULTS.
+        private const val MAX_SONG_SEARCH_RESULTS = 15
+        private const val MAX_ALBUM_SEARCH_RESULTS = 8
+        private const val MAX_ARTIST_SEARCH_RESULTS = 7
     }
 
     fun getRootItems(): List<MediaItem> {
@@ -121,17 +126,17 @@ class AutoMediaBrowseTree @Inject constructor(
         val results = mutableListOf<MediaItem>()
         val trimmedQuery = query.trim()
 
-        // Search songs
+        // Search songs (capped so albums/artists keep their budget)
         val songs = musicRepository.searchSongs(trimmedQuery).first()
-        results.addAll(songs.take(MAX_SEARCH_RESULTS).map { buildPlayableSongItem(it) })
+        results.addAll(songs.take(MAX_SONG_SEARCH_RESULTS).map { buildPlayableSongItem(it) })
 
         // Search albums
         val albums = musicRepository.searchAlbums(trimmedQuery).first()
-        results.addAll(albums.take(10).map { buildBrowsableAlbumItem(it) })
+        results.addAll(albums.take(MAX_ALBUM_SEARCH_RESULTS).map { buildBrowsableAlbumItem(it) })
 
         // Search artists
         val artists = musicRepository.searchArtists(trimmedQuery).first()
-        results.addAll(artists.take(10).map { buildBrowsableArtistItem(it) })
+        results.addAll(artists.take(MAX_ARTIST_SEARCH_RESULTS).map { buildBrowsableArtistItem(it) })
 
         return results.take(MAX_SEARCH_RESULTS)
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/cast/CastAudioMimeUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/cast/CastAudioMimeUtils.kt
@@ -71,10 +71,8 @@ internal object CastAudioMimeUtils {
             "audio/l16",
             "audio/l24" -> normalizedBase
 
-            "audio/aiff",
-            "audio/x-aiff",
-            "audio/aif" -> "audio/mpeg"
-
+            // AIFF is uncompressed LPCM, NOT MPEG — advertising audio/mpeg makes the Cast receiver
+            // try to MP3-decode AIFF and fail. Return null so it routes through the transcode path.
             else -> null
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/http/MediaFileHttpServerService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/http/MediaFileHttpServerService.kt
@@ -105,9 +105,12 @@ class MediaFileHttpServerService : Service() {
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
     private val castHttpLogTag = "CastHttpServer"
-    private val signatureMimeCache = mutableMapOf<String, String?>()
+    // Synchronized maps: these are read/written from concurrent Ktor request coroutines. They store
+    // null as a "probed, no result" sentinel, so ConcurrentHashMap (which rejects null values) is
+    // unusable; a synchronized wrapper prevents the HashMap corruption that concurrent access causes.
+    private val signatureMimeCache = java.util.Collections.synchronizedMap(mutableMapOf<String, String?>())
     // Cache for the actual codec info (codec MIME, sample rate, channels) to avoid re-probing.
-    private val codecInfoCache = mutableMapOf<String, AudioCodecInfo?>()
+    private val codecInfoCache = java.util.Collections.synchronizedMap(mutableMapOf<String, AudioCodecInfo?>())
     private val httpDateFormatter: DateTimeFormatter =
         DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC)
 
@@ -563,7 +566,8 @@ class MediaFileHttpServerService : Service() {
                                         e,
                                         "GET /song exception songId=${song.id} uri=${song.contentUriString}"
                                     )
-                                    call.respond(HttpStatusCode.InternalServerError, "Error serving file: ${e.message}")
+                                    // Don't echo e.message: it can contain file paths / content URIs.
+                                    call.respond(HttpStatusCode.InternalServerError, "Error serving file")
                                 }
                             }
                             head("/song/{songId}") {
@@ -1936,36 +1940,42 @@ class MediaFileHttpServerService : Service() {
             transcodeCache.remove(songId)
         }
 
-        // No entry yet — we are the first request. Create the entry and start transcoding.
+        // No entry yet — we are the first request. Create the entry atomically: computeIfAbsent
+        // guarantees that if two requests for the same song race here, only one creates the entry
+        // and launches the background transcode; the loser reuses the winner's entry/temp file.
         val tempFile = File(cacheDir, "cast_transcode_${songId}.aac")
-        // Remove stale failed temp file if present.
-        runCatching { if (tempFile.exists()) tempFile.delete() }
+        var startedTranscode = false
+        val entry = transcodeCache.computeIfAbsent(songId) {
+            // Remove stale failed temp file if present (only the creating thread does this).
+            runCatching { if (tempFile.exists()) tempFile.delete() }
+            startedTranscode = true
+            TranscodeEntry(tempFile = tempFile)
+        }
 
-        val entry = TranscodeEntry(tempFile = tempFile)
-        transcodeCache[songId] = entry
+        if (startedTranscode) {
+            Timber.tag(castHttpLogTag).d("transcode-cache MISS songId=%s, starting progressive stream", songId)
+            Timber.tag("PX_CAST_HTTP").i("transcode_cache_start songId=$songId codec=${codecInfo.codecMime}")
 
-        Timber.tag(castHttpLogTag).d("transcode-cache MISS songId=%s, starting progressive stream", songId)
-        Timber.tag("PX_CAST_HTTP").i("transcode_cache_start songId=$songId codec=${codecInfo.codecMime}")
-
-        // Transcode to the temp file in the background while we stream progressively to Cast.
-        // This decouples the encoder from the response stream: a Cast connection reset no longer
-        // marks the entry as failed and no longer deletes the temp file mid-transcode.
-        serviceScope.launch {
-            runCatching {
-                FileOutputStream(tempFile).use { fos ->
-                    transcodeToAacAdts(codecInfo, song, uri, fos)
+            // Transcode to the temp file in the background while we stream progressively to Cast.
+            // This decouples the encoder from the response stream: a Cast connection reset no longer
+            // marks the entry as failed and no longer deletes the temp file mid-transcode.
+            serviceScope.launch {
+                runCatching {
+                    FileOutputStream(entry.tempFile).use { fos ->
+                        transcodeToAacAdts(codecInfo, song, uri, fos)
+                    }
+                    entry.done = true
+                    Timber.tag("PX_CAST_HTTP").i("transcode_cache_done songId=$songId size=${entry.tempFile.length()}")
+                }.onFailure { t ->
+                    entry.failed = true
+                    runCatching { entry.tempFile.delete() }
+                    if (!t.isClientAbortDuringResponse()) {
+                        Timber.tag(castHttpLogTag).e(t, "transcode-cache bg transcode failed songId=%s", songId)
+                        Timber.tag("PX_CAST_HTTP").e(t, "transcode_cache_error songId=$songId")
+                    }
+                }.also {
+                    entry.latch.countDown()
                 }
-                entry.done = true
-                Timber.tag("PX_CAST_HTTP").i("transcode_cache_done songId=$songId size=${tempFile.length()}")
-            }.onFailure { t ->
-                entry.failed = true
-                runCatching { tempFile.delete() }
-                if (!t.isClientAbortDuringResponse()) {
-                    Timber.tag(castHttpLogTag).e(t, "transcode-cache bg transcode failed songId=%s", songId)
-                    Timber.tag("PX_CAST_HTTP").e(t, "transcode_cache_error songId=$songId")
-                }
-            }.also {
-                entry.latch.countDown()
             }
         }
 
@@ -2620,7 +2630,7 @@ class MediaFileHttpServerService : Service() {
                                 }
                             }
                         } else if (isEos && !encoderEosQueued) {
-                            queueEncoderEndOfStream(encoder, encoderInfo, decoderOutput.timeUs, outputStream, codecInfo)
+                            queueEncoderEndOfStream(encoder, encoderInfo, decoderOutput.timeUs, outputStream, codecInfo, encChannels)
                             encoderEosQueued = true
                         }
 
@@ -2636,7 +2646,7 @@ class MediaFileHttpServerService : Service() {
                 }
 
                 if (srcDone && decDone && !encoderEosQueued) {
-                    queueEncoderEndOfStream(encoder, encoderInfo, 0L, outputStream, codecInfo)
+                    queueEncoderEndOfStream(encoder, encoderInfo, 0L, outputStream, codecInfo, encChannels)
                     encoderEosQueued = true
                 }
 
@@ -2645,7 +2655,7 @@ class MediaFileHttpServerService : Service() {
                             encoder,
                             encoderInfo,
                             codecInfo.sampleRate,
-                            codecInfo.channelCount,
+                            encChannels,
                             outputStream
                         )
                     ) {
@@ -2763,7 +2773,8 @@ class MediaFileHttpServerService : Service() {
         encoderInfo: MediaCodec.BufferInfo,
         ptsUs: Long,
         outputStream: OutputStream,
-        codecInfo: AudioCodecInfo
+        codecInfo: AudioCodecInfo,
+        encoderChannels: Int
     ) {
         repeat(4) {
             val encInIdx = encoder.dequeueInputBuffer(20_000L)
@@ -2781,7 +2792,7 @@ class MediaFileHttpServerService : Service() {
                 encoder,
                 encoderInfo,
                 codecInfo.sampleRate,
-                codecInfo.channelCount,
+                encoderChannels,
                 outputStream,
                 firstTimeoutUs = 20_000L
             )

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/DualPlayerEngine.kt
@@ -796,6 +796,13 @@ class DualPlayerEngine @Inject constructor(
             Timber.tag("DualPlayerEngine").w("Hi-Fi mode requested but device does not support PCM_FLOAT")
             return
         }
+        if (transitionRunning) {
+            // Rebuilding the players underneath an active crossfade tears down the player the fade
+            // loop still references. Skip; the change applies on the next toggle (matches the
+            // audio-offload fallback guard in disableAudioOffloadForSession).
+            Timber.tag("DualPlayerEngine").w("Skipping Hi-Fi mode change during active transition.")
+            return
+        }
         hiFiModeEnabled = enabled
         rebuildPlayersPreservingMasterState("Hi-Fi mode set to $enabled")
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/player/TransitionController.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/player/TransitionController.kt
@@ -38,7 +38,7 @@ class TransitionController @Inject constructor(
     private val transitionRepository: TransitionRepository,
     private val userPreferencesRepository: UserPreferencesRepository,
 ) {
-    private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private var scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var transitionListener: Player.Listener? = null
     private var transitionSchedulerJob: Job? = null
     private var currentObservedPlayer: Player? = null
@@ -62,6 +62,12 @@ class TransitionController @Inject constructor(
      */
     fun initialize() {
         if (transitionListener != null) return // Already initialized
+
+        // release() cancels `scope`; on re-initialization (e.g. service restart) recreate it if dead
+        // so scheduleTransitionFor's launches are not silently dropped onto a cancelled scope.
+        if (scope.coroutineContext[Job]?.isActive != true) {
+            scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+        }
 
         Timber.tag("TransitionDebug").d("Initializing TransitionController...")
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/PhoneDirectWatchTransferCoordinator.kt
@@ -75,7 +75,12 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val json = Json { ignoreUnknownKeys = true }
     private val albumPaletteSeedCache = ConcurrentHashMap<Long, Int>()
-    private val albumArtworkTransferCache = ConcurrentHashMap<Long, ByteArray>()
+    // Bounded LRU (~20 MiB) instead of an unbounded map: this @Singleton would otherwise retain
+    // up to TRANSFER_ARTWORK_MAX_BYTES per distinct album forever, risking OOM on low-end phones.
+    private val albumArtworkTransferCache =
+        object : android.util.LruCache<Long, ByteArray>(20 * 1024 * 1024) {
+            override fun sizeOf(key: Long, value: ByteArray): Int = value.size
+        }
 
     private data class OpenedSongSource(
         val inputStream: InputStream,
@@ -511,7 +516,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
 
     private fun resolveTransferArtworkBytes(song: Song): ByteArray? {
         if (song.albumId > 0L) {
-            albumArtworkTransferCache[song.albumId]?.let { return it }
+            albumArtworkTransferCache.get(song.albumId)?.let { return it }
         }
 
         val bitmap = loadSongAlbumArtBitmapForTransfer(song) ?: return null
@@ -523,7 +528,7 @@ class PhoneDirectWatchTransferCoordinator @Inject constructor(
                 null
             } else {
                 if (song.albumId > 0L) {
-                    albumArtworkTransferCache[song.albumId] = bytes
+                    albumArtworkTransferCache.put(song.albumId, bytes)
                 }
                 bytes
             }

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/wear/WearCommandReceiver.kt
@@ -116,6 +116,15 @@ class WearCommandReceiver : WearableListenerService() {
             WearPlaybackCommand.PLAY_FROM_CONTEXT -> {
                 handlePlayFromContext(command)
             }
+            WearPlaybackCommand.PLAY_ITEM -> {
+                handlePlayItem(command)
+            }
+            WearPlaybackCommand.PLAY_NEXT_FROM_CONTEXT -> {
+                handleEnqueueItem(command, playNext = true)
+            }
+            WearPlaybackCommand.ADD_TO_QUEUE_FROM_CONTEXT -> {
+                handleEnqueueItem(command, playNext = false)
+            }
             else -> {
                 getOrBuildMediaController { controller ->
                     when (command.action) {
@@ -220,6 +229,80 @@ class WearCommandReceiver : WearableListenerService() {
                 }
             } catch (e: Exception) {
                 Timber.tag(TAG).e(e, "Failed to handle PLAY_FROM_CONTEXT")
+            }
+        }
+    }
+
+    /**
+     * Handle PLAY_ITEM: resolve a single song by ID and start playing it immediately.
+     */
+    private fun handlePlayItem(command: WearPlaybackCommand) {
+        val songId = command.songId
+        if (songId == null) {
+            Timber.tag(TAG).w("PLAY_ITEM missing songId")
+            return
+        }
+        scope.launch {
+            try {
+                val song = musicRepository.getSong(songId).first()
+                if (song == null) {
+                    Timber.tag(TAG).w("PLAY_ITEM: song not found for id=%s", songId)
+                    return@launch
+                }
+                val mediaItem = dualPlayerEngine.resolveMediaItem(MediaItemBuilder.build(song))
+                getOrBuildMediaController { controller ->
+                    controller.setMediaItems(listOf(mediaItem), 0, 0L)
+                    controller.prepare()
+                    controller.play()
+                    Timber.tag(TAG).d("PLAY_ITEM: playing %s", song.title)
+                }
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to handle PLAY_ITEM")
+            }
+        }
+    }
+
+    /**
+     * Handle PLAY_NEXT_FROM_CONTEXT / ADD_TO_QUEUE_FROM_CONTEXT: resolve a single song and either
+     * insert it right after the current item or append it to the end of the active queue. If nothing
+     * is queued yet, fall back to starting playback of the song.
+     */
+    private fun handleEnqueueItem(command: WearPlaybackCommand, playNext: Boolean) {
+        val songId = command.songId
+        if (songId == null) {
+            Timber.tag(TAG).w("%s missing songId", command.action)
+            return
+        }
+        scope.launch {
+            try {
+                val song = musicRepository.getSong(songId).first()
+                if (song == null) {
+                    Timber.tag(TAG).w("%s: song not found for id=%s", command.action, songId)
+                    return@launch
+                }
+                val mediaItem = MediaItemBuilder.build(song)
+                // Resolve here (in the coroutine body); getOrBuildMediaController's callback is not a
+                // suspend context. Only the "start now" branch needs the resolved (cloud-ready) item;
+                // enqueued items are resolved later when they become current (matches PLAY_FROM_CONTEXT).
+                val resolvedMediaItem = dualPlayerEngine.resolveMediaItem(mediaItem)
+                getOrBuildMediaController { controller ->
+                    when {
+                        controller.mediaItemCount == 0 -> {
+                            controller.setMediaItems(listOf(resolvedMediaItem), 0, 0L)
+                            controller.prepare()
+                            controller.play()
+                        }
+                        playNext -> {
+                            val insertIndex = (controller.currentMediaItemIndex + 1)
+                                .coerceIn(0, controller.mediaItemCount)
+                            controller.addMediaItem(insertIndex, mediaItem)
+                        }
+                        else -> controller.addMediaItem(mediaItem)
+                    }
+                    Timber.tag(TAG).d("%s: enqueued %s (playNext=%b)", command.action, song.title, playNext)
+                }
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to handle %s", command.action)
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/di/AppModule.kt
@@ -164,7 +164,8 @@ object AppModule {
             PixelPlayDatabase.MIGRATION_37_38,
             PixelPlayDatabase.MIGRATION_38_39,
             PixelPlayDatabase.MIGRATION_39_40,
-            PixelPlayDatabase.MIGRATION_40_41
+            PixelPlayDatabase.MIGRATION_40_41,
+            PixelPlayDatabase.MIGRATION_41_42
         )
             .addCallback(PixelPlayDatabase.createRuntimeArtifactsCallback())
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumArtCollage.kt
@@ -99,7 +99,7 @@ fun AlbumArtCollage(
                                     .offset(cfg.offsetX, cfg.offsetY)
                                     .graphicsLayer { rotationZ = cfg.rot }
                                     .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
+                                        interactionSource = remember(idx) { MutableInteractionSource() },
                                         indication = null
                                     ) { onSongClick(song) }
                                     .background(shape = cfg.shape, color = MaterialTheme.colorScheme.surfaceContainerHigh)
@@ -121,7 +121,7 @@ fun AlbumArtCollage(
                                     .offset(cfg.offsetX, cfg.offsetY)
                                     .graphicsLayer { rotationZ = cfg.rot }
                                     .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
+                                        interactionSource = remember(j) { MutableInteractionSource() },
                                         indication = null
                                     ) { onSongClick(song) }
                                     .clip(cfg.shape)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumCarouselSelection.kt
@@ -168,7 +168,7 @@ fun AlbumCarouselSection(
                         .aspectRatio(1f)
                         .clickable(
                             enabled = isFocusedItem && song.albumId != -1L,
-                            interactionSource = remember { MutableInteractionSource() },
+                            interactionSource = remember(index) { MutableInteractionSource() },
                             indication = null,
                             onClick = { onAlbumClick(song) }
                         )

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/CastBottomSheet.kt
@@ -90,6 +90,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -179,7 +181,10 @@ fun CastBottomSheet(
     val isRemotePlaybackActive by playerViewModel.isRemotePlaybackActive.collectAsStateWithLifecycle()
     val isCastConnecting by playerViewModel.isCastConnecting.collectAsStateWithLifecycle()
     val trackVolume by playerViewModel.trackVolume.collectAsStateWithLifecycle()
-    val isPlaying = playerViewModel.stablePlayerState.collectAsStateWithLifecycle().value.isPlaying
+    // Slice isPlaying out of stablePlayerState so this sheet doesn't recompose on every state change.
+    val isPlaying by remember(playerViewModel) {
+        playerViewModel.stablePlayerState.map { it.isPlaying }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(initialValue = playerViewModel.stablePlayerState.value.isPlaying)
     val context = LocalContext.current
 
     val requiredPermissions = remember {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -73,6 +73,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.rememberUpdatedState
@@ -1489,8 +1491,10 @@ private fun SongMetadataDisplaySection(
             )
         }
         
-        val stablePlayerState by playerViewModel.stablePlayerState.collectAsStateWithLifecycle()
-        val isBuffering = stablePlayerState.isBuffering
+        // Slice isBuffering rather than collecting the whole stablePlayerState in this hot path.
+        val isBuffering by remember(playerViewModel) {
+            playerViewModel.stablePlayerState.map { it.isBuffering }.distinctUntilChanged()
+        }.collectAsStateWithLifecycle(initialValue = playerViewModel.stablePlayerState.value.isBuffering)
 
 
         AnimatedVisibility(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -259,6 +259,8 @@ fun AppNavigation(
                             playerViewModel = playerViewModel,
                             onBackClick = { navController.popBackStack() }
                         )
+                    } else {
+                        Text(stringResource(R.string.nav_error_item_id_missing), modifier = Modifier)
                     }
                 }
             }
@@ -405,6 +407,8 @@ fun AppNavigation(
                             playerViewModel = playerViewModel
                         )
                     }
+                } else {
+                    Text(stringResource(R.string.nav_error_item_id_missing), modifier = Modifier)
                 }
             }
             composable(
@@ -424,10 +428,12 @@ fun AppNavigation(
                             playerViewModel = playerViewModel
                         )
                     }
+                } else {
+                    Text(stringResource(R.string.nav_error_item_id_missing), modifier = Modifier)
                 }
             }
             composable(
-                "nav_bar_corner_radius",
+                Screen.NavBarCrRad.route,
                 enterTransition = { enterTransition() },
                 exitTransition = { exitTransition() },
                 popEnterTransition = { popEnterTransition() },

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/NavControllerExtensions.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/NavControllerExtensions.kt
@@ -49,6 +49,7 @@ fun NavController.navigateSafelyReplacing(
 }
 
 fun NavController.navigateToTopLevelSafely(route: String): Boolean {
+    if (!isReadyForNavigation()) return false
     val startDestinationId = runCatching { graph.startDestinationId }.getOrNull() ?: return false
     navigate(route) {
         popUpTo(startDestinationId) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistSettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/ArtistSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.theveloper.pixelplay.presentation.screens
 
+import com.theveloper.pixelplay.presentation.navigation.Screen
 import com.theveloper.pixelplay.presentation.navigation.navigateSafely
 
 import androidx.compose.animation.AnimatedVisibility
@@ -226,7 +227,7 @@ fun ArtistSettingsScreen(
                                 )
                             },
                             onClick = {
-                                navController.navigateSafely("delimiter_config")
+                                navController.navigateSafely(Screen.DelimiterConfig.route)
                             }
                         )
 
@@ -258,7 +259,7 @@ fun ArtistSettingsScreen(
                                 )
                             },
                             onClick = {
-                                navController.navigateSafely("word_delimiter_config")
+                                navController.navigateSafely(Screen.WordDelimiterConfig.route)
                             }
                         )
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DailyMixScreen.kt
@@ -199,12 +199,17 @@ fun DailyMixScreen(
             },
             onDeleteFromDevice = playerViewModel::deleteFromDevice,
             onNavigateToAlbum = {
-                // Assuming Screen object has a method to create a route
-                navController.navigateSafely(Screen.AlbumDetail.createRoute(song.albumId))
+                // Guard the -1L sentinel (external/streaming songs) so we don't push a detail screen
+                // for a non-existent album/artist and land the user on an error page.
+                if (song.albumId != -1L) {
+                    navController.navigateSafely(Screen.AlbumDetail.createRoute(song.albumId))
+                }
                 showSongInfoSheet = false
             },
             onNavigateToArtist = {
-                navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
+                if (song.artistId != -1L) {
+                    navController.navigateSafely(Screen.ArtistDetail.createRoute(song.artistId))
+                }
                 showSongInfoSheet = false
             },
             onNavigateToArtistById = { artistId ->

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/HomeScreen.kt
@@ -433,16 +433,22 @@ fun HomeScreen(
                                 navController.navigateSafely(Screen.DailyMixScreen.route)
                             },
                             onNavigateToAlbum = { song ->
-                                navController.navigateSafelyReplacing(
-                                    route = Screen.AlbumDetail.createRoute(song.albumId),
-                                    patternToPop = Screen.AlbumDetail.route
-                                )
+                                // Skip the -1L sentinel (external/streaming songs) to avoid navigating
+                                // to a non-existent album detail screen.
+                                if (song.albumId != -1L) {
+                                    navController.navigateSafelyReplacing(
+                                        route = Screen.AlbumDetail.createRoute(song.albumId),
+                                        patternToPop = Screen.AlbumDetail.route
+                                    )
+                                }
                             },
                             onNavigateToArtist = { song ->
-                                navController.navigateSafelyReplacing(
-                                    route = Screen.ArtistDetail.createRoute(song.artistId),
-                                    patternToPop = Screen.ArtistDetail.route
-                                )
+                                if (song.artistId != -1L) {
+                                    navController.navigateSafelyReplacing(
+                                        route = Screen.ArtistDetail.createRoute(song.artistId),
+                                        patternToPop = Screen.ArtistDetail.route
+                                    )
+                                }
                             },
                             onNavigateToGenre = { song ->
                                 song.genre?.let {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -1847,10 +1847,11 @@ fun LibraryScreen(
 
     if (showSongInfoBottomSheet && selectedSongForInfo != null) {
         val currentSong = selectedSongForInfo
-        val isFavorite = remember(currentSong?.id, favoriteIds) { derivedStateOf { currentSong?.let {
-            favoriteIds.contains(
-                it.id)
-        } } }.value ?: false
+        // Plain remember keyed on the inputs: wrapping derivedStateOf in remember and reading .value
+        // immediately defeats derivedStateOf and just adds overhead.
+        val isFavorite = remember(currentSong?.id, favoriteIds) {
+            currentSong?.let { favoriteIds.contains(it.id) } ?: false
+        }
 
         if (currentSong != null) {
             SongInfoBottomSheet(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SettingsScreen.kt
@@ -277,7 +277,7 @@ fun SettingsScreen(
                     ExpressiveCategoryItem(
                         category = SettingsCategory.ABOUT,
                         customColors = getCategoryColors(SettingsCategory.ABOUT, isDark),
-                        onClick = { navController.navigateSafely("about") },
+                        onClick = { navController.navigateSafely(Screen.About.route) },
                         shape = shapeFor(itemIndex)
                     )
                 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastStateHolder.kt
@@ -241,16 +241,20 @@ class CastStateHolder @Inject constructor(
                 mediaRouterCallback,
                 MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY or MediaRouter.CALLBACK_FLAG_PERFORM_ACTIVE_SCAN
             )
-            updateRoutes()
-            syncSelectedRouteFromRouter(mediaRouter)
-
-            kotlinx.coroutines.delay(1800)
-
-            mediaRouter.removeCallback(mediaRouterCallback)
-            mediaRouter.addCallback(mediaRouteSelector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
-            updateRoutes()
-            syncSelectedRouteFromRouter(mediaRouter)
-            _isRefreshingRoutes.value = false
+            try {
+                updateRoutes()
+                syncSelectedRouteFromRouter(mediaRouter)
+                kotlinx.coroutines.delay(1800)
+            } finally {
+                // Always downgrade active scan -> passive discovery, even if this job is cancelled
+                // mid-delay by a rapid re-refresh; otherwise the radios stay in active-scan mode and
+                // drain the battery indefinitely.
+                mediaRouter.removeCallback(mediaRouterCallback)
+                mediaRouter.addCallback(mediaRouteSelector, mediaRouterCallback, MediaRouter.CALLBACK_FLAG_REQUEST_DISCOVERY)
+                updateRoutes()
+                syncSelectedRouteFromRouter(mediaRouter)
+                _isRefreshingRoutes.value = false
+            }
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/CastTransferStateHolder.kt
@@ -23,6 +23,7 @@ import com.theveloper.pixelplay.data.service.http.CastSessionSecurity
 import com.theveloper.pixelplay.data.service.http.MediaFileHttpServerService
 import com.theveloper.pixelplay.data.service.player.CastPlayer
 import com.theveloper.pixelplay.data.service.player.DualPlayerEngine
+import com.theveloper.pixelplay.di.AppScope
 
 import com.theveloper.pixelplay.utils.MediaItemBuilder
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -51,7 +52,8 @@ class CastTransferStateHolder @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val castStateHolder: CastStateHolder,
     private val playbackStateHolder: PlaybackStateHolder,
-    private val dualPlayerEngine: DualPlayerEngine // For local player control during transfer
+    private val dualPlayerEngine: DualPlayerEngine, // For local player control during transfer
+    @param:AppScope private val appScope: CoroutineScope
 ) {
     private val CAST_LOG_TAG = "PlayerCastTransfer"
     private val remoteBufferingSoftRecoveryMs = 6_000L
@@ -209,7 +211,10 @@ class CastTransferStateHolder @Inject constructor(
             }
             override fun onSessionEnded(session: CastSession, error: Int) {
                 sessionSuspendedRecoveryJob?.cancel()
-                scope?.launch { stopServerAndTransferBack() }
+                // Use the app-level scope rather than the nullable `scope`: onSessionEnded can race
+                // with onCleared() (which nulls `scope`), and dropping this cleanup would leave the
+                // Ktor HTTP server running and the local player never restored.
+                appScope.launch { stopServerAndTransferBack() }
             }
             override fun onSessionSuspended(session: CastSession, reason: Int) {
                 Timber.tag(CAST_LOG_TAG).w("Cast session suspended (reason=%d). Waiting for recovery.", reason)
@@ -247,10 +252,14 @@ class CastTransferStateHolder @Inject constructor(
         if (currentSession != null) {
             val callback = remoteMediaClientCallback
             val progressListener = remoteProgressListener
+            // Unregister first: the Cast SDK does not de-dup, and the same listener instances may be
+            // re-registered on session resume (see transferPlayback), which would double every callback.
             if (callback != null) {
+                currentSession.remoteMediaClient?.unregisterCallback(callback)
                 currentSession.remoteMediaClient?.registerCallback(callback)
             }
             if (progressListener != null) {
+                currentSession.remoteMediaClient?.removeProgressListener(progressListener)
                 currentSession.remoteMediaClient?.addProgressListener(progressListener, 1000)
             }
             startRemoteProgressObserver()
@@ -671,13 +680,17 @@ class CastTransferStateHolder @Inject constructor(
 
             val callback = remoteMediaClientCallback
             val progressListener = remoteProgressListener
+            // Unregister before registering: onSessionResumed re-enters here with the same listener
+            // instances; without this the SDK fires every status/progress callback twice.
             if (callback != null) {
+                session.remoteMediaClient?.unregisterCallback(callback)
                 session.remoteMediaClient?.registerCallback(callback)
             }
             if (progressListener != null) {
+                session.remoteMediaClient?.removeProgressListener(progressListener)
                 session.remoteMediaClient?.addProgressListener(progressListener, 1000)
             }
-            
+
             startRemoteProgressObserver()
         }
     }
@@ -973,8 +986,18 @@ class CastTransferStateHolder @Inject constructor(
 
     private fun parseIpv4Address(rawAddress: String?): Inet4Address? {
         val normalized = rawAddress?.trim()?.takeIf { it.isNotEmpty() } ?: return null
-        val parsed = runCatching { InetAddress.getByName(normalized) }.getOrNull() ?: return null
-        return parsed as? Inet4Address
+        // Parse a numeric dotted-quad directly via getByAddress(). InetAddress.getByName() can block
+        // on a DNS lookup for non-literal hosts and is a StrictMode violation when (as here) this runs
+        // on the main dispatcher; getByAddress() with raw bytes never resolves DNS.
+        val parts = normalized.split('.')
+        if (parts.size != 4) return null
+        val bytes = ByteArray(4)
+        for (i in 0 until 4) {
+            val octet = parts[i].toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            bytes[i] = octet.toByte()
+        }
+        return runCatching { InetAddress.getByAddress(bytes) as? Inet4Address }.getOrNull()
     }
 
     private fun isSameSubnet(localAddress: Inet4Address, remoteAddress: Inet4Address, prefixLength: Int): Boolean {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ColorSchemeProcessor.kt
@@ -200,9 +200,11 @@ class ColorSchemeProcessor @Inject constructor(
             
             val drawable = context.imageLoader.execute(request).drawable ?: return null
             
+            // Drawables without intrinsic dimensions report -1; fall back to a usable size so we
+            // don't extract a seed color from a 1x1 bitmap.
             createBitmap(
-                drawable.intrinsicWidth.coerceAtLeast(1),
-                drawable.intrinsicHeight.coerceAtLeast(1)
+                drawable.intrinsicWidth.takeIf { it > 0 } ?: 128,
+                drawable.intrinsicHeight.takeIf { it > 0 } ?: 128
             ).also { bmp ->
                 Canvas(bmp).let { canvas ->
                     drawable.setBounds(0, 0, canvas.width, canvas.height)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ConnectivityStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ConnectivityStateHolder.kt
@@ -575,9 +575,13 @@ class ConnectivityStateHolder @Inject constructor(
         wifiStateReceiver?.let { 
             runCatching { context.unregisterReceiver(it) }
         }
-        bluetoothStateReceiver?.let { 
+        bluetoothStateReceiver?.let {
             runCatching { context.unregisterReceiver(it) }
         }
+        audioDeviceCallback?.let {
+            runCatching { audioManager.unregisterAudioDeviceCallback(it) }
+        }
+        audioDeviceCallback = null
         if (hasBluetoothScanPermission()) {
             bluetoothAdapter?.takeIf { isBluetoothDiscoveryActive(it) }?.let {
                 cancelBluetoothDiscovery(it)

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/DailyMixStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/DailyMixStateHolder.kt
@@ -142,12 +142,14 @@ class DailyMixStateHolder @Inject constructor(
     fun checkAndUpdateIfNeeded(favoriteSongIdsFlow: kotlinx.coroutines.flow.Flow<Set<String>>) {
         scope?.launch {
             val lastUpdate = userPreferencesRepository.lastDailyMixUpdateFlow.first()
-            val today = Calendar.getInstance().get(Calendar.DAY_OF_YEAR)
-            val lastUpdateDay = Calendar.getInstance().apply {
-                timeInMillis = lastUpdate
-            }.get(Calendar.DAY_OF_YEAR)
+            val todayCal = Calendar.getInstance()
+            val lastCal = Calendar.getInstance().apply { timeInMillis = lastUpdate }
+            // Compare full date (year + day-of-year); comparing DAY_OF_YEAR alone treats e.g. day 150
+            // of two different years as "same day" and suppresses the refresh.
+            val isDifferentDay = todayCal.get(Calendar.YEAR) != lastCal.get(Calendar.YEAR) ||
+                todayCal.get(Calendar.DAY_OF_YEAR) != lastCal.get(Calendar.DAY_OF_YEAR)
 
-            if (today != lastUpdateDay) {
+            if (isDifferentDay) {
                 updateDailyMix(favoriteSongIdsFlow)
                 userPreferencesRepository.saveLastDailyMixUpdateTimestamp(System.currentTimeMillis())
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LibraryStateHolder.kt
@@ -544,12 +544,14 @@ class LibraryStateHolder @Inject constructor(
         _allSongs.update { currentList ->
             currentList.map { if (it.id == updatedSong.id) updatedSong else it }.toImmutableList()
         }
+        _allSongsById.update { current -> current + (updatedSong.id to updatedSong) }
     }
 
     fun removeSong(songId: String) {
         _allSongs.update { currentList ->
             currentList.filter { it.id != songId }.toImmutableList()
         }
+        _allSongsById.update { current -> current - songId }
     }
 
     fun setStorageFilter(filter: com.theveloper.pixelplay.data.model.StorageFilter) {

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1948,12 +1948,17 @@ class PlayerViewModel @Inject constructor(
         // Initialize connectivity monitoring (WiFi/Bluetooth)
         connectivityStateHolder.initialize()
 
-        // Initialize sleep timer state holder
+        // Initialize sleep timer state holder.
+        // Create the current-song-id flow once and share it; previously the provider built a new
+        // Eagerly-started stateIn() coroutine on every end-of-track toggle, leaking one per cycle.
+        val currentSongIdFlow = stablePlayerState
+            .map { it.currentSong?.id }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
         sleepTimerStateHolder.initialize(
             scope = viewModelScope,
             toastEmitter = { msg -> _toastEvents.emit(msg) },
             mediaControllerProvider = { mediaController },
-            currentSongIdProvider = { stablePlayerState.map { it.currentSong?.id }.stateIn(viewModelScope, SharingStarted.Eagerly, null) },
+            currentSongIdProvider = { currentSongIdFlow },
             songTitleResolver = { songId -> libraryStateHolder.allSongsById.value[songId]?.title ?: "Unknown" }
         )
 
@@ -2129,8 +2134,6 @@ class PlayerViewModel @Inject constructor(
             getUiState = { _playerUiState.value },
             onHideDismissUndoBar = { hideDismissUndoBar() }
         )
-
-        Trace.endSection() // End PlayerViewModel.init
     }
 
     fun onMainActivityStart() {
@@ -2600,7 +2603,7 @@ class PlayerViewModel @Inject constructor(
                 awaitPlayerCollapse()
             }
 
-            _artistNavigationRequests.emit(artistId)
+            _artistNavigationRequests.emit(resolvedId)
         }
     }
 
@@ -3399,7 +3402,7 @@ class PlayerViewModel @Inject constructor(
         } else {
             setPreparingSong(null)
         }
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers.Default) {
             val albumArtUri = song.albumArtUriString
             if (albumArtUri.isNullOrBlank()) {
                 themeStateHolder.extractAndGenerateColorScheme(
@@ -4005,9 +4008,7 @@ class PlayerViewModel @Inject constructor(
                 _toastEvents.emit(
                     context.getString(R.string.player_share_zip_failed_format, error.localizedMessage ?: ""),
                 )
-                println(
-                    "Failed to share: ${error.localizedMessage}"
-                )
+                Timber.e(error, "Failed to share zip")
             }
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ThemeStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/ThemeStateHolder.kt
@@ -3,6 +3,7 @@ package com.theveloper.pixelplay.presentation.viewmodel
 import android.net.Uri
 import android.content.ComponentCallbacks2
 import android.os.Trace
+import timber.log.Timber
 import androidx.compose.ui.graphics.Color
 import com.theveloper.pixelplay.data.preferences.AlbumArtColorAccuracy
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
@@ -244,8 +245,8 @@ class ThemeStateHolder @Inject constructor(
              return
          }
 
-         android.util.Log.d("ThemeStateHolder", "forceRegenerateColorScheme called for: $uriString")
-         android.util.Log.d("ThemeStateHolder", "Current tracked global URI: ${_currentAlbumArtUri.value}")
+         Timber.tag("ThemeStateHolder").d("forceRegenerateColorScheme called for: $uriString")
+         Timber.tag("ThemeStateHolder").d("Current tracked global URI: ${_currentAlbumArtUri.value}")
          
          colorSchemeProcessor.invalidateScheme(uriString)
 
@@ -281,10 +282,10 @@ class ThemeStateHolder @Inject constructor(
          // Also update the main current album art scheme if it matches the one we are tracking
          // We use equality check. If they are the same string object or equal content.
          if (_currentAlbumArtUri.value == uriString) {
-             android.util.Log.d("ThemeStateHolder", "Updating global color scheme flow directly.")
+             Timber.tag("ThemeStateHolder").d("Updating global color scheme flow directly.")
              _currentAlbumArtColorSchemePair.value = newScheme
          } else {
-             android.util.Log.d("ThemeStateHolder", "Global URI did not match. Skipping global update.")
+             Timber.tag("ThemeStateHolder").d("Global URI did not match. Skipping global update.")
          }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/PixelPlayGlanceWidget.kt
@@ -3,7 +3,6 @@ package com.theveloper.pixelplay.ui.glancewidget
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize

--- a/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/ui/glancewidget/WidgetUtils.kt
@@ -20,9 +20,9 @@ object AlbumArtBitmapCache {
     fun getBitmap(key: String): Bitmap? = lruCache.get(key)
 
     fun putBitmap(key: String, bitmap: Bitmap) {
-        if (getBitmap(key) == null) {
-            lruCache.put(key, bitmap)
-        }
+        // LruCache.put is itself synchronized and last-write-wins, so the previous get-then-put
+        // guard only added a non-atomic race; an unconditional put is both simpler and correct.
+        lruCache.put(key, bitmap)
     }
 
     fun getKey(byteArray: ByteArray): String {

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AudioDecoder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AudioDecoder.kt
@@ -19,78 +19,82 @@ object AudioDecoder {
     suspend fun decodeToFloatArray(context: Context, uri: Uri, requiredSamples: Int): Result<FloatArray> = withContext(Dispatchers.IO) {
         runCatching {
             val extractor = MediaExtractor()
-            extractor.setDataSource(context, uri, null)
+            try {
+                extractor.setDataSource(context, uri, null)
 
-            val trackIndex = findAudioTrack(extractor)
-            if (trackIndex == -1) {
+                val trackIndex = findAudioTrack(extractor)
+                if (trackIndex == -1) {
+                    error("No audio track found in the file.")
+                }
+                extractor.selectTrack(trackIndex)
+                val format = extractor.getTrackFormat(trackIndex)
+
+                val mime = format.getString(MediaFormat.KEY_MIME) ?: error("MIME type not found.")
+                val decoder = MediaCodec.createDecoderByType(mime)
+                try {
+                    decoder.configure(format, null, null, 0)
+                    decoder.start()
+
+                    val pcmData = mutableListOf<Float>()
+                    val bufferInfo = MediaCodec.BufferInfo()
+                    var isEndOfStream = false
+
+                    while (!isEndOfStream && pcmData.size < requiredSamples) { // --- MODIFICADO: Condición de parada ---
+                        val inputBufferIndex = decoder.dequeueInputBuffer(TIMEOUT_US)
+                        if (inputBufferIndex >= 0) {
+                            val inputBuffer = decoder.getInputBuffer(inputBufferIndex)
+                            if (inputBuffer == null) {
+                                Timber.tag("AudioDecoder").w("Decoder input buffer was null, ending decode early")
+                                decoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                                isEndOfStream = true
+                                continue
+                            }
+                            val sampleSize = extractor.readSampleData(inputBuffer, 0)
+                            if (sampleSize < 0) {
+                                decoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                                isEndOfStream = true
+                            } else {
+                                decoder.queueInputBuffer(inputBufferIndex, 0, sampleSize, extractor.sampleTime, 0)
+                                extractor.advance()
+                            }
+                        }
+
+                        var outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+                        while (outputBufferIndex >= 0) {
+                            val outputBuffer = decoder.getOutputBuffer(outputBufferIndex)
+                            if (outputBuffer == null) {
+                                Timber.tag("AudioDecoder").w("Decoder output buffer was null, skipping chunk")
+                                decoder.releaseOutputBuffer(outputBufferIndex, false)
+                                outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+                                continue
+                            }
+                            pcmData.addAll(byteBufferToFloatArray(outputBuffer, format).asList())
+                            decoder.releaseOutputBuffer(outputBufferIndex, false)
+
+                            // Si ya tenemos suficientes muestras, salimos del bucle interno
+                            if (pcmData.size >= requiredSamples) break
+
+                            outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
+                        }
+                    }
+
+                    Timber.tag("AudioDecoder").d("Successfully decoded ${pcmData.size} samples.")
+
+                    // --- MODIFICADO: Rellenamos con silencio si la canción es más corta que lo requerido ---
+                    if (pcmData.size < requiredSamples) {
+                        val padding = FloatArray(requiredSamples - pcmData.size) { 0f }
+                        pcmData.addAll(padding.asList())
+                    }
+
+                    // Devolvemos el array con el tamaño exacto
+                    pcmData.toFloatArray().copyOf(requiredSamples)
+                } finally {
+                    runCatching { decoder.stop() }
+                    decoder.release()
+                }
+            } finally {
                 extractor.release()
-                error("No audio track found in the file.")
             }
-            extractor.selectTrack(trackIndex)
-            val format = extractor.getTrackFormat(trackIndex)
-
-            val mime = format.getString(MediaFormat.KEY_MIME) ?: error("MIME type not found.")
-            val decoder = MediaCodec.createDecoderByType(mime)
-            decoder.configure(format, null, null, 0)
-            decoder.start()
-
-            val pcmData = mutableListOf<Float>()
-            val bufferInfo = MediaCodec.BufferInfo()
-            var isEndOfStream = false
-
-            while (!isEndOfStream && pcmData.size < requiredSamples) { // --- MODIFICADO: Condición de parada ---
-                val inputBufferIndex = decoder.dequeueInputBuffer(TIMEOUT_US)
-                if (inputBufferIndex >= 0) {
-                    val inputBuffer = decoder.getInputBuffer(inputBufferIndex)
-                    if (inputBuffer == null) {
-                        Timber.tag("AudioDecoder").w("Decoder input buffer was null, ending decode early")
-                        decoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
-                        isEndOfStream = true
-                        continue
-                    }
-                    val sampleSize = extractor.readSampleData(inputBuffer, 0)
-                    if (sampleSize < 0) {
-                        decoder.queueInputBuffer(inputBufferIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
-                        isEndOfStream = true
-                    } else {
-                        decoder.queueInputBuffer(inputBufferIndex, 0, sampleSize, extractor.sampleTime, 0)
-                        extractor.advance()
-                    }
-                }
-
-                var outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
-                while (outputBufferIndex >= 0) {
-                    val outputBuffer = decoder.getOutputBuffer(outputBufferIndex)
-                    if (outputBuffer == null) {
-                        Timber.tag("AudioDecoder").w("Decoder output buffer was null, skipping chunk")
-                        decoder.releaseOutputBuffer(outputBufferIndex, false)
-                        outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
-                        continue
-                    }
-                    pcmData.addAll(byteBufferToFloatArray(outputBuffer, format).asList())
-                    decoder.releaseOutputBuffer(outputBufferIndex, false)
-
-                    // Si ya tenemos suficientes muestras, salimos del bucle interno
-                    if (pcmData.size >= requiredSamples) break
-
-                    outputBufferIndex = decoder.dequeueOutputBuffer(bufferInfo, TIMEOUT_US)
-                }
-            }
-
-            decoder.stop()
-            decoder.release()
-            extractor.release()
-
-            Timber.tag("AudioDecoder").d("Successfully decoded ${pcmData.size} samples.")
-
-            // --- MODIFICADO: Rellenamos con silencio si la canción es más corta que lo requerido ---
-            if (pcmData.size < requiredSamples) {
-                val padding = FloatArray(requiredSamples - pcmData.size) { 0f }
-                pcmData.addAll(padding.asList())
-            }
-
-            // Devolvemos el array con el tamaño exacto
-            pcmData.toFloatArray().copyOf(requiredSamples)
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/utils/AudioMetaUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/AudioMetaUtils.kt
@@ -3,8 +3,8 @@ package com.theveloper.pixelplay.utils
 import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
-import android.util.Log
 import com.theveloper.pixelplay.data.database.MusicDao
+import timber.log.Timber
 import java.io.File
 import java.util.Locale
 
@@ -44,31 +44,32 @@ object AudioMetaUtils {
                 bitrate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()
                 sampleRate = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_SAMPLERATE)?.toIntOrNull()
             } catch (e: Exception) {
-                Log.w("AudioMetaUtils", "Retriever failed for $filePath: ${e.message}")
+                Timber.tag("AudioMetaUtils").w(e, "Retriever failed for $filePath")
             }
         }
 
         // Fallback with MediaExtractor
+        val extractor = MediaExtractor()
         try {
-            MediaExtractor().apply {
-                setDataSource(filePath)
-                for (i in 0 until trackCount) {
-                    val format: MediaFormat = getTrackFormat(i)
-                    val trackMime = format.getString(MediaFormat.KEY_MIME)
-                    if (trackMime?.startsWith("audio/") == true) {
-                        mimeType = mimeType ?: trackMime
-                        sampleRate =
-                            sampleRate ?: format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
-                        bitrate = bitrate ?: if (format.containsKey(MediaFormat.KEY_BIT_RATE)) {
-                            format.getInteger(MediaFormat.KEY_BIT_RATE)
-                        } else null
-                        break
-                    }
+            extractor.setDataSource(filePath)
+            for (i in 0 until extractor.trackCount) {
+                val format: MediaFormat = extractor.getTrackFormat(i)
+                val trackMime = format.getString(MediaFormat.KEY_MIME)
+                if (trackMime?.startsWith("audio/") == true) {
+                    mimeType = mimeType ?: trackMime
+                    sampleRate = sampleRate ?: if (format.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+                        format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                    } else null
+                    bitrate = bitrate ?: if (format.containsKey(MediaFormat.KEY_BIT_RATE)) {
+                        format.getInteger(MediaFormat.KEY_BIT_RATE)
+                    } else null
+                    break
                 }
-                release()
             }
         } catch (e: Exception) {
-            Log.w("AudioMetaUtils", "Extractor failed for $filePath: ${e.message}")
+            Timber.tag("AudioMetaUtils").w(e, "Extractor failed for $filePath")
+        } finally {
+            runCatching { extractor.release() }
         }
 
         return AudioMeta(mimeType, bitrate, sampleRate)

--- a/app/src/main/java/com/theveloper/pixelplay/utils/Formats.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/Formats.kt
@@ -1,6 +1,7 @@
 package com.theveloper.pixelplay.utils
 
 import com.theveloper.pixelplay.data.model.Song
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 fun formatDuration(milliseconds: Long): String {
@@ -12,9 +13,9 @@ fun formatDuration(milliseconds: Long): String {
     val seconds = totalSeconds % 60
 
     return if (hours > 0) {
-        String.format("%02d:%02d:%02d", hours, minutes, seconds)
+        String.format(Locale.US, "%02d:%02d:%02d", hours, minutes, seconds)
     } else {
-        String.format("%02d:%02d", minutes, seconds)
+        String.format(Locale.US, "%02d:%02d", minutes, seconds)
     }
 }
 
@@ -23,9 +24,9 @@ fun formatTotalDuration(songs: List<Song>): String {
     val hours = TimeUnit.MILLISECONDS.toHours(totalMillis)
     val minutes = TimeUnit.MILLISECONDS.toMinutes(totalMillis) % 60
     return if (hours > 0) {
-        String.format("%d h %02d min", hours, minutes)
+        String.format(Locale.US, "%d h %02d min", hours, minutes)
     } else {
-        String.format("%d min", minutes)
+        String.format(Locale.US, "%d min", minutes)
     }
 }
 
@@ -35,10 +36,10 @@ fun formatListeningDurationLong(milliseconds: Long): String {
     val minutes = totalMinutes % 60
     val seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds) % 60
     return when {
-        hours > 0 && minutes > 0 -> String.format("%d h %02d m", hours, minutes)
-        hours > 0 -> String.format("%d h", hours)
-        minutes > 0 -> String.format("%d m", minutes)
-        else -> String.format("%d s", seconds)
+        hours > 0 && minutes > 0 -> String.format(Locale.US, "%d h %02d m", hours, minutes)
+        hours > 0 -> String.format(Locale.US, "%d h", hours)
+        minutes > 0 -> String.format(Locale.US, "%d m", minutes)
+        else -> String.format(Locale.US, "%d s", seconds)
     }
 }
 
@@ -48,10 +49,10 @@ fun formatListeningDurationCompact(milliseconds: Long): String {
     val minutes = totalMinutes % 60
     val seconds = TimeUnit.MILLISECONDS.toSeconds(milliseconds) % 60
     return when {
-        hours > 0 && minutes > 0 -> String.format("%dh %02dm", hours, minutes)
-        hours > 0 -> String.format("%dh", hours)
-        minutes > 0 -> String.format("%dm", minutes)
-        else -> String.format("%ds", seconds)
+        hours > 0 && minutes > 0 -> String.format(Locale.US, "%dh %02dm", hours, minutes)
+        hours > 0 -> String.format(Locale.US, "%dh", hours)
+        minutes > 0 -> String.format(Locale.US, "%dm", minutes)
+        else -> String.format(Locale.US, "%ds", seconds)
     }
 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaMetadataRetrieverPool.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaMetadataRetrieverPool.kt
@@ -2,6 +2,7 @@ package com.theveloper.pixelplay.utils
 
 import android.media.MediaMetadataRetriever
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Thread-safe helper for MediaMetadataRetriever usage.
@@ -58,6 +59,8 @@ object MediaMetadataRetrieverPool {
         val retriever = acquire()
         return try {
             block(retriever)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             null
         } finally {

--- a/app/src/main/res/values/strings_screens.xml
+++ b/app/src/main/res/values/strings_screens.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- Navigation / misc -->
     <string name="nav_error_genre_id_missing">Error: Genre ID missing</string>
+    <string name="nav_error_item_id_missing">Error: required ID missing</string>
     <string name="easter_egg_thank_you">Thank you for using PixelPlayer!</string>
 
     <!-- Word delimiter config -->

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearDataListenerService.kt
@@ -121,9 +121,7 @@ class WearDataListenerService : WearableListenerService() {
                 try {
                     val dataClient = Wearable.getDataClient(this@WearDataListenerService)
                     val response = dataClient.getFdForAsset(asset).await()
-                    val inputStream = response.inputStream
-                    val bitmap = BitmapFactory.decodeStream(inputStream)
-                    inputStream.close()
+                    val bitmap = response.inputStream.use { BitmapFactory.decodeStream(it) }
                     stateRepository.updateAlbumArt(bitmap)
                     Timber.tag(TAG).d("Album art updated")
                 } catch (e: Exception) {

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackController.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearPlaybackController.kt
@@ -138,7 +138,8 @@ class WearPlaybackController @Inject constructor(
     fun setSleepTimerDuration(durationMinutes: Int) = sendCommand(
         WearPlaybackCommand(
             action = WearPlaybackCommand.SET_SLEEP_TIMER_DURATION,
-            durationMinutes = durationMinutes,
+            // Clamp to a sane range (1 min .. 8 h) so a corrupt/hostile value can't reach the phone.
+            durationMinutes = durationMinutes.coerceIn(1, 8 * 60),
         )
     )
 

--- a/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
+++ b/wear/src/main/java/com/theveloper/pixelplay/data/WearTransferRepository.kt
@@ -1077,12 +1077,17 @@ class WearTransferRepository @Inject constructor(
         return String(data, Charsets.UTF_8)
     }
 
-    private fun InputStream.readBytesSafely(): ByteArray {
+    private fun InputStream.readBytesSafely(maxBytes: Int = 8 * 1024 * 1024): ByteArray {
         val buffer = ByteArray(8192)
         val output = java.io.ByteArrayOutputStream()
+        var total = 0
         while (true) {
             val read = read(buffer)
             if (read <= 0) break
+            total += read
+            // Cap the payload so a malicious/buggy phone cannot OOM the (RAM-constrained) watch.
+            // The caller wraps this in runCatching, so the throw fails the transfer gracefully.
+            require(total <= maxBytes) { "Payload exceeds max $maxBytes bytes" }
             output.write(buffer, 0, read)
         }
         return output.toByteArray()


### PR DESCRIPTION
Addresses ~60 issues re-verified against current source (review false positives excluded). Highlights:

- Cast HTTP server: thread-safe MIME/codec caches, atomic transcode-cache miss path, correct ADTS channel count for multichannel, no path leak in 500s
- Cast: unregister-before-register callbacks, app-scope transfer-back on session end, non-blocking IPv4 parse, active-scan downgrade in finally
- Media: try/finally release for MediaCodec/MediaExtractor, retriever pool rethrows CancellationException, atomic (backup+restore) metadata write-back
- DB: AlbumArtThemeEntity composite primary key + migration 41->42 so palette styles no longer overwrite each other
- DataStore: AI API keys excluded from backup export, EQ preset mutations made single-transaction
- StateHolders/VM: unregister AudioDeviceCallback, keep allSongsById in sync, emit resolved artistId, drop orphan Trace.endSection, share end-of-track flow
- TransitionController recreates its scope on restart; setHiFiMode guarded against player rebuild mid-transition
- Wear/Auto: handle PLAY_ITEM/PLAY_NEXT/ADD_TO_QUEUE, search result budgeting, InputStream.use + payload cap, bounded LRU artwork cache
- Navigation: lifecycle guard on navigateToTopLevelSafely, -1L sentinel guards, null-arg fallbacks, Screen.* route constants
- UI: state slicing in Cast/full-player sheets, keyed MutableInteractionSource, remove derivedStateOf-in-remember antipattern
- Misc: startForegroundService for sleep timer, locale-safe Formats, backup cover-image size cap + path sanitize, raw Log -> Timber in hot paths

Compiles (:app + :wear). No new unit-test failures.