### PR TITLE
refactor: delegate shuffle and playback orchestration to QueueStateHo…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1120,6 +1120,31 @@ class PlayerViewModel @Inject constructor(
         reloadLyricsForCurrentSong = ::loadLyricsForCurrentSong,
     )
 
+    /**
+     * Bundles the ViewModel-owned collaborators that [QueueStateHolder]'s shuffle entry points
+     * need (source resolution + shuffled-playback dispatch), without that holder depending on
+     * this ViewModel.
+     */
+    private fun shufflePlaybackCallbacks() = ShufflePlaybackCallbacks(
+        scope = viewModelScope,
+        currentStorageFilter = { playerUiState.value.currentStorageFilter },
+        albums = { libraryStateHolder.albums.value },
+        artists = { libraryStateHolder.artists.value },
+        playShuffled = { songs, queueName -> playSongsShuffled(songs, queueName, startAtZero = true) },
+    )
+
+    /**
+     * Bundles the ViewModel collaborators that [QueueStateHolder]'s album/artist play entry
+     * points need to dispatch sequential playback and reveal the player sheet.
+     */
+    private fun playbackSourceCallbacks() = PlaybackSourceCallbacks(
+        scope = viewModelScope,
+        playSongs = { songs, startSong, queueName, playlistId ->
+            playSongs(songs, startSong, queueName, playlistId)
+        },
+        showSheet = { _isSheetVisible.value = true },
+    )
+
     fun onSearchNavIconDoubleTapped() {
         _searchNavDoubleTapEvents.tryEmit(Unit)
     }
@@ -1479,17 +1504,8 @@ class PlayerViewModel @Inject constructor(
         )
     }
 
-    fun shuffleAllSongs(queueName: String = "All Songs (Shuffled)") {
-        Log.d("ShuffleDebug", "shuffleAllSongs called.")
-        
-        // Load random songs from DB instead of materializing the entire library
-        viewModelScope.launch {
-            val randomSongs = musicRepository.getRandomSongs(limit = 500)
-            if (randomSongs.isNotEmpty()) {
-                playSongsShuffled(randomSongs, queueName, startAtZero = true)
-            }
-        }
-    }
+    fun shuffleAllSongs(queueName: String = "All Songs (Shuffled)") =
+        queueStateHolder.shuffleAll(queueName, shufflePlaybackCallbacks())
 
     /**
      * Called from Quick Settings tile. Unlike shuffleAllSongs(), this always starts
@@ -1544,52 +1560,17 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    fun playRandomSong() {
-        viewModelScope.launch {
-            val randomSongs = musicRepository.getRandomSongs(limit = 500)
-            if (randomSongs.isNotEmpty()) {
-                playSongsShuffled(randomSongs, "All Songs (Shuffled)", startAtZero = true)
-            }
-        }
-    }
+    fun playRandomSong() =
+        queueStateHolder.playRandom(shufflePlaybackCallbacks())
 
-    fun shuffleFavoriteSongs() {
-        Log.d("ShuffleDebug", "shuffleFavoriteSongs called.")
+    fun shuffleFavoriteSongs() =
+        queueStateHolder.shuffleFavorites(shufflePlaybackCallbacks())
 
-        // Load favorite songs from DB on-demand instead of holding them in memory
-        viewModelScope.launch {
-            val favSongs = musicRepository.getFavoriteSongsOnce(playerUiState.value.currentStorageFilter)
-            if (favSongs.isNotEmpty()) {
-                playSongsShuffled(favSongs, "Liked Songs (Shuffled)", startAtZero = true)
-            }
-        }
-    }
+    fun shuffleRandomAlbum() =
+        queueStateHolder.shuffleRandomAlbum(shufflePlaybackCallbacks())
 
-    fun shuffleRandomAlbum() {
-        viewModelScope.launch {
-            val allAlbums = libraryStateHolder.albums.value
-            if (allAlbums.isNotEmpty()) {
-                val randomAlbum = allAlbums.random()
-                val albumSongs = musicRepository.getSongsForAlbum(randomAlbum.id).first()
-                if (albumSongs.isNotEmpty()) {
-                    playSongsShuffled(albumSongs, randomAlbum.title, startAtZero = true)
-                }
-            }
-        }
-    }
-
-    fun shuffleRandomArtist() {
-        viewModelScope.launch {
-            val allArtists = libraryStateHolder.artists.value
-            if (allArtists.isNotEmpty()) {
-                val randomArtist = allArtists.random()
-                val artistSongs = musicRepository.getSongsForArtist(randomArtist.id).first()
-                if (artistSongs.isNotEmpty()) {
-                    playSongsShuffled(artistSongs, randomArtist.name, startAtZero = true)
-                }
-            }
-        }
-    }
+    fun shuffleRandomArtist() =
+        queueStateHolder.shuffleRandomArtist(shufflePlaybackCallbacks())
 
 
     private fun loadPersistedDailyMix() {
@@ -2362,52 +2343,11 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
-    fun playAlbum(album: Album) {
-        Log.d("ShuffleDebug", "playAlbum called for album: ${album.title}")
-        viewModelScope.launch {
-            try {
-                val songsList: List<Song> = withContext(Dispatchers.IO) {
-                    musicRepository.getSongsForAlbum(album.id).first()
-                }
+    fun playAlbum(album: Album) =
+        queueStateHolder.playAlbum(album, playbackSourceCallbacks())
 
-                if (songsList.isNotEmpty()) {
-                    val sortedSongs = songsList.sortedWith(
-                        compareBy<Song> { it.discNumber ?: 1 }
-                            .thenBy { if (it.trackNumber > 0) it.trackNumber else Int.MAX_VALUE }
-                            .thenBy { it.title.lowercase() }
-                    )
-
-                    playSongs(sortedSongs, sortedSongs.first(), album.title, null)
-                    _isSheetVisible.value = true // Mostrar reproductor
-                } else {
-                    Log.w("PlayerViewModel", "Album '${album.title}' has no playable songs.")
-                }
-            } catch (e: Exception) {
-                Log.e("PlayerViewModel", "Error playing album ${album.title}", e)
-            }
-        }
-    }
-
-    fun playArtist(artist: Artist) {
-        Log.d("ShuffleDebug", "playArtist called for artist: ${artist.name}")
-        viewModelScope.launch {
-            try {
-                val songsList: List<Song> = withContext(Dispatchers.IO) {
-                    musicRepository.getSongsForArtist(artist.id).first()
-                }
-
-                if (songsList.isNotEmpty()) {
-                    playSongs(songsList, songsList.first(), artist.name, null)
-                    _isSheetVisible.value = true
-                } else {
-                    Log.w("PlayerViewModel", "Artist '${artist.name}' has no playable songs.")
-                    // podrías emitir un evento Toast
-                }
-            } catch (e: Exception) {
-                Log.e("PlayerViewModel", "Error playing artist ${artist.name}", e)
-            }
-        }
-    }
+    fun playArtist(artist: Artist) =
+        queueStateHolder.playArtist(artist, playbackSourceCallbacks())
 
     fun removeSongFromQueue(songId: String) {
         queueUndoStateHolder.removeSongFromQueue(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolder.kt
@@ -1,21 +1,65 @@
 package com.theveloper.pixelplay.presentation.viewmodel
 
+import com.theveloper.pixelplay.data.model.Album
+import com.theveloper.pixelplay.data.model.Artist
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.model.StorageFilter
+import com.theveloper.pixelplay.data.repository.MusicRepository
 import com.theveloper.pixelplay.utils.QueueUtils
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
+ * Bundles the ViewModel-owned collaborators that the shuffle entry points need so this
+ * holder can resolve a song source and dispatch shuffled playback without depending on
+ * [PlayerViewModel]. Mirrors the lambda-callback pattern used by [MetadataEditCallbacks].
+ *
+ * - [scope]            the ViewModel's coroutine scope.
+ * - [currentStorageFilter] reads the active storage filter for favorites resolution.
+ * - [albums]/[artists] snapshot the in-memory library categories for the "random" pickers.
+ * - [playShuffled]     hands the resolved list to the ViewModel's shuffled-playback dispatch.
+ */
+class ShufflePlaybackCallbacks(
+    val scope: CoroutineScope,
+    val currentStorageFilter: () -> StorageFilter,
+    val albums: () -> List<Album>,
+    val artists: () -> List<Artist>,
+    val playShuffled: (songs: List<Song>, queueName: String) -> Unit,
+)
+
+/**
+ * Bundles the ViewModel collaborators that the album/artist play entry points need to
+ * dispatch sequential playback and reveal the player sheet.
+ */
+class PlaybackSourceCallbacks(
+    val scope: CoroutineScope,
+    val playSongs: (songs: List<Song>, startSong: Song, queueName: String, playlistId: String?) -> Unit,
+    val showSheet: () -> Unit,
+)
+
+/**
  * Manages queue shuffle state.
  * Extracted from PlayerViewModel to improve modularity.
- * 
+ *
  * This class handles the original queue order for shuffle/unshuffle operations.
  */
 @Singleton
-class QueueStateHolder @Inject constructor() {
-    
+class QueueStateHolder @Inject constructor(
+    private val musicRepository: MusicRepository
+) {
+
+    companion object {
+        private const val SHUFFLE_SAMPLE_LIMIT = 500
+        private const val ALL_SONGS_SHUFFLED_QUEUE = "All Songs (Shuffled)"
+        private const val FAVORITES_SHUFFLED_QUEUE = "Liked Songs (Shuffled)"
+    }
+
     // Original queue order before shuffle (for restoring when unshuffling)
     private var _originalQueueOrder: List<Song> = emptyList()
     val originalQueueOrder: List<Song> get() = _originalQueueOrder
@@ -121,5 +165,124 @@ class QueueStateHolder @Inject constructor() {
             QueueUtils.buildAnchoredShuffleQueueSuspending(songs, startIndex, startAtZero)
         }
         return Pair(shuffledQueue, startSong)
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /*                       Shuffle / play orchestration                         */
+    /* -------------------------------------------------------------------------- */
+
+    /**
+     * Shuffles a bounded random sample of the whole library. Loads songs straight from the
+     * repository instead of materializing the entire library in memory.
+     */
+    fun shuffleAll(
+        queueName: String = ALL_SONGS_SHUFFLED_QUEUE,
+        callbacks: ShufflePlaybackCallbacks
+    ) {
+        callbacks.scope.launch {
+            val randomSongs = musicRepository.getRandomSongs(limit = SHUFFLE_SAMPLE_LIMIT)
+            if (randomSongs.isNotEmpty()) {
+                callbacks.playShuffled(randomSongs, queueName)
+            }
+        }
+    }
+
+    /**
+     * Picks and plays a random song by shuffling a bounded random sample of the library.
+     */
+    fun playRandom(callbacks: ShufflePlaybackCallbacks) =
+        shuffleAll(ALL_SONGS_SHUFFLED_QUEUE, callbacks)
+
+    /**
+     * Shuffles the user's favorite songs. Favorites are loaded on demand rather than
+     * held in memory.
+     */
+    fun shuffleFavorites(callbacks: ShufflePlaybackCallbacks) {
+        callbacks.scope.launch {
+            val favSongs = musicRepository.getFavoriteSongsOnce(callbacks.currentStorageFilter())
+            if (favSongs.isNotEmpty()) {
+                callbacks.playShuffled(favSongs, FAVORITES_SHUFFLED_QUEUE)
+            }
+        }
+    }
+
+    /**
+     * Picks a random album and plays it shuffled.
+     */
+    fun shuffleRandomAlbum(callbacks: ShufflePlaybackCallbacks) {
+        callbacks.scope.launch {
+            val allAlbums = callbacks.albums()
+            if (allAlbums.isEmpty()) return@launch
+            val randomAlbum = allAlbums.random()
+            val albumSongs = musicRepository.getSongsForAlbum(randomAlbum.id).first()
+            if (albumSongs.isNotEmpty()) {
+                callbacks.playShuffled(albumSongs, randomAlbum.title)
+            }
+        }
+    }
+
+    /**
+     * Picks a random artist and plays their catalogue shuffled.
+     */
+    fun shuffleRandomArtist(callbacks: ShufflePlaybackCallbacks) {
+        callbacks.scope.launch {
+            val allArtists = callbacks.artists()
+            if (allArtists.isEmpty()) return@launch
+            val randomArtist = allArtists.random()
+            val artistSongs = musicRepository.getSongsForArtist(randomArtist.id).first()
+            if (artistSongs.isNotEmpty()) {
+                callbacks.playShuffled(artistSongs, randomArtist.name)
+            }
+        }
+    }
+
+    /**
+     * Loads an album's songs, orders them by disc/track, and dispatches sequential playback.
+     */
+    fun playAlbum(album: Album, callbacks: PlaybackSourceCallbacks) {
+        callbacks.scope.launch {
+            try {
+                val songsList: List<Song> = withContext(Dispatchers.IO) {
+                    musicRepository.getSongsForAlbum(album.id).first()
+                }
+
+                if (songsList.isNotEmpty()) {
+                    val sortedSongs = songsList.sortedWith(
+                        compareBy<Song> { it.discNumber ?: 1 }
+                            .thenBy { if (it.trackNumber > 0) it.trackNumber else Int.MAX_VALUE }
+                            .thenBy { it.title.lowercase() }
+                    )
+
+                    callbacks.playSongs(sortedSongs, sortedSongs.first(), album.title, null)
+                    callbacks.showSheet()
+                } else {
+                    Timber.w("Album '%s' has no playable songs.", album.title)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error playing album %s", album.title)
+            }
+        }
+    }
+
+    /**
+     * Loads an artist's songs and dispatches sequential playback.
+     */
+    fun playArtist(artist: Artist, callbacks: PlaybackSourceCallbacks) {
+        callbacks.scope.launch {
+            try {
+                val songsList: List<Song> = withContext(Dispatchers.IO) {
+                    musicRepository.getSongsForArtist(artist.id).first()
+                }
+
+                if (songsList.isNotEmpty()) {
+                    callbacks.playSongs(songsList, songsList.first(), artist.name, null)
+                    callbacks.showSheet()
+                } else {
+                    Timber.w("Artist '%s' has no playable songs.", artist.name)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error playing artist %s", artist.name)
+            }
+        }
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModelTest.kt
@@ -513,112 +513,56 @@ class PlayerViewModelTest {
             every { MediaItemBuilder.playbackUri(any<Song>()) } returns mockedPlaybackUri
         }
 
+        // Source resolution + shuffled dispatch now live in QueueStateHolder (Pass 2). The
+        // ViewModel methods are thin delegates, so these tests verify the delegation. The moved
+        // business logic is covered directly in QueueStateHolderTest.
         @Test
-        fun `shuffleAllSongs calls prepareShuffledQueue with random songs at index zero`() = runTest {
-            val randomSongs = listOf(song2, song3, song1)
-            coEvery { mockMusicRepository.getRandomSongs(500) } returns randomSongs
-            stubShuffledPlayback(randomSongs, "All Songs (Shuffled)", startSong = song2)
-
+        fun `shuffleAllSongs delegates to QueueStateHolder shuffleAll`() = runTest {
             playerViewModel.shuffleAllSongs()
             advanceUntilIdle()
 
-            coVerify { mockMusicRepository.getRandomSongs(500) }
-            coVerify {
-                mockQueueStateHolder.prepareShuffledQueueSuspending(
-                    randomSongs,
-                    "All Songs (Shuffled)",
-                    true
-                )
-            }
+            verify { mockQueueStateHolder.shuffleAll("All Songs (Shuffled)", any()) }
         }
 
         @Test
-        fun `playRandomSong calls prepareShuffledQueue with startAtZero`() = runTest {
-            val randomSongs = listOf(song3, song1, song2)
-            coEvery { mockMusicRepository.getRandomSongs(500) } returns randomSongs
-            stubShuffledPlayback(randomSongs, "All Songs (Shuffled)", startSong = song3)
-
+        fun `playRandomSong delegates to QueueStateHolder playRandom`() = runTest {
             playerViewModel.playRandomSong()
             advanceUntilIdle()
 
-            coVerify {
-                mockQueueStateHolder.prepareShuffledQueueSuspending(
-                    randomSongs,
-                    "All Songs (Shuffled)",
-                    true
-                )
-            }
+            verify { mockQueueStateHolder.playRandom(any()) }
         }
 
         @Test
-        fun `shuffleFavoriteSongs calls prepareShuffledQueue with startAtZero`() = runTest {
-            val favoriteSongs = listOf(song1, song3)
-            coEvery { mockMusicRepository.getFavoriteSongsOnce(StorageFilter.ALL) } returns favoriteSongs
-            stubShuffledPlayback(favoriteSongs, "Liked Songs (Shuffled)", startSong = song1)
-
+        fun `shuffleFavoriteSongs delegates to QueueStateHolder shuffleFavorites`() = runTest {
             playerViewModel.shuffleFavoriteSongs()
             advanceUntilIdle()
 
-            coVerify { mockMusicRepository.getFavoriteSongsOnce(StorageFilter.ALL) }
-            coVerify {
-                mockQueueStateHolder.prepareShuffledQueueSuspending(
-                    favoriteSongs,
-                    "Liked Songs (Shuffled)",
-                    true
-                )
-            }
+            verify { mockQueueStateHolder.shuffleFavorites(any()) }
         }
 
         @Test
-        fun `shuffleRandomAlbum calls prepareShuffledQueue with startAtZero`() = runTest {
-            val album = Album(
-                id = 77L,
-                title = "Album Roulette",
-                artist = "Artist A",
-                year = 2024,
-                dateAdded = 0L,
-                albumArtUriString = null,
-                songCount = 3
-            )
-            every { mockLibraryStateHolder.albums } returns MutableStateFlow(persistentListOf(album))
-            every { mockMusicRepository.getSongsForAlbum(album.id) } returns flowOf(listOf(song1, song2, song3))
-            stubShuffledPlayback(listOf(song1, song2, song3), album.title, startSong = song2)
-
+        fun `shuffleRandomAlbum delegates to QueueStateHolder shuffleRandomAlbum`() = runTest {
             playerViewModel.shuffleRandomAlbum()
             advanceUntilIdle()
 
-            coVerify {
-                mockQueueStateHolder.prepareShuffledQueueSuspending(
-                    listOf(song1, song2, song3),
-                    "Album Roulette",
-                    true
-                )
-            }
+            verify { mockQueueStateHolder.shuffleRandomAlbum(any()) }
         }
 
         @Test
-        fun `shuffleRandomArtist calls prepareShuffledQueue with startAtZero`() = runTest {
-            val artist = Artist(id = 88L, name = "Artist Roulette", songCount = 3)
-            every { mockLibraryStateHolder.artists } returns MutableStateFlow(persistentListOf(artist))
-            every { mockMusicRepository.getSongsForArtist(artist.id) } returns flowOf(listOf(song3, song2, song1))
-            stubShuffledPlayback(listOf(song3, song2, song1), artist.name, startSong = song3)
-
+        fun `shuffleRandomArtist delegates to QueueStateHolder shuffleRandomArtist`() = runTest {
             playerViewModel.shuffleRandomArtist()
             advanceUntilIdle()
 
-            coVerify {
-                mockQueueStateHolder.prepareShuffledQueueSuspending(
-                    listOf(song3, song2, song1),
-                    "Artist Roulette",
-                    true
-                )
-            }
+            verify { mockQueueStateHolder.shuffleRandomArtist(any()) }
         }
 
         @Test
         fun `triggerShuffleAllFromTile uses startAtZero when library is already loaded`() = runTest {
             val songs = listOf(song1, song2, song3)
             _allSongsFlow.value = songs.toImmutableList()
+            // The tile pulls a bounded random sample from the repository; stub it so the
+            // "already loaded" path returns immediately without going through a sync retry.
+            coEvery { mockMusicRepository.getRandomSongs(500) } returns songs
             stubShuffledPlayback(songs, "All Songs (Shuffled)", startSong = song1)
 
             playerViewModel.triggerShuffleAllFromTile()

--- a/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolderTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/presentation/viewmodel/QueueStateHolderTest.kt
@@ -1,0 +1,257 @@
+package com.theveloper.pixelplay.presentation.viewmodel
+
+import com.theveloper.pixelplay.MainCoroutineExtension
+import com.theveloper.pixelplay.data.model.Album
+import com.theveloper.pixelplay.data.model.Artist
+import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.model.StorageFilter
+import com.theveloper.pixelplay.data.repository.MusicRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Covers the shuffle/play orchestration extracted from PlayerViewModel into QueueStateHolder
+ * during Pass 2. The ViewModel delegates to these methods via the callback bundles; here we
+ * exercise the real holder with a mocked [MusicRepository] and capturing callbacks.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MainCoroutineExtension::class)
+class QueueStateHolderTest {
+
+    private val musicRepository: MusicRepository = mockk(relaxed = true)
+
+    private fun holder() = QueueStateHolder(musicRepository)
+
+    private fun song(id: String, title: String = "Song $id", track: Int = 0, disc: Int? = null) = Song(
+        id = id,
+        title = title,
+        artist = "Artist",
+        genre = "Rock",
+        albumArtUriString = null,
+        artistId = 1L,
+        albumId = 1L,
+        contentUriString = "content://dummy/$id",
+        duration = 180_000L,
+        bitrate = null,
+        sampleRate = null,
+        album = "Album",
+        path = "path",
+        mimeType = "audio/mpeg",
+        trackNumber = track,
+        discNumber = disc
+    )
+
+    private val song1 = song("1")
+    private val song2 = song("2")
+    private val song3 = song("3")
+
+    private class CapturingShuffleCallbacks(
+        scope: kotlinx.coroutines.CoroutineScope,
+        storageFilter: StorageFilter = StorageFilter.ALL,
+        albums: List<Album> = emptyList(),
+        artists: List<Artist> = emptyList()
+    ) {
+        var played: Pair<List<Song>, String>? = null
+        val callbacks = ShufflePlaybackCallbacks(
+            scope = scope,
+            currentStorageFilter = { storageFilter },
+            albums = { albums },
+            artists = { artists },
+            playShuffled = { songs, queueName -> played = songs to queueName }
+        )
+    }
+
+    @Test
+    fun `shuffleAll resolves a random sample and dispatches shuffled playback`() = runTest {
+        val songs = listOf(song1, song2, song3)
+        coEvery { musicRepository.getRandomSongs(500) } returns songs
+        val cb = CapturingShuffleCallbacks(this)
+
+        holder().shuffleAll("All Songs (Shuffled)", cb.callbacks)
+        advanceUntilIdle()
+
+        assertEquals(songs, cb.played?.first)
+        assertEquals("All Songs (Shuffled)", cb.played?.second)
+    }
+
+    @Test
+    fun `shuffleAll does not dispatch when the sample is empty`() = runTest {
+        coEvery { musicRepository.getRandomSongs(500) } returns emptyList()
+        val cb = CapturingShuffleCallbacks(this)
+
+        holder().shuffleAll(callbacks = cb.callbacks)
+        advanceUntilIdle()
+
+        assertNull(cb.played)
+    }
+
+    @Test
+    fun `playRandom dispatches the all-songs shuffled queue`() = runTest {
+        val songs = listOf(song3, song1)
+        coEvery { musicRepository.getRandomSongs(500) } returns songs
+        val cb = CapturingShuffleCallbacks(this)
+
+        holder().playRandom(cb.callbacks)
+        advanceUntilIdle()
+
+        assertEquals(songs, cb.played?.first)
+        assertEquals("All Songs (Shuffled)", cb.played?.second)
+    }
+
+    @Test
+    fun `shuffleFavorites resolves favorites for the active storage filter`() = runTest {
+        val favorites = listOf(song1, song2)
+        coEvery { musicRepository.getFavoriteSongsOnce(StorageFilter.ONLINE) } returns favorites
+        val cb = CapturingShuffleCallbacks(this, storageFilter = StorageFilter.ONLINE)
+
+        holder().shuffleFavorites(cb.callbacks)
+        advanceUntilIdle()
+
+        assertEquals(favorites, cb.played?.first)
+        assertEquals("Liked Songs (Shuffled)", cb.played?.second)
+    }
+
+    @Test
+    fun `shuffleRandomAlbum picks an album and dispatches its songs under the album name`() = runTest {
+        val album = Album(
+            id = 77L,
+            title = "Album Roulette",
+            artist = "Artist A",
+            year = 2024,
+            dateAdded = 0L,
+            albumArtUriString = null,
+            songCount = 2
+        )
+        val albumSongs = listOf(song1, song2)
+        every { musicRepository.getSongsForAlbum(album.id) } returns flowOf(albumSongs)
+        val cb = CapturingShuffleCallbacks(this, albums = listOf(album))
+
+        holder().shuffleRandomAlbum(cb.callbacks)
+        advanceUntilIdle()
+
+        assertEquals(albumSongs, cb.played?.first)
+        assertEquals("Album Roulette", cb.played?.second)
+    }
+
+    @Test
+    fun `shuffleRandomAlbum is a no-op when there are no albums`() = runTest {
+        val cb = CapturingShuffleCallbacks(this, albums = emptyList())
+
+        holder().shuffleRandomAlbum(cb.callbacks)
+        advanceUntilIdle()
+
+        assertNull(cb.played)
+    }
+
+    @Test
+    fun `shuffleRandomArtist picks an artist and dispatches their songs under the artist name`() = runTest {
+        val artist = Artist(id = 88L, name = "Artist Roulette", songCount = 2)
+        val artistSongs = listOf(song3, song1)
+        every { musicRepository.getSongsForArtist(artist.id) } returns flowOf(artistSongs)
+        val cb = CapturingShuffleCallbacks(this, artists = listOf(artist))
+
+        holder().shuffleRandomArtist(cb.callbacks)
+        advanceUntilIdle()
+
+        assertEquals(artistSongs, cb.played?.first)
+        assertEquals("Artist Roulette", cb.played?.second)
+    }
+
+    @Test
+    fun `playAlbum orders songs by disc then track then title`() = runTest {
+        val album = Album(
+            id = 5L,
+            title = "Ordered Album",
+            artist = "Artist A",
+            year = 2024,
+            dateAdded = 0L,
+            albumArtUriString = null,
+            songCount = 3
+        )
+        // Intentionally out of order: disc 2 track 1, disc 1 track 2, disc 1 track 1.
+        val disc2track1 = song("a", track = 1, disc = 2)
+        val disc1track2 = song("b", track = 2, disc = 1)
+        val disc1track1 = song("c", track = 1, disc = 1)
+        every { musicRepository.getSongsForAlbum(album.id) } returns
+            flowOf(listOf(disc2track1, disc1track2, disc1track1))
+
+        var playedSongs: List<Song>? = null
+        var startSong: Song? = null
+        var sheetShown = false
+        val cb = PlaybackSourceCallbacks(
+            scope = this,
+            playSongs = { songs, start, _, _ -> playedSongs = songs; startSong = start },
+            showSheet = { sheetShown = true }
+        )
+
+        holder().playAlbum(album, cb)
+        // playAlbum hops to Dispatchers.IO, so the virtual scheduler can't drain it; join the
+        // launched child coroutine instead.
+        coroutineContext.job.children.forEach { it.join() }
+
+        assertEquals(listOf(disc1track1, disc1track2, disc2track1), playedSongs)
+        assertEquals(disc1track1, startSong)
+        assertEquals(true, sheetShown)
+    }
+
+    @Test
+    fun `playAlbum does not dispatch when the album has no songs`() = runTest {
+        val album = Album(
+            id = 6L,
+            title = "Empty Album",
+            artist = "Artist A",
+            year = 2024,
+            dateAdded = 0L,
+            albumArtUriString = null,
+            songCount = 0
+        )
+        every { musicRepository.getSongsForAlbum(album.id) } returns flowOf(emptyList())
+
+        var dispatched = false
+        var sheetShown = false
+        val cb = PlaybackSourceCallbacks(
+            scope = this,
+            playSongs = { _, _, _, _ -> dispatched = true },
+            showSheet = { sheetShown = true }
+        )
+
+        holder().playAlbum(album, cb)
+        coroutineContext.job.children.forEach { it.join() }
+
+        assertEquals(false, dispatched)
+        assertEquals(false, sheetShown)
+    }
+
+    @Test
+    fun `playArtist dispatches the artist songs and reveals the sheet`() = runTest {
+        val artist = Artist(id = 9L, name = "Some Artist", songCount = 2)
+        val artistSongs = listOf(song1, song2)
+        every { musicRepository.getSongsForArtist(artist.id) } returns flowOf(artistSongs)
+
+        var playedSongs: List<Song>? = null
+        var queueName: String? = null
+        var sheetShown = false
+        val cb = PlaybackSourceCallbacks(
+            scope = this,
+            playSongs = { songs, _, name, _ -> playedSongs = songs; queueName = name },
+            showSheet = { sheetShown = true }
+        )
+
+        holder().playArtist(artist, cb)
+        coroutineContext.job.children.forEach { it.join() }
+
+        assertEquals(artistSongs, playedSongs)
+        assertEquals("Some Artist", queueName)
+        assertEquals(true, sheetShown)
+    }
+}


### PR DESCRIPTION
…lder

Moves shuffle and playback logic from `PlayerViewModel` to `QueueStateHolder` to improve modularity and testability. This refactor introduces callback bundles to handle communication between the state holder and the ViewModel without creating circular dependencies.

- Extracted `shuffleAll`, `playRandom`, `shuffleFavorites`, and category-based shuffle logic into `QueueStateHolder`.
- Moved `playAlbum` and `playArtist` orchestration, including disc/track sorting logic, to the state holder.
- Introduced `ShufflePlaybackCallbacks` and `PlaybackSourceCallbacks` to bridge data resolution with ViewModel playback methods.
- Refactored `PlayerViewModel` to delegate UI-triggered shuffle and play actions to the state holder using the new callback bundles.
- Added `QueueStateHolderTest` to cover the extracted orchestration logic and updated `PlayerViewModelTest` to verify proper delegation.