### PR TITLE
Opt: Add setArtworkData for MediaItem

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -111,6 +111,42 @@ import androidx.core.net.toUri
 
 // Acciones personalizadas para compatibilidad con el widget existente
 
+suspend fun loadArtworkBytesViaCoil(context: Context, uri: Uri): ByteArray? {
+    val appContext = context.applicationContext
+    val request = ImageRequest.Builder(appContext)
+        .data(uri)
+        .size(
+            ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx,
+            ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx,
+        )
+        .precision(Precision.INEXACT)
+        .allowHardware(false)
+        .memoryCachePolicy(CachePolicy.ENABLED)
+        .networkCachePolicy(CachePolicy.ENABLED)
+        .build()
+
+    return runCatching {
+        val drawable = appContext.imageLoader.execute(request).drawable ?: return@runCatching null
+        val fallbackSizePx = ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx
+        val bitmap = drawable.toBitmap(
+            width = drawable.intrinsicWidth.takeIf { it > 0 } ?: fallbackSizePx,
+            height = drawable.intrinsicHeight.takeIf { it > 0 } ?: fallbackSizePx,
+            config = Bitmap.Config.ARGB_8888,
+        )
+        val encodedBytes = ByteArrayOutputStream().use { output ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 92, output)
+            output.toByteArray()
+        }
+        ArtworkTransportSanitizer.sanitizeEncodedBytes(
+            data = encodedBytes,
+            config = ArtworkTransportSanitizer.WIDGET_CONFIG,
+        )
+    }.getOrElse { error ->
+        Timber.tag("MusicService_PixelPlay").w(error, "Artwork read failed via Coil for uri=%s", uri)
+        null
+    }
+}
+
 
 @UnstableApi
 @AndroidEntryPoint
@@ -2343,7 +2379,6 @@ class MusicService : MediaLibraryService() {
             }
             if (remote.artworkUri != null) {
                 artworkUri = remote.artworkUri
-                artworkData = null
             }
             isPlaying = remote.isPlaying
             currentPosition = remote.currentPositionMs
@@ -2680,7 +2715,7 @@ class MusicService : MediaLibraryService() {
                 }
     }
 
-    private suspend fun loadArtworkBytesForWidget(uri: Uri): ByteArray? {
+    public suspend fun loadArtworkBytesForWidget(uri: Uri): ByteArray? {
         val uriString = uri.toString()
         val scheme = uri.scheme?.lowercase()
         val isLocalArtworkUri = com.theveloper.pixelplay.utils.LocalArtworkUri.isLocalArtworkUri(uriString)
@@ -2726,42 +2761,7 @@ class MusicService : MediaLibraryService() {
                     connection?.disconnect()
                 }
             }
-            else -> loadArtworkBytesViaCoil(uri)
-        }
-    }
-
-    private suspend fun loadArtworkBytesViaCoil(uri: Uri): ByteArray? {
-        val request = ImageRequest.Builder(applicationContext)
-            .data(uri)
-            .size(
-                ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx,
-                ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx,
-            )
-            .precision(Precision.INEXACT)
-            .allowHardware(false)
-            .memoryCachePolicy(CachePolicy.ENABLED)
-            .networkCachePolicy(CachePolicy.ENABLED)
-            .build()
-
-        return runCatching {
-            val drawable = applicationContext.imageLoader.execute(request).drawable ?: return@runCatching null
-            val fallbackSizePx = ArtworkTransportSanitizer.WIDGET_CONFIG.maxDimensionPx
-            val bitmap = drawable.toBitmap(
-                width = drawable.intrinsicWidth.takeIf { it > 0 } ?: fallbackSizePx,
-                height = drawable.intrinsicHeight.takeIf { it > 0 } ?: fallbackSizePx,
-                config = Bitmap.Config.ARGB_8888,
-            )
-            val encodedBytes = ByteArrayOutputStream().use { output ->
-                bitmap.compress(Bitmap.CompressFormat.JPEG, 92, output)
-                output.toByteArray()
-            }
-            ArtworkTransportSanitizer.sanitizeEncodedBytes(
-                data = encodedBytes,
-                config = ArtworkTransportSanitizer.WIDGET_CONFIG,
-            )
-        }.getOrElse { error ->
-            Timber.tag(TAG).w(error, "Widget artwork read failed via Coil for uri=%s", uri)
-            null
+            else -> loadArtworkBytesViaCoil(applicationContext, uri)
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaItemBuilder.kt
@@ -3,13 +3,20 @@ package com.theveloper.pixelplay.utils
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import androidx.annotation.OptIn
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MediaMetadata.PICTURE_TYPE_FRONT_COVER
+import androidx.media3.common.util.UnstableApi
 import com.theveloper.pixelplay.data.provider.SharedArtworkContentProvider
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.service.loadArtworkBytesViaCoil
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 object MediaItemBuilder {
     private const val EXTERNAL_MEDIA_ID_PREFIX = "external:"
@@ -111,6 +118,7 @@ object MediaItemBuilder {
             .setMediaMetadata(
                 buildMediaMetadataForSong(
                     song = song,
+                    context = context,
                     exposedArtworkUri = externalControllerArtworkUri(context, song.albumArtUriString)
                 )
             )
@@ -259,8 +267,10 @@ object MediaItemBuilder {
         }
     }
 
+    @OptIn(UnstableApi::class)
     private fun buildMediaMetadataForSong(
         song: Song,
+        context: Context? = null,
         exposedArtworkUri: Uri? = artworkUri(song.albumArtUriString)
     ): MediaMetadata {
         val metadataBuilder = MediaMetadata.Builder()
@@ -270,6 +280,13 @@ object MediaItemBuilder {
 
         exposedArtworkUri?.let { artworkUri ->
             metadataBuilder.setArtworkUri(artworkUri)
+            context?.let { appContext ->
+                runBlocking(Dispatchers.IO) {
+                    loadArtworkBytesViaCoil(appContext, artworkUri)
+                }?.let { artworkData ->
+                    metadataBuilder.setArtworkData(artworkData, PICTURE_TYPE_FRONT_COVER)
+                }
+            }
         }
 
         val extras = Bundle().apply {


### PR DESCRIPTION
For my Samsung Glaxy Watch, artwork uri couldn't be loaded for the watch, so i added the artwrok data.
loadArtworkBytesViaCoil function is also be lifted up to the top class, so i can re-use the function to deal with the uri

before
<img width="4032" height="2268" alt="DSC_0053" src="https://github.com/user-attachments/assets/054f80ab-6268-4ea6-adb7-701312c740f6" />

after
<img width="4032" height="2268" alt="DSC_0055" src="https://github.com/user-attachments/assets/28794aae-a99a-4ef2-9e5d-6b244dfdc57c" />
