### PR TITLE
perf: optimize navigation bar and blur animations via caching and dra…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -75,6 +76,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -141,6 +143,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 import com.theveloper.pixelplay.presentation.utils.AppHapticsConfig
@@ -659,6 +662,7 @@ class MainActivity : ComponentActivity() {
         val navBarCompactMode by playerViewModel.navBarCompactMode.collectAsStateWithLifecycle()
         val navBarCornerRadiusRaw by playerViewModel.navBarCornerRadius.collectAsStateWithLifecycle()
         val navBarCornerRadius = sanitizeNavBarCornerRadius(navBarCornerRadiusRaw)
+        val useSmoothCorners by playerViewModel.useSmoothCorners.collectAsStateWithLifecycle()
         val isMiniPlayerDismissing by playerViewModel.isMiniPlayerDismissing.collectAsStateWithLifecycle()
         val hapticsEnabled by playerViewModel.hapticsEnabled.collectAsStateWithLifecycle()
         val rootView = LocalView.current
@@ -694,7 +698,7 @@ class MainActivity : ComponentActivity() {
         val navBarOccupiedHeight by remember(systemNavBarInset, navBarCompactMode) {
             derivedStateOf { resolveNavBarOccupiedHeight(systemNavBarInset, navBarCompactMode) }
         }
-        val navBarVisibilityProgress by animateFloatAsState(
+        val navBarVisibilityProgressState = animateFloatAsState(
             targetValue = if (shouldHideNavigationBar) 0f else 1f,
             animationSpec = tween(
                 durationMillis = 220,
@@ -702,6 +706,7 @@ class MainActivity : ComponentActivity() {
             ),
             label = "NavBarVisibilityProgress"
         )
+        val navBarVisibilityProgress by navBarVisibilityProgressState
         val visibleNavBarOccupiedHeight by remember(navBarOccupiedHeight, navBarVisibilityProgress) {
             derivedStateOf { navBarOccupiedHeight * navBarVisibilityProgress }
         }
@@ -794,54 +799,21 @@ class MainActivity : ComponentActivity() {
                         val showPlayerContentArea = currentSongId != null
                         val navBarElevation = 3.dp
 
-                        val animatedNavBarCornerRadius by animateDpAsState(
+                        val animatedNavBarCornerRadius = animateDpAsState(
                             targetValue = navBarCornerRadius.dp,
                             animationSpec = tween(400),
                             label = "NavBarCornerRadius"
                         )
 
-                        val animatedDefaultTopCornerRadius by animateDpAsState(
+                        val animatedDefaultTopCornerRadius = animateDpAsState(
                             targetValue = if (showPlayerContentArea && !isMiniPlayerDismissing) 10.dp else navBarCornerRadius.dp,
                             animationSpec = tween(400),
                             label = "NavBarDefaultTopCornerRadius"
                         )
 
-                        val actualShape = remember(
-                            navBarStyle,
-                            showPlayerContentArea,
-                            isMiniPlayerDismissing,
-                            navBarCornerRadius,
-                            animatedNavBarCornerRadius,
-                            animatedDefaultTopCornerRadius
-                        ) {
-                            DynamicSmoothCornerShape(
-                                topRadiusProvider = {
-                                    val fraction = playerViewModel.playerContentExpansionFraction.value
-                                    if (navBarStyle == NavBarStyle.DEFAULT) {
-                                        animatedDefaultTopCornerRadius
-                                    } else if (navBarStyle == NavBarStyle.FULL_WIDTH) {
-                                        lerp(navBarCornerRadius.dp, 26.dp, fraction)
-                                    } else if (showPlayerContentArea) {
-                                        if (fraction < 0.2f) {
-                                            lerp(navBarCornerRadius.dp, 26.dp, (fraction / 0.2f).coerceIn(0f, 1f))
-                                        } else {
-                                            26.dp
-                                        }
-                                    } else {
-                                        navBarCornerRadius.dp
-                                    }
-                                },
-                                bottomRadiusProvider = {
-                                    if (navBarStyle == NavBarStyle.DEFAULT) {
-                                        animatedNavBarCornerRadius
-                                    } else if (navBarStyle == NavBarStyle.FULL_WIDTH) {
-                                        0.dp
-                                    } else {
-                                        animatedNavBarCornerRadius
-                                    }
-                                }
-                            )
-                        }
+                        // Shape is now resolved per quantized radius in the draw phase
+                        // (see the Surface graphicsLayer below) instead of being
+                        // re-remembered every animation frame.
 
                         var componentHeightPx by remember { mutableStateOf(0) }
                         val density = LocalDensity.current
@@ -851,11 +823,15 @@ class MainActivity : ComponentActivity() {
                         val bottomBarPaddingPx = remember(bottomBarPadding, density) {
                             with(density) { bottomBarPadding.toPx() }
                         }
+                        val navBarElevationPx = remember(navBarElevation, density) {
+                            with(density) { navBarElevation.toPx() }
+                        }
+                        val navBarShapeCache = remember { NavBarShapeCache() }
 
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(visibleNavBarOccupiedHeight)
+                                .height(navBarOccupiedHeight)
                                 .clipToBounds()
                         ) {
                             val onSearchIconDoubleTap = remember(playerViewModel) {
@@ -869,19 +845,45 @@ class MainActivity : ComponentActivity() {
                                     .padding(bottom = bottomBarPadding)
                                     .onSizeChanged { componentHeightPx = it.height }
                                     .graphicsLayer {
-                                        val hideFraction = if (showPlayerContentArea) {
+                                        // Slide-down hide: covers both the player-expansion
+                                        // hide and the route-based hide as a pure translation,
+                                        // so child items never resize or get clipped/squished.
+                                        val expansionHide = if (showPlayerContentArea) {
                                             playerViewModel.playerContentExpansionFraction.value.coerceIn(0f, 1f)
                                         } else {
                                             0f
                                         }
+                                        val routeHide = (1f - navBarVisibilityProgressState.value).coerceIn(0f, 1f)
+                                        val hideFraction = maxOf(expansionHide, routeHide)
                                         translationY = (componentHeightPx + shadowOverflowPx + bottomBarPaddingPx) * hideFraction
                                         alpha = 1f
                                     }
                                     .height(navBarHeight)
-                                    .padding(horizontal = horizontalPadding),
-                                color = NavigationBarDefaults.containerColor,
-                                shape = actualShape,
-                                shadowElevation = navBarElevation
+                                    .padding(horizontal = horizontalPadding)
+                                    .graphicsLayer {
+                                        // Animated corner shape resolved in the draw phase:
+                                        // animating the radius re-clips this layer only — no
+                                        // recomposition and no layout pass for the bar.
+                                        val fraction = playerViewModel.playerContentExpansionFraction.value
+                                        val topDp = when {
+                                            navBarStyle == NavBarStyle.DEFAULT -> animatedDefaultTopCornerRadius.value
+                                            navBarStyle == NavBarStyle.FULL_WIDTH -> lerp(navBarCornerRadius.dp, 26.dp, fraction)
+                                            showPlayerContentArea -> if (fraction < 0.2f) {
+                                                lerp(navBarCornerRadius.dp, 26.dp, (fraction / 0.2f).coerceIn(0f, 1f))
+                                            } else {
+                                                26.dp
+                                            }
+                                            else -> navBarCornerRadius.dp
+                                        }
+                                        val bottomDp = when (navBarStyle) {
+                                            NavBarStyle.FULL_WIDTH -> 0.dp
+                                            else -> animatedNavBarCornerRadius.value
+                                        }
+                                        shape = navBarShapeCache.get(this, topDp.toPx(), bottomDp.toPx(), useSmoothCorners)
+                                        clip = true
+                                        shadowElevation = navBarElevationPx
+                                    },
+                                color = NavigationBarDefaults.containerColor
                             ) {
                                 PlayerInternalNavigationBar(
                                     navController = navController,
@@ -932,23 +934,19 @@ class MainActivity : ComponentActivity() {
                         val expansionFractionProvider = remember(playerViewModel.playerContentExpansionFraction) {
                             { playerViewModel.playerContentExpansionFraction.value }
                         }
+                        val blurEffectCache = remember { BlurEffectCache() }
 
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
                                 .graphicsLayer {
-                                    val fraction = expansionFractionProvider()
                                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                        val blurPx = fraction * 100f // 40px target blur at 100% expanded
-                                        if (blurPx > 0f) {
-                                            renderEffect = AndroidRenderEffect.createBlurEffect(
-                                                blurPx,
-                                                blurPx,
-                                                AndroidShader.TileMode.CLAMP
-                                            ).asComposeRenderEffect()
-                                        } else {
-                                            renderEffect = null
-                                        }
+                                        val fraction = expansionFractionProvider()
+                                        // Quantize to 4px steps: rebuild the RenderEffect only
+                                        // when the blur crosses a step, reuse the cached object
+                                        // every other frame.
+                                        val quantizedBlurPx = (fraction * 100f / 4f).roundToInt() * 4f
+                                        renderEffect = blurEffectCache.get(quantizedBlurPx)
                                     }
                                 }
                         ) {
@@ -1135,27 +1133,121 @@ class MainActivity : ComponentActivity() {
 
 }
 
+/**
+ * Caches the (expensive) RenderEffect Java object so we don't allocate a new
+ * blur every animation frame. The radius is quantized at the call site, so this
+ * only rebuilds ~25 times across the whole expand animation instead of 60+/sec.
+ */
+private class BlurEffectCache {
+    private var lastRadiusPx: Float = Float.NaN
+    private var cached: androidx.compose.ui.graphics.RenderEffect? = null
+
+    fun get(radiusPx: Float): androidx.compose.ui.graphics.RenderEffect? {
+        if (radiusPx <= 0f) {
+            lastRadiusPx = 0f
+            cached = null
+            return null
+        }
+        if (radiusPx != lastRadiusPx) {
+            lastRadiusPx = radiusPx
+            cached = AndroidRenderEffect
+                .createBlurEffect(radiusPx, radiusPx, AndroidShader.TileMode.CLAMP)
+                .asComposeRenderEffect()
+        }
+        return cached
+    }
+}
+
+/**
+ * Returns a cached Shape instance for a quantized (top, bottom) radius pair.
+ * Because the instance identity is stable while the radii don't move past a
+ * sub-pixel threshold, the graphics layer reuses its cached Outline between
+ * frames and only re-clips when the radius actually changes.
+ */
+private class NavBarShapeCache {
+    private var lastTopPx: Float = Float.NaN
+    private var lastBottomPx: Float = Float.NaN
+    private var lastSmooth: Boolean = true
+    private var cached: androidx.compose.ui.graphics.Shape = RectangleShape
+
+    fun get(
+        density: androidx.compose.ui.unit.Density,
+        topPx: Float,
+        bottomPx: Float,
+        smooth: Boolean
+    ): androidx.compose.ui.graphics.Shape {
+        if (smooth == lastSmooth &&
+            !lastTopPx.isNaN() &&
+            kotlin.math.abs(topPx - lastTopPx) < 0.5f &&
+            kotlin.math.abs(bottomPx - lastBottomPx) < 0.5f
+        ) {
+            return cached
+        }
+        lastTopPx = topPx
+        lastBottomPx = bottomPx
+        lastSmooth = smooth
+        cached = with(density) {
+            DynamicSmoothCornerShape(
+                useSmoothCorners = smooth,
+                topRadius = topPx.toDp(),
+                bottomRadius = bottomPx.toDp()
+            )
+        }
+        return cached
+    }
+}
+
+/**
+ * Fixed-radius corner shape. Swaps AbsoluteSmoothCornerShape for a plain
+ * RoundedCornerShape when smooth corners are disabled in settings. The radius
+ * values are identical in both branches, so the animated radius behavior is
+ * unchanged regardless of which delegate is active. The resulting Outline is
+ * cached per (size, layoutDirection) so repeated draws are cheap.
+ */
 private class DynamicSmoothCornerShape(
-    private val topRadiusProvider: () -> androidx.compose.ui.unit.Dp,
-    private val bottomRadiusProvider: () -> androidx.compose.ui.unit.Dp
+    private val useSmoothCorners: Boolean,
+    private val topRadius: androidx.compose.ui.unit.Dp,
+    private val bottomRadius: androidx.compose.ui.unit.Dp
 ) : androidx.compose.ui.graphics.Shape {
+
+    private var cachedSize: androidx.compose.ui.geometry.Size =
+        androidx.compose.ui.geometry.Size.Unspecified
+    private var cachedLayoutDirection: androidx.compose.ui.unit.LayoutDirection? = null
+    private var cachedOutline: androidx.compose.ui.graphics.Outline? = null
+
     override fun createOutline(
         size: androidx.compose.ui.geometry.Size,
         layoutDirection: androidx.compose.ui.unit.LayoutDirection,
         density: androidx.compose.ui.unit.Density
     ): androidx.compose.ui.graphics.Outline {
-        val topRadius = topRadiusProvider()
-        val bottomRadius = bottomRadiusProvider()
-        val delegate = AbsoluteSmoothCornerShape(
-            cornerRadiusTL = topRadius,
-            smoothnessAsPercentTL = 60,
-            cornerRadiusTR = topRadius,
-            smoothnessAsPercentTR = 60,
-            cornerRadiusBL = bottomRadius,
-            smoothnessAsPercentBL = 60,
-            cornerRadiusBR = bottomRadius,
-            smoothnessAsPercentBR = 60
-        )
-        return delegate.createOutline(size, layoutDirection, density)
+        cachedOutline?.let {
+            if (cachedSize == size && cachedLayoutDirection == layoutDirection) return it
+        }
+
+        val delegate: androidx.compose.ui.graphics.Shape = if (useSmoothCorners) {
+            AbsoluteSmoothCornerShape(
+                cornerRadiusTL = topRadius,
+                smoothnessAsPercentTL = 60,
+                cornerRadiusTR = topRadius,
+                smoothnessAsPercentTR = 60,
+                cornerRadiusBL = bottomRadius,
+                smoothnessAsPercentBL = 60,
+                cornerRadiusBR = bottomRadius,
+                smoothnessAsPercentBR = 60
+            )
+        } else {
+            RoundedCornerShape(
+                topStart = topRadius,
+                topEnd = topRadius,
+                bottomEnd = bottomRadius,
+                bottomStart = bottomRadius
+            )
+        }
+
+        return delegate.createOutline(size, layoutDirection, density).also {
+            cachedSize = size
+            cachedLayoutDirection = layoutDirection
+            cachedOutline = it
+        }
     }
 }


### PR DESCRIPTION
…w-phase clipping

Implements performance optimizations for the navigation bar and background blur during player expansion. These changes reduce recompositions and object allocations by moving clipping to the graphics layer and caching expensive UI objects.

- Moved navigation bar shape and clipping logic to `graphicsLayer` to avoid triggering layout passes during corner radius animations.
- Introduced `BlurEffectCache` to quantize blur radii (4px steps) and reuse `RenderEffect` instances, reducing allocations during expansion.
- Added `NavBarShapeCache` to provide stable `Shape` instances for quantized corner radii.
- Refactored `DynamicSmoothCornerShape` to cache generated `Outline` paths and support toggling between smooth and standard rounded corners.
- Updated navigation bar visibility logic to use vertical translation instead of height changes, preventing child elements from resizing or squishing during transitions.
- Integrated `useSmoothCorners` state to dynamically switch between `AbsoluteSmoothCornerShape` and `RoundedCornerShape`.