### PR TITLE
refactor: move AI lyrics translation logic to LyricsStateHolder

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
@@ -41,6 +41,21 @@ interface LyricsLoadCallback {
 }
 
 /**
+ * Callbacks supplied by [PlayerViewModel] so the AI-translation flow can reach the AI layer and
+ * resolve localized strings without [LyricsStateHolder] depending on AiStateHolder or a Context.
+ * Mirrors the callback-lambda pattern used elsewhere (e.g. [LyricsStateHolder.fetchLyricsForSong]).
+ *
+ * @param translate Delegates the raw lyrics to the AI translator (AiStateHolder.translateLyrics).
+ * @param getString Resolves a no-arg string resource.
+ * @param getErrorString Resolves the generic AI error string (R.string.ai_error_generic) with a detail.
+ */
+class LyricsTranslationCallbacks(
+    val translate: suspend (String) -> Result<String>,
+    val getString: (Int) -> String,
+    val getErrorString: (String) -> String
+)
+
+/**
  * Manages lyrics loading, search state, and sync offset.
  * Extracted from PlayerViewModel to improve modularity.
  */
@@ -318,6 +333,62 @@ class LyricsStateHolder @Inject constructor(
             }
 
             _messageEvents.emit("Lyrics imported successfully!")
+        }
+    }
+
+    /**
+     * Translate the current song's lyrics via AI and import the result.
+     * The actual inference is delegated through [LyricsTranslationCallbacks.translate] so this holder
+     * stays decoupled from the AI layer. Toasts are surfaced through [messageEvents] as usual.
+     */
+    fun translateLyricsViaAi(currentSong: Song, lyricsObj: Lyrics?, cb: LyricsTranslationCallbacks) {
+        val songId = currentSong.id.toLongOrNull() ?: return
+        val rawLyrics = currentSong.lyrics
+
+        if (rawLyrics.isNullOrBlank()) {
+            _messageEvents.tryEmit(cb.getString(R.string.lyrics_not_found))
+            return
+        }
+
+        if (lyricsObj?.synced != null) {
+            val hasValidTranslation = lyricsObj.synced.any { !it.translation.isNullOrBlank() }
+            if (hasValidTranslation) {
+                _messageEvents.tryEmit(cb.getString(R.string.ai_lyrics_already_translated))
+                return
+            }
+        }
+
+        scope?.launch {
+            _messageEvents.emit(cb.getString(R.string.ai_lyrics_translating))
+            val result = cb.translate(rawLyrics)
+            result.onSuccess { translatedText ->
+                if (translatedText.trim() == "ALREADY_IN_TARGET_LANGUAGE") {
+                    _messageEvents.emit(cb.getString(R.string.ai_lyrics_already_in_target_language))
+                    return@onSuccess
+                }
+
+                if (translatedText.isNotBlank()) {
+                    val validation = LyricsImportSecurity.validateImportedLrcContent(translatedText)
+                    if (validation is LyricsImportValidationResult.Valid) {
+                        importLyricsFromFile(songId, validation.value, currentSong)
+                        _messageEvents.emit(cb.getString(R.string.ai_lyrics_translation_success))
+                    } else {
+                        val reason = (validation as LyricsImportValidationResult.Invalid).reason
+                        val errorMsg = LyricsImportSecurity.messageFor(reason)
+                        _messageEvents.emit(cb.getErrorString(errorMsg))
+                    }
+                } else {
+                    _messageEvents.emit(cb.getErrorString("Empty response"))
+                }
+            }.onFailure {
+                if (it.message?.contains("key", ignoreCase = true) == true ||
+                    it.message?.contains("config", ignoreCase = true) == true
+                ) {
+                    _messageEvents.emit(cb.getString(R.string.ai_error_api_key))
+                } else {
+                    _messageEvents.emit(cb.getErrorString(it.message ?: ""))
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -4926,53 +4926,15 @@ class PlayerViewModel @Inject constructor(
 
     fun translateLyricsViaAi() {
         val currentSong = stablePlayerState.value.currentSong ?: return
-        val songId = currentSong.id.toLongOrNull() ?: return
-        val rawLyrics = currentSong.lyrics
-        val lyricsObj = stablePlayerState.value.lyrics
-
-        if (rawLyrics.isNullOrBlank()) {
-            sendToast(context.getString(R.string.lyrics_not_found))
-            return
-        }
-
-        if (lyricsObj?.synced != null) {
-            val hasValidTranslation = lyricsObj.synced.any { !it.translation.isNullOrBlank() }
-            if (hasValidTranslation) {
-                sendToast(context.getString(R.string.ai_lyrics_already_translated))
-                return
-            }
-        }
-
-        viewModelScope.launch {
-            sendToast(context.getString(R.string.ai_lyrics_translating))
-            val result = aiStateHolder.translateLyrics(rawLyrics)
-            result.onSuccess { translatedText ->
-                if (translatedText.trim() == "ALREADY_IN_TARGET_LANGUAGE") {
-                    sendToast(context.getString(R.string.ai_lyrics_already_in_target_language))
-                    return@onSuccess
-                }
-
-                if (translatedText.isNotBlank()) {
-                    val validation = com.theveloper.pixelplay.utils.LyricsImportSecurity.validateImportedLrcContent(translatedText)
-                    if (validation is com.theveloper.pixelplay.utils.LyricsImportValidationResult.Valid) {
-                        lyricsStateHolder.importLyricsFromFile(songId, validation.value, currentSong)
-                        sendToast(context.getString(R.string.ai_lyrics_translation_success))
-                    } else {
-                        val reason = (validation as com.theveloper.pixelplay.utils.LyricsImportValidationResult.Invalid).reason
-                        val errorMsg = com.theveloper.pixelplay.utils.LyricsImportSecurity.messageFor(reason)
-                        sendToast(context.getString(R.string.ai_error_generic, errorMsg))
-                    }
-                } else {
-                     sendToast(context.getString(R.string.ai_error_generic, "Empty response"))
-                }
-            }.onFailure {
-                if (it.message?.contains("key", ignoreCase = true) == true || it.message?.contains("config", ignoreCase = true) == true) {
-                    sendToast(context.getString(R.string.ai_error_api_key))
-                } else {
-                    sendToast(context.getString(R.string.ai_error_generic, it.message))
-                }
-            }
-        }
+        lyricsStateHolder.translateLyricsViaAi(
+            currentSong = currentSong,
+            lyricsObj = stablePlayerState.value.lyrics,
+            cb = LyricsTranslationCallbacks(
+                translate = { rawLyrics -> aiStateHolder.translateLyrics(rawLyrics) },
+                getString = { resId -> context.getString(resId) },
+                getErrorString = { detail -> context.getString(R.string.ai_error_generic, detail) }
+            )
+        )
     }
 
     /**


### PR DESCRIPTION
Decouples the AI translation flow from `PlayerViewModel` by migrating the logic to `LyricsStateHolder`. This refactoring improves modularity and ensures that the state holder remains independent of the AI layer and Android `Context` through a callback mechanism.

- Added `LyricsTranslationCallbacks` to delegate AI inference and string resource resolution.
- Relocated the `translateLyricsViaAi` implementation to `LyricsStateHolder`, including validation and error handling.
- updated `PlayerViewModel` to call the new state holder method using lambda-based callbacks.
- Preserved existing security validation via `LyricsImportSecurity` during the translation import process.