### PR TITLE
refactor: decompose MusicService and modularize PlayerViewModel liste…

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/service/CastSyncCoordinator.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/CastSyncCoordinator.kt
@@ -1,0 +1,278 @@
+package com.theveloper.pixelplay.data.service
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.media3.common.Player
+import com.google.android.gms.cast.MediaMetadata as CastMediaMetadata
+import com.google.android.gms.cast.MediaStatus
+import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManager
+import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
+import com.theveloper.pixelplay.data.service.cast.CastRemotePlaybackState
+import com.theveloper.pixelplay.presentation.viewmodel.ListeningStatsTracker
+import timber.log.Timber
+
+/**
+ * Snapshot of the currently casting remote player, projected from the Cast
+ * [MediaStatus]. Consumed by both the listening-stats sync and the widget/Wear
+ * surfaces, so it lives at file scope rather than nested in [MusicService].
+ */
+internal data class RemotePlaybackSnapshot(
+    val occurrenceId: String,
+    val songId: String?,
+    val title: String,
+    val artist: String,
+    val artworkUri: Uri?,
+    val isPlaying: Boolean,
+    val isActuallyPlaying: Boolean,
+    val currentPositionMs: Long,
+    val totalDurationMs: Long,
+    val repeatMode: Int,
+    val isShuffleEnabled: Boolean,
+)
+
+/**
+ * Owns Cast remote-session synchronization, extracted from [MusicService] during
+ * the Pass 5 service decomposition.
+ *
+ * Responsibilities:
+ *  - Registering/unregistering the [SessionManagerListener] and per-session
+ *    [RemoteMediaClient.Callback].
+ *  - Tracking the observed [CastSession] and mirroring its playback into the
+ *    [ListeningStatsTracker].
+ *  - Projecting the remote [MediaStatus] into a [RemotePlaybackSnapshot] for the
+ *    widget/Wear surfaces.
+ *
+ * The service supplies [requestWidgetUpdate] so the coordinator can trigger a UI
+ * refresh without depending on the widget pipeline directly. All Cast SDK access
+ * is wrapped in [runCatching] to tolerate Play Services being unavailable.
+ */
+internal class CastSyncCoordinator(
+    private val context: Context,
+    private val listeningStatsTracker: ListeningStatsTracker,
+    private val requestWidgetUpdate: (force: Boolean) -> Unit,
+) {
+    private companion object {
+        private const val TAG = "MusicService_PixelPlay"
+    }
+
+    private var sessionManager: SessionManager? = null
+    private var sessionManagerListener: SessionManagerListener<CastSession>? = null
+    private var remoteClientCallback: RemoteMediaClient.Callback? = null
+    private var observedSession: CastSession? = null
+    private var activeStatsOccurrenceId: String? = null
+    private var activePlaybackIntent: Boolean = false
+
+    /** The active remote media client, if any, preferring the observed session. */
+    fun currentRemoteMediaClient(): RemoteMediaClient? =
+        observedSession?.remoteMediaClient ?: sessionManager?.currentCastSession?.remoteMediaClient
+
+    fun start() {
+        val manager = runCatching {
+            CastContext.getSharedInstance(context).sessionManager
+        }.getOrElse { error ->
+            Timber.tag(TAG).w(error, "CastContext unavailable; skipping cast wear sync setup")
+            return
+        }
+        sessionManager = manager
+
+        val remoteCallback = object : RemoteMediaClient.Callback() {
+            override fun onStatusUpdated() {
+                syncListeningStatsFromRemote()
+                requestWidgetUpdate(false)
+            }
+
+            override fun onMetadataUpdated() {
+                syncListeningStatsFromRemote()
+                requestWidgetUpdate(false)
+            }
+
+            override fun onQueueStatusUpdated() {
+                syncListeningStatsFromRemote()
+                requestWidgetUpdate(false)
+            }
+
+            override fun onPreloadStatusUpdated() {
+                requestWidgetUpdate(false)
+            }
+        }
+        remoteClientCallback = remoteCallback
+
+        val sessionListener = object : SessionManagerListener<CastSession> {
+            override fun onSessionStarted(session: CastSession, sessionId: String) {
+                attachRemoteClient(session)
+            }
+
+            override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
+                attachRemoteClient(session)
+            }
+
+            override fun onSessionEnded(session: CastSession, error: Int) {
+                if (observedSession === session) {
+                    attachRemoteClient(null)
+                } else {
+                    requestWidgetUpdate(true)
+                }
+            }
+
+            override fun onSessionStarting(session: CastSession) = Unit
+            override fun onSessionStartFailed(session: CastSession, error: Int) = requestWidgetUpdate(true)
+            override fun onSessionEnding(session: CastSession) = Unit
+            override fun onSessionResuming(session: CastSession, sessionId: String) = Unit
+            override fun onSessionResumeFailed(session: CastSession, error: Int) = requestWidgetUpdate(true)
+            override fun onSessionSuspended(session: CastSession, reason: Int) = requestWidgetUpdate(true)
+        }
+        sessionManagerListener = sessionListener
+        runCatching {
+            manager.addSessionManagerListener(sessionListener, CastSession::class.java)
+        }.onFailure { e ->
+            Timber.tag(TAG).w(e, "Failed to register Cast session listener")
+        }
+
+        attachRemoteClient(manager.currentCastSession)
+    }
+
+    private fun attachRemoteClient(session: CastSession?) {
+        if (observedSession === session) return
+
+        observedSession?.remoteMediaClient?.let { oldClient ->
+            remoteClientCallback?.let { callback ->
+                runCatching { oldClient.unregisterCallback(callback) }
+            }
+        }
+
+        observedSession = session
+        session?.remoteMediaClient?.let { remoteClient ->
+            remoteClientCallback?.let { callback ->
+                runCatching { remoteClient.registerCallback(callback) }
+            }
+            remoteClient.requestStatus()
+            syncListeningStatsFromRemote()
+        } ?: run {
+            activeStatsOccurrenceId = null
+            activePlaybackIntent = false
+            listeningStatsTracker.onPlaybackStopped()
+        }
+        requestWidgetUpdate(true)
+    }
+
+    fun stop() {
+        observedSession?.remoteMediaClient?.let { remoteClient ->
+            remoteClientCallback?.let { callback ->
+                runCatching { remoteClient.unregisterCallback(callback) }
+            }
+        }
+        observedSession = null
+
+        val listener = sessionManagerListener
+        val manager = sessionManager
+        if (listener != null && manager != null) {
+            runCatching { manager.removeSessionManagerListener(listener, CastSession::class.java) }
+                .onFailure { e ->
+                    Timber.tag(TAG).w(e, "Failed to remove Cast session listener")
+                }
+        }
+        sessionManagerListener = null
+        remoteClientCallback = null
+        sessionManager = null
+    }
+
+    fun syncListeningStatsFromRemote() {
+        val snapshot = resolveRemoteSnapshot() ?: return
+        val songId = snapshot.songId?.takeIf { it.isNotBlank() }
+        if (songId == null) {
+            activeStatsOccurrenceId = null
+            listeningStatsTracker.onPlaybackStopped()
+            return
+        }
+
+        if (activeStatsOccurrenceId != snapshot.occurrenceId) {
+            activeStatsOccurrenceId = snapshot.occurrenceId
+            listeningStatsTracker.onTrackChanged(
+                songId = songId,
+                positionMs = snapshot.currentPositionMs,
+                durationMs = snapshot.totalDurationMs,
+                isPlaying = snapshot.isActuallyPlaying
+            )
+            return
+        }
+
+        listeningStatsTracker.ensureSession(
+            songId = songId,
+            positionMs = snapshot.currentPositionMs,
+            durationMs = snapshot.totalDurationMs,
+            isPlaying = snapshot.isActuallyPlaying
+        )
+    }
+
+    fun resolveRemoteSnapshot(): RemotePlaybackSnapshot? {
+        val remoteClient = currentRemoteMediaClient() ?: return null
+
+        val mediaStatus = remoteClient.mediaStatus ?: return null
+        if (mediaStatus.playerState == MediaStatus.PLAYER_STATE_UNKNOWN) {
+            return null
+        }
+
+        val currentItem = mediaStatus.getQueueItemById(mediaStatus.currentItemId)
+        val mediaInfo = currentItem?.media ?: remoteClient.mediaInfo
+        val metadata = mediaInfo?.metadata
+        if (metadata == null && currentItem == null) {
+            return null
+        }
+
+        val songId = currentItem
+            ?.customData
+            ?.optString("songId")
+            ?.takeIf { it.isNotBlank() }
+        val occurrenceId = currentItem
+            ?.itemId
+            ?.takeIf { it > 0 }
+            ?.toString()
+            ?: songId
+            ?: mediaInfo?.contentId
+            ?: return null
+
+        val durationHintMs = currentItem
+            ?.customData
+            ?.optLong("durationHintMs", -1L)
+            ?.takeIf { it > 0L }
+
+        val streamDurationMs = remoteClient.streamDuration.takeIf { it > 0L }
+        val effectiveDurationMs = (streamDurationMs ?: durationHintMs ?: 0L).coerceAtLeast(0L)
+        val imageUri = metadata
+                ?.images
+                ?.firstOrNull()
+                ?.url
+                ?.toString()
+                ?.takeIf { it.isNotBlank() }?.toUri()
+
+        val mappedRepeatMode = when (mediaStatus.queueRepeatMode) {
+            MediaStatus.REPEAT_MODE_REPEAT_SINGLE -> Player.REPEAT_MODE_ONE
+            MediaStatus.REPEAT_MODE_REPEAT_ALL,
+            MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE -> Player.REPEAT_MODE_ALL
+            else -> Player.REPEAT_MODE_OFF
+        }
+        val remotePlayback = CastRemotePlaybackState.project(
+            mediaStatus = mediaStatus,
+            previousPlayIntent = activePlaybackIntent
+        )
+        activePlaybackIntent = remotePlayback.playWhenReady
+
+        return RemotePlaybackSnapshot(
+            occurrenceId = occurrenceId,
+            songId = songId,
+            title = metadata?.getString(CastMediaMetadata.KEY_TITLE).orEmpty(),
+            artist = metadata?.getString(CastMediaMetadata.KEY_ARTIST).orEmpty(),
+            artworkUri = imageUri,
+            isPlaying = remotePlayback.isPlaying,
+            isActuallyPlaying = mediaStatus.playerState == MediaStatus.PLAYER_STATE_PLAYING,
+            currentPositionMs = remoteClient.approximateStreamPosition.coerceAtLeast(0L),
+            totalDurationMs = effectiveDurationMs,
+            repeatMode = mappedRepeatMode,
+            isShuffleEnabled = mediaStatus.queueRepeatMode == MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE,
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/MusicService.kt
@@ -19,8 +19,6 @@ import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.graphics.drawable.toBitmap
-import androidx.glance.appwidget.GlanceAppWidgetManager
-import androidx.glance.appwidget.state.updateAppWidgetState
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -36,13 +34,6 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionCommands
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
-import com.google.android.gms.cast.MediaMetadata as CastMediaMetadata
-import com.google.android.gms.cast.MediaStatus
-import com.google.android.gms.cast.framework.CastContext
-import com.google.android.gms.cast.framework.CastSession
-import com.google.android.gms.cast.framework.SessionManager
-import com.google.android.gms.cast.framework.SessionManagerListener
-import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
@@ -56,13 +47,9 @@ import com.theveloper.pixelplay.data.preferences.EqualizerPreferencesRepository
 import com.theveloper.pixelplay.data.preferences.ThemePreferencesRepository
 import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 import com.theveloper.pixelplay.data.repository.MusicRepository
-import com.theveloper.pixelplay.data.service.cast.CastRemotePlaybackState
 import com.theveloper.pixelplay.data.service.player.DualPlayerEngine
 import com.theveloper.pixelplay.data.service.player.TransitionController
-import com.theveloper.pixelplay.ui.glancewidget.ControlWidget4x2
-import com.theveloper.pixelplay.ui.glancewidget.PixelPlayGlanceWidget
 import com.theveloper.pixelplay.ui.glancewidget.PlayerActions
-import com.theveloper.pixelplay.ui.glancewidget.PlayerInfoStateDefinition
 import com.theveloper.pixelplay.utils.AlbumArtUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -81,8 +68,6 @@ import com.theveloper.pixelplay.data.preferences.AlbumArtColorAccuracy
 import com.theveloper.pixelplay.data.preferences.AlbumArtPaletteStyle
 import com.theveloper.pixelplay.presentation.viewmodel.ColorSchemeProcessor
 import androidx.compose.ui.graphics.toArgb
-import com.theveloper.pixelplay.ui.glancewidget.BarWidget4x1
-import com.theveloper.pixelplay.ui.glancewidget.GridWidget2x2
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import com.theveloper.pixelplay.data.preferences.ThemePreference
@@ -96,7 +81,6 @@ import com.theveloper.pixelplay.utils.MediaItemBuilder
 import com.theveloper.pixelplay.data.navidrome.NavidromeRepository
 import com.theveloper.pixelplay.di.AppScope
 import com.theveloper.pixelplay.presentation.viewmodel.ListeningStatsTracker
-import kotlin.math.abs
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
@@ -182,18 +166,17 @@ class MusicService : MediaLibraryService() {
     @AppScope
     lateinit var appScope: CoroutineScope
 
-    private var replayGainEnabled = false
-    private var replayGainUseAlbumGain = false
-    private var replayGainJob: Job? = null
-    private var replayGainRequestToken = 0L
-    private var userSelectedVolume = 1f
-    private var expectedReplayGainVolume: Float? = null
-    private var pendingReplayGainVolume: Float? = null
-    // Last successfully applied RG volume — used to avoid a full-volume spike
-    // during the IO read for the next track (Repeat/Shuffle/Queue changes).
-    private var lastAppliedReplayGainVolume: Float? = null
-    // MediaId for which lastAppliedReplayGainVolume was computed.
-    private var lastReplayGainMediaId: String? = null
+    // ReplayGain volume-normalization state + logic, extracted to a standalone
+    // component. Lazily built so the Hilt-injected engine/replayGainManager and the
+    // service scope are ready before first use (first playback event).
+    private val replayGainProcessor by lazy {
+        ReplayGainProcessor(
+            engine = engine,
+            replayGainManager = replayGainManager,
+            scope = serviceScope,
+            currentSessionMediaItem = { mediaSession?.player?.currentMediaItem },
+        )
+    }
 
     private var favoriteSongIds = emptySet<String>()
     private var mediaSession: MediaLibrarySession? = null
@@ -214,12 +197,27 @@ class MusicService : MediaLibraryService() {
         getSystemService(Context.ALARM_SERVICE) as AlarmManager
     }
     private var endOfTrackTimerSongId: String? = null
-    private var castSessionManager: SessionManager? = null
-    private var castSessionManagerListener: SessionManagerListener<CastSession>? = null
-    private var castRemoteClientCallback: RemoteMediaClient.Callback? = null
-    private var observedCastSession: CastSession? = null
-    private var activeCastStatsOccurrenceId: String? = null
-    private var activeCastPlaybackIntent: Boolean = false
+    // Cast remote-session synchronization, extracted to a standalone coordinator.
+    // Lazily built so the Hilt-injected listeningStatsTracker is ready before first use.
+    private val castSyncCoordinator by lazy {
+        CastSyncCoordinator(
+            context = this,
+            listeningStatsTracker = listeningStatsTracker,
+            requestWidgetUpdate = { force -> widgetUpdateManager.requestFullUpdate(force) },
+        )
+    }
+    // Glance widget + Wear OS update pipeline, extracted to a standalone manager.
+    // State assembly (buildPlayerInfo / resolveCurrentMediaIdForWear) stays here and
+    // is supplied as callbacks; the manager owns debounce, diffing and rendering.
+    private val widgetUpdateManager by lazy {
+        WidgetUpdateManager(
+            context = applicationContext,
+            scope = serviceScope,
+            wearStatePublisher = wearStatePublisher,
+            buildPlayerInfo = { buildPlayerInfo() },
+            resolveCurrentMediaIdForWear = { resolveCurrentMediaIdForWear() },
+        )
+    }
     private var playbackSnapshotPersistJob: Job? = null
     private var playbackSnapshotUnloadWriteJob: Job? = null
     private var isRestoringPlaybackSnapshot = false
@@ -243,7 +241,6 @@ class MusicService : MediaLibraryService() {
         // JSON+DataStore rewrite on every Media3 event (track transition fires 3-4 listeners
         // within ~200ms) is unnecessary work. 1500ms coalesces those without harming restore.
         private const val PLAYBACK_SNAPSHOT_DEBOUNCE_MS = 1500L
-        private const val FORCED_WIDGET_STATE_DEBOUNCE_MS = 250L
         private const val MEDIA_SESSION_BUTTON_DEBOUNCE_MS = 250L
         private const val DEFERRED_SERVICE_STARTUP_WORK_DELAY_MS = 1_000L
         private const val PAUSED_RESTORE_PREPARE_QUEUE_LIMIT = 50
@@ -273,7 +270,6 @@ class MusicService : MediaLibraryService() {
         private const val AUTO_CONTEXT_PLAYLIST = "playlist"
         private const val DEFAULT_STREAM_BUFFER_SIZE = 8 * 1024
         private const val WIDGET_ART_FAILURE_RETRY_MS = 30_000L
-        private const val WIDGET_QUEUE_PREVIEW_LIMIT = 4
         private const val HEADSET_RECONNECT_RESUME_WINDOW_MS = 15_000L
 
         fun markPendingMediaButtonForegroundStart() {
@@ -303,7 +299,7 @@ class MusicService : MediaLibraryService() {
 
     private val playerSwapListener: (Player) -> Unit = { newPlayer ->
         publishMediaSessionPlayer(newPlayer, "Swapped MediaSession player to new instance.")
-        prepareReplayGainForTransitionPlayer(newPlayer)
+        replayGainProcessor.prepareForTransition(newPlayer)
     }
 
     private val transitionDisplayPlayerListener: (Player) -> Unit = { displayPlayer ->
@@ -311,11 +307,11 @@ class MusicService : MediaLibraryService() {
             displayPlayer,
             "Published incoming crossfade player to MediaSession."
         )
-        prepareReplayGainForTransitionPlayer(displayPlayer)
+        replayGainProcessor.prepareForTransition(displayPlayer)
     }
 
     private val transitionFinishedListener: () -> Unit = {
-        onTransitionFinished()
+        replayGainProcessor.onTransitionFinished()
     }
 
     private fun publishMediaSessionPlayer(player: Player, logMessage: String) {
@@ -329,24 +325,8 @@ class MusicService : MediaLibraryService() {
 
         Timber.tag("MusicService").d(logMessage)
         syncLocalListeningStatsFromPlayer(player)
-        requestWidgetFullUpdate(force = true)
+        widgetUpdateManager.requestFullUpdate(true)
         refreshMediaSessionUi(session)
-    }
-
-    private fun prepareReplayGainForTransitionPlayer(player: Player) {
-        // Pre-compute ReplayGain for the incoming track while the crossfade is still running.
-        // isTransitionRunning() is true here, so applyReplayGain stores the result as
-        // pendingReplayGainVolume. onTransitionFinished() applies it cleanly once the fade
-        // loop ends, avoiding any volume jump on the incoming track.
-        //
-        // Also try to set incomingTrackReplayGainVolume immediately from cache so the
-        // fade loop can use the correct final volume even before the IO coroutine finishes.
-        val incomingItem = player.currentMediaItem
-        val cachedVolume = getCachedReplayGainVolume(incomingItem)
-        if (cachedVolume != null) {
-            engine.incomingTrackReplayGainVolume = cachedVolume
-        }
-        applyReplayGain(incomingItem)
     }
 
     private fun syncLocalListeningStatsFromPlayer(
@@ -426,7 +406,7 @@ class MusicService : MediaLibraryService() {
         
         // Ensure engine is ready (re-initialize if service was restarted)
         engine.initialize()
-        userSelectedVolume = engine.masterPlayer.volume.coerceIn(0f, 1f)
+        replayGainProcessor.captureUserVolume(engine.masterPlayer.volume)
         syncLocalListeningStatsFromPlayer(engine.masterPlayer)
 
         engine.masterPlayer.addListener(playerListener)
@@ -443,7 +423,7 @@ class MusicService : MediaLibraryService() {
         serviceScope.launch {
             delay(DEFERRED_SERVICE_STARTUP_WORK_DELAY_MS)
             if (!isPlaybackUnloadInProgress && mediaSession != null) {
-                initializeCastWearSync()
+                castSyncCoordinator.start()
             }
         }
         registerHeadsetReconnectMonitor()
@@ -452,7 +432,7 @@ class MusicService : MediaLibraryService() {
             musicRepository.telegramRepository.downloadCompleted.collect {
                 if (isCurrentWidgetArtworkBackedByTelegram()) {
                     invalidateCachedWidgetArtwork()
-                    requestWidgetAndWearRefreshWithFollowUp()
+                    widgetUpdateManager.requestWithFollowUp()
                 }
             }
         }
@@ -520,16 +500,16 @@ class MusicService : MediaLibraryService() {
         // ReplayGain preference collectors
         serviceScope.launch {
             userPreferencesRepository.replayGainEnabledFlow.collect { enabled ->
-                replayGainEnabled = enabled
+                replayGainProcessor.setEnabled(enabled)
                 // Re-apply to current track when toggled
-                applyReplayGain(mediaSession?.player?.currentMediaItem)
+                replayGainProcessor.apply(mediaSession?.player?.currentMediaItem)
             }
         }
         serviceScope.launch {
             userPreferencesRepository.replayGainUseAlbumGainFlow.collect { useAlbum ->
-                replayGainUseAlbumGain = useAlbum
+                replayGainProcessor.setUseAlbumGain(useAlbum)
                 // Re-apply to current track when mode changes
-                applyReplayGain(mediaSession?.player?.currentMediaItem)
+                replayGainProcessor.apply(mediaSession?.player?.currentMediaItem)
             }
         }
 
@@ -666,7 +646,7 @@ class MusicService : MediaLibraryService() {
                         }
                         session.player.repeatMode = newMode
                         refreshMediaSessionUi(session)
-                        requestWidgetFullUpdate(force = true)
+                        widgetUpdateManager.requestFullUpdate(true)
                     }
                     MusicNotificationProvider.CUSTOM_COMMAND_LIKE -> {
                         val songId = session.player.currentMediaItem?.mediaId
@@ -879,7 +859,7 @@ class MusicService : MediaLibraryService() {
         serviceScope.launch {
             restorePlaybackQueueSnapshotIfNeeded()
             mediaSession?.let { refreshMediaSessionUi(it) }
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
         }
 
         serviceScope.launch {
@@ -896,7 +876,7 @@ class MusicService : MediaLibraryService() {
                         Timber.tag("MusicService")
                             .d("Favorite status changed for current song. Updating notification.")
                         mediaSession?.let { refreshMediaSessionUi(it) }
-                        requestWidgetFullUpdate(force = true)
+                        widgetUpdateManager.requestFullUpdate(true)
                     }
                 }
             }
@@ -1079,15 +1059,15 @@ class MusicService : MediaLibraryService() {
                         player.prepare()
                     }
                     player.playWhenReady = !player.playWhenReady
-                    requestWidgetFullUpdate(force = true)
+                    widgetUpdateManager.requestFullUpdate(true)
                 }
                 PlayerActions.NEXT -> {
                     player.seekToNext()
-                    requestWidgetFullUpdate(force = true)
+                    widgetUpdateManager.requestFullUpdate(true)
                 }
                 PlayerActions.PREVIOUS -> {
                     player.seekToPrevious()
-                    requestWidgetFullUpdate(force = true)
+                    widgetUpdateManager.requestFullUpdate(true)
                 }
                 PlayerActions.FAVORITE -> {
                     val songId = player.currentMediaItem?.mediaId
@@ -1100,7 +1080,7 @@ class MusicService : MediaLibraryService() {
                                 favoriteSongIds - songId
                             }
                             mediaSession?.let { refreshMediaSessionUi(it) }
-                            requestWidgetFullUpdate(force = true)
+                            widgetUpdateManager.requestFullUpdate(true)
                         }
                     }
                 }
@@ -1129,7 +1109,7 @@ class MusicService : MediaLibraryService() {
                     } ?: run {
                         // Fallback if session not ready
                         isManualShuffleEnabled = newState
-                        requestWidgetFullUpdate(force = true)
+                        widgetUpdateManager.requestFullUpdate(true)
                     }
                 }
                 PlayerActions.REPEAT -> {
@@ -1139,7 +1119,7 @@ class MusicService : MediaLibraryService() {
                         else -> Player.REPEAT_MODE_OFF
                     }
                     player.repeatMode = newMode
-                    requestWidgetFullUpdate(force = true)
+                    widgetUpdateManager.requestFullUpdate(true)
                 }
                 ACTION_SLEEP_TIMER_EXPIRED -> {
                     Timber.tag(TAG).d("Sleep timer expired action received. Pausing player.")
@@ -1221,14 +1201,7 @@ class MusicService : MediaLibraryService() {
 
     private val playerListener = object : Player.Listener {
         override fun onVolumeChanged(volume: Float) {
-            if (engine.isTransitionRunning()) return
-            val expectedVolume = expectedReplayGainVolume
-            if (expectedVolume != null && abs(expectedVolume - volume) < 0.001f) {
-                expectedReplayGainVolume = null
-                return
-            }
-            expectedReplayGainVolume = null
-            userSelectedVolume = volume.coerceIn(0f, 1f)
+            replayGainProcessor.onPlayerVolumeChanged(volume)
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -1252,12 +1225,12 @@ class MusicService : MediaLibraryService() {
             // Re-apply the last known RG volume immediately when resuming playback.
             // After a pause, ExoPlayer may reset the audio track volume internally,
             // causing a brief full-volume spike before the IO coroutine finishes.
-            if (isPlaying && !engine.isTransitionRunning()) {
-                lastAppliedReplayGainVolume?.let { setPlayerVolume(player, it) }
+            if (isPlaying) {
+                replayGainProcessor.reapplyLastAppliedVolume(player)
             }
             // Push state immediately so the watch can foreground PixelPlay before
             // system media surfaces take over.
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist()
         }
@@ -1273,7 +1246,7 @@ class MusicService : MediaLibraryService() {
                 }
                 else -> clearHeadsetReconnectResume()
             }
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist()
         }
@@ -1306,13 +1279,13 @@ class MusicService : MediaLibraryService() {
         }
 
         override fun onTimelineChanged(timeline: Timeline, reason: Int) {
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             schedulePlaybackSnapshotPersist(immediate = timeline.isEmpty)
             // Pre-fetch RG for the next track so the cache is warm before playback starts
             val player = engine.masterPlayer
             val nextIndex = player.nextMediaItemIndex
             if (nextIndex != androidx.media3.common.C.INDEX_UNSET) {
-                runCatching { prefetchReplayGain(player.getMediaItemAt(nextIndex)) }
+                runCatching { replayGainProcessor.prefetch(player.getMediaItemAt(nextIndex)) }
             }
         }
 
@@ -1348,12 +1321,10 @@ class MusicService : MediaLibraryService() {
                 if (oldMediaId != null && oldMediaId == newMediaId) {
                     // Same track (e.g. repeat, seek) — no IO needed, apply last known RG volume
                     // immediately to avoid a spike while the coroutine reads tags again.
-                    lastAppliedReplayGainVolume?.let {
-                        if (!engine.isTransitionRunning()) setPlayerVolume(engine.masterPlayer, it)
-                    }
+                    replayGainProcessor.reapplyLastAppliedVolume(engine.masterPlayer)
                 } else {
                     // Different track — full recompute needed
-                    applyReplayGain(currentItem)
+                    replayGainProcessor.apply(currentItem)
                 }
             }
         }
@@ -1390,16 +1361,16 @@ class MusicService : MediaLibraryService() {
                     Timber.tag(TAG).d("Cleared end-of-track timer after manual track change")
                 }
             }
-            applyReplayGain(mediaSession?.player?.currentMediaItem)
+            replayGainProcessor.apply(mediaSession?.player?.currentMediaItem)
             // Pre-fetch RG for the track after this one so it's cached when needed
             val player = engine.masterPlayer
             val nextIndex = player.nextMediaItemIndex
             if (nextIndex != androidx.media3.common.C.INDEX_UNSET) {
-                runCatching { prefetchReplayGain(player.getMediaItemAt(nextIndex)) }
+                runCatching { replayGainProcessor.prefetch(player.getMediaItemAt(nextIndex)) }
             }
             // Optimization: Don't force-update widgets on every rapid skip.
             // Let the debounced updater handle it to prevent UI freezes.
-            requestWidgetFullUpdate(force = false)
+            widgetUpdateManager.requestFullUpdate(false)
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist()
         }
@@ -1407,31 +1378,24 @@ class MusicService : MediaLibraryService() {
         override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
             // Some devices/apps deliver title/artist/art after transition callback.
             // Force an immediate publish for real-time watch metadata.
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             mediaSession?.let { refreshMediaSessionUiWithFollowUp(it) }
             // Only recompute RG if the track actually changed — onMediaMetadataChanged
             // also fires on queue edits (add/remove) without a track change, which would
             // launch a redundant IO coroutine and cause a brief volume spike.
-            val currentMediaId = mediaSession?.player?.currentMediaItem?.mediaId
-            if (currentMediaId != null && currentMediaId != lastReplayGainMediaId) {
-                applyReplayGain(mediaSession?.player?.currentMediaItem)
-            } else if (currentMediaId != null) {
-                lastAppliedReplayGainVolume?.let {
-                    if (!engine.isTransitionRunning()) setPlayerVolume(engine.masterPlayer, it)
-                }
-            }
+            replayGainProcessor.onMediaMetadataChanged(mediaSession?.player?.currentMediaItem)
         }
 
         override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
             Timber.tag("MusicService")
                 .d("playerListener.onShuffleModeEnabledChanged: $shuffleModeEnabled")
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist()
         }
 
         override fun onRepeatModeChanged(repeatMode: Int) {
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             mediaSession?.let { refreshMediaSessionUi(it) }
             schedulePlaybackSnapshotPersist()
         }
@@ -1439,260 +1403,6 @@ class MusicService : MediaLibraryService() {
         override fun onPlayerError(error: PlaybackException) {
             Timber.tag(TAG).e(error, "Error en el reproductor: ")
         }
-    }
-
-    /**
-     * Applies ReplayGain volume normalization to the current track.
-     * Reads RG tags from the file and adjusts player.volume accordingly.
-     */
-    private fun applyReplayGain(mediaItem: MediaItem?) {
-        replayGainJob?.cancel()
-        replayGainRequestToken += 1
-        val requestToken = replayGainRequestToken
-
-        if (mediaItem == null) {
-            return
-        }
-
-        if (!replayGainEnabled) {
-            pendingReplayGainVolume = null
-            if (!engine.isTransitionRunning()) {
-                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
-            }
-            return
-        }
-
-        val mediaId = mediaItem.mediaId
-        val filePath = mediaItem.mediaMetadata.extras
-            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH)
-
-        if (filePath.isNullOrBlank()) {
-            Timber.tag(TAG).d("ReplayGain: No file path for track, keeping user-selected volume")
-            if (!engine.isTransitionRunning()) {
-                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
-            }
-            return
-        }
-
-        val useAlbumGain = replayGainUseAlbumGain
-
-        // Apply the last known RG volume immediately so there is no full-volume spike
-        // while the IO coroutine reads the tags for the new track.
-        if (!engine.isTransitionRunning()) {
-            lastAppliedReplayGainVolume?.let { setPlayerVolume(engine.masterPlayer, it) }
-        }
-
-        // Read ReplayGain tags on IO thread to avoid blocking main
-        replayGainJob = serviceScope.launch {
-            val rgValues = withContext(Dispatchers.IO) {
-                replayGainManager.readReplayGain(filePath)
-            }
-
-            if (requestToken != replayGainRequestToken) {
-                return@launch
-            }
-
-            val currentMediaId = mediaSession?.player?.currentMediaItem?.mediaId
-            if (currentMediaId != mediaId) {
-                Timber.tag(TAG).d("ReplayGain: Ignoring stale result for mediaId=%s", mediaId)
-                return@launch
-            }
-
-            val volume = replayGainManager.getVolumeMultiplier(
-                rgValues,
-                useAlbumGain = useAlbumGain
-            )
-
-            if (engine.isTransitionRunning()) {
-                // Store for application after transition completes.
-                // Also pass to engine so the crossfade loop ends at the correct RG
-                // volume instead of hard-coding 1f, preventing the audible jump.
-                pendingReplayGainVolume = volume
-                engine.incomingTrackReplayGainVolume = volume
-                Timber.tag(TAG).d("ReplayGain: Stored pending volume=%.2f for %s (transition running)",
-                    volume, mediaItem.mediaMetadata.title
-                )
-            } else {
-                pendingReplayGainVolume = null
-                engine.incomingTrackReplayGainVolume = null
-                lastAppliedReplayGainVolume = volume
-                lastReplayGainMediaId = mediaId
-                setPlayerVolume(engine.masterPlayer, volume)
-                Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
-                    volume, mediaItem.mediaMetadata.title
-                )
-            }
-        }
-    }
-
-    /**
-     * Returns the cached ReplayGain volume for a media item if already computed, or null.
-     * Does NOT trigger an IO read — only reads from the in-memory cache.
-     */
-    private fun getCachedReplayGainVolume(mediaItem: MediaItem?): Float? {
-        if (!replayGainEnabled || mediaItem == null) return null
-        val filePath = mediaItem.mediaMetadata.extras
-            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return null
-        if (filePath.isBlank()) return null
-        val cached = replayGainManager.getCachedReplayGain(filePath) ?: return null
-        return replayGainManager.getVolumeMultiplier(cached, useAlbumGain = replayGainUseAlbumGain)
-    }
-
-    /**
-     * Pre-fetches ReplayGain tags for a media item into the cache without applying the volume.
-     * Called on queue changes and track transitions so the cache is warm by the time
-     * applyReplayGain() runs, avoiding the 1-2s JNI read delay on playback start.
-     */
-    private fun prefetchReplayGain(mediaItem: MediaItem?) {
-        if (!replayGainEnabled || mediaItem == null) return
-        val filePath = mediaItem.mediaMetadata.extras
-            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return
-        if (filePath.isBlank()) return
-        serviceScope.launch(Dispatchers.IO) {
-            replayGainManager.readReplayGain(filePath)
-        }
-    }
-
-    private fun setPlayerVolume(player: Player, volume: Float) {
-        val clampedVolume = volume.coerceIn(0f, 1f)
-        expectedReplayGainVolume = clampedVolume
-        player.volume = clampedVolume
-    }
-
-    private fun onTransitionFinished() {
-        val player = engine.masterPlayer
-        val pending = pendingReplayGainVolume
-        pendingReplayGainVolume = null
-
-        if (!replayGainEnabled) {
-            setPlayerVolume(player, userSelectedVolume)
-            Timber.tag(TAG).d("ReplayGain: Transition finished, RG disabled — restored userSelectedVolume=%.2f", userSelectedVolume)
-            return
-        }
-
-        if (pending != null) {
-            // The crossfade loop ramps to this value; apply it now as the stable post-fade volume.
-            // Also update lastAppliedReplayGainVolume so any subsequent onPositionDiscontinuity
-            // (REASON_AUTO_TRANSITION fires right after crossfade ends) uses this value
-            // immediately instead of launching a new IO coroutine and causing a spike.
-            lastAppliedReplayGainVolume = pending
-            setPlayerVolume(player, pending)
-            Timber.tag(TAG).d("ReplayGain: Transition finished, applied pending volume=%.2f", pending)
-        } else {
-            // No pending volume was computed during transition, trigger full computation
-            applyReplayGain(mediaSession?.player?.currentMediaItem)
-            Timber.tag(TAG).d("ReplayGain: Transition finished, no pending volume — triggering full recomputation")
-        }
-    }
-
-    private fun initializeCastWearSync() {
-        val sessionManager = runCatching {
-            CastContext.getSharedInstance(this).sessionManager
-        }.getOrElse { error ->
-            Timber.tag(TAG).w(error, "CastContext unavailable; skipping cast wear sync setup")
-            return
-        }
-        castSessionManager = sessionManager
-
-        val remoteCallback = object : RemoteMediaClient.Callback() {
-            override fun onStatusUpdated() {
-                syncCastListeningStatsFromRemote()
-                requestWidgetFullUpdate(force = false)
-            }
-
-            override fun onMetadataUpdated() {
-                syncCastListeningStatsFromRemote()
-                requestWidgetFullUpdate(force = false)
-            }
-
-            override fun onQueueStatusUpdated() {
-                syncCastListeningStatsFromRemote()
-                requestWidgetFullUpdate(force = false)
-            }
-
-            override fun onPreloadStatusUpdated() {
-                requestWidgetFullUpdate(force = false)
-            }
-        }
-        castRemoteClientCallback = remoteCallback
-
-        val sessionListener = object : SessionManagerListener<CastSession> {
-            override fun onSessionStarted(session: CastSession, sessionId: String) {
-                attachCastRemoteClient(session)
-            }
-
-            override fun onSessionResumed(session: CastSession, wasSuspended: Boolean) {
-                attachCastRemoteClient(session)
-            }
-
-            override fun onSessionEnded(session: CastSession, error: Int) {
-                if (observedCastSession === session) {
-                    attachCastRemoteClient(null)
-                } else {
-                    requestWidgetFullUpdate(force = true)
-                }
-            }
-
-            override fun onSessionStarting(session: CastSession) = Unit
-            override fun onSessionStartFailed(session: CastSession, error: Int) = requestWidgetFullUpdate(force = true)
-            override fun onSessionEnding(session: CastSession) = Unit
-            override fun onSessionResuming(session: CastSession, sessionId: String) = Unit
-            override fun onSessionResumeFailed(session: CastSession, error: Int) = requestWidgetFullUpdate(force = true)
-            override fun onSessionSuspended(session: CastSession, reason: Int) = requestWidgetFullUpdate(force = true)
-        }
-        castSessionManagerListener = sessionListener
-        runCatching {
-            sessionManager.addSessionManagerListener(sessionListener, CastSession::class.java)
-        }.onFailure { e ->
-            Timber.tag(TAG).w(e, "Failed to register Cast session listener")
-        }
-
-        attachCastRemoteClient(sessionManager.currentCastSession)
-    }
-
-    private fun attachCastRemoteClient(session: CastSession?) {
-        if (observedCastSession === session) return
-
-        observedCastSession?.remoteMediaClient?.let { oldClient ->
-            castRemoteClientCallback?.let { callback ->
-                runCatching { oldClient.unregisterCallback(callback) }
-            }
-        }
-
-        observedCastSession = session
-        session?.remoteMediaClient?.let { remoteClient ->
-            castRemoteClientCallback?.let { callback ->
-                runCatching { remoteClient.registerCallback(callback) }
-            }
-            remoteClient.requestStatus()
-            syncCastListeningStatsFromRemote()
-        } ?: run {
-            activeCastStatsOccurrenceId = null
-            activeCastPlaybackIntent = false
-            listeningStatsTracker.onPlaybackStopped()
-        }
-        requestWidgetFullUpdate(force = true)
-    }
-
-    private fun stopCastWearSync() {
-        observedCastSession?.remoteMediaClient?.let { remoteClient ->
-            castRemoteClientCallback?.let { callback ->
-                runCatching { remoteClient.unregisterCallback(callback) }
-            }
-        }
-        observedCastSession = null
-
-        val listener = castSessionManagerListener
-        val manager = castSessionManager
-        if (listener != null && manager != null) {
-            runCatching { manager.removeSessionManagerListener(listener, CastSession::class.java) }
-                .onFailure { e ->
-                    Timber.tag(TAG).w(e, "Failed to remove Cast session listener")
-                }
-        }
-        castSessionManagerListener = null
-        castRemoteClientCallback = null
-        castSessionManager = null
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
@@ -1725,12 +1435,11 @@ class MusicService : MediaLibraryService() {
         playbackSnapshotPersistJob?.cancel()
         mediaSessionButtonRefreshJob?.cancel()
         followUpMediaSessionUiRefreshJob?.cancel()
-        followUpWidgetUpdateJob?.cancel()
-        debouncedWidgetUpdateJob?.cancel()
-        stopCastWearSync()
+        widgetUpdateManager.cancel()
+        castSyncCoordinator.stop()
         unregisterHeadsetReconnectMonitor()
         wearStatePublisher.clearState()
-        replayGainJob?.cancel()
+        replayGainProcessor.cancel()
 
         engine.removePlayerSwapListener(playerSwapListener)
         engine.removeTransitionDisplayPlayerListener(transitionDisplayPlayerListener)
@@ -1766,8 +1475,8 @@ class MusicService : MediaLibraryService() {
             Timber.tag(TAG).d("onTrimMemory(level=%d): releasing widget bitmap caches", level)
             invalidateCachedWidgetArtwork()
             // Drop the stale PlayerInfo copy so its embedded ByteArray is GC-eligible.
-            // The next processWidgetUpdateInternal() call will rebuild it from scratch.
-            lastWidgetPlayerInfo = null
+            // The next widget update cycle will rebuild it from scratch.
+            widgetUpdateManager.clearCachedState()
         }
     }
 
@@ -2082,151 +1791,12 @@ class MusicService : MediaLibraryService() {
     }
 
     // --- LÓGICA PARA ACTUALIZACIÓN DE WIDGETS Y DATOS ---
-    private var debouncedWidgetUpdateJob: Job? = null
-    private var followUpWidgetUpdateJob: Job? = null
     private var followUpMediaSessionUiRefreshJob: Job? = null
     private var mediaSessionButtonRefreshJob: Job? = null
     private var lastAppliedMediaButtonSignature: String? = null
-    private val widgetStateDebounceMs = 300L
-
-    private fun requestWidgetFullUpdate(force: Boolean = false) {
-        debouncedWidgetUpdateJob?.cancel()
-        debouncedWidgetUpdateJob = serviceScope.launch {
-            val debounceMs = if (force) {
-                FORCED_WIDGET_STATE_DEBOUNCE_MS
-            } else {
-                widgetStateDebounceMs
-            }
-            if (debounceMs > 0L) {
-                delay(debounceMs)
-            }
-            processWidgetUpdateInternal()
-        }
-    }
-
-    private fun requestWidgetAndWearRefreshWithFollowUp() {
-        requestWidgetFullUpdate(force = true)
-        followUpWidgetUpdateJob?.cancel()
-        followUpWidgetUpdateJob = serviceScope.launch {
-            delay(250L)
-            requestWidgetFullUpdate(force = true)
-        }
-    }
-
-    private data class RemotePlaybackSnapshot(
-        val occurrenceId: String,
-        val songId: String?,
-        val title: String,
-        val artist: String,
-        val artworkUri: Uri?,
-        val isPlaying: Boolean,
-        val isActuallyPlaying: Boolean,
-        val currentPositionMs: Long,
-        val totalDurationMs: Long,
-        val repeatMode: Int,
-        val isShuffleEnabled: Boolean,
-    )
-
-    private fun syncCastListeningStatsFromRemote() {
-        val snapshot = resolveCastRemoteSnapshot() ?: return
-        val songId = snapshot.songId?.takeIf { it.isNotBlank() }
-        if (songId == null) {
-            activeCastStatsOccurrenceId = null
-            listeningStatsTracker.onPlaybackStopped()
-            return
-        }
-
-        if (activeCastStatsOccurrenceId != snapshot.occurrenceId) {
-            activeCastStatsOccurrenceId = snapshot.occurrenceId
-            listeningStatsTracker.onTrackChanged(
-                songId = songId,
-                positionMs = snapshot.currentPositionMs,
-                durationMs = snapshot.totalDurationMs,
-                isPlaying = snapshot.isActuallyPlaying
-            )
-            return
-        }
-
-        listeningStatsTracker.ensureSession(
-            songId = songId,
-            positionMs = snapshot.currentPositionMs,
-            durationMs = snapshot.totalDurationMs,
-            isPlaying = snapshot.isActuallyPlaying
-        )
-    }
-
-    private fun resolveCastRemoteSnapshot(): RemotePlaybackSnapshot? {
-        val remoteClient = observedCastSession?.remoteMediaClient
-            ?: castSessionManager?.currentCastSession?.remoteMediaClient
-            ?: return null
-
-        val mediaStatus = remoteClient.mediaStatus ?: return null
-        if (mediaStatus.playerState == MediaStatus.PLAYER_STATE_UNKNOWN) {
-            return null
-        }
-
-        val currentItem = mediaStatus.getQueueItemById(mediaStatus.currentItemId)
-        val mediaInfo = currentItem?.media ?: remoteClient.mediaInfo
-        val metadata = mediaInfo?.metadata
-        if (metadata == null && currentItem == null) {
-            return null
-        }
-
-        val songId = currentItem
-            ?.customData
-            ?.optString("songId")
-            ?.takeIf { it.isNotBlank() }
-        val occurrenceId = currentItem
-            ?.itemId
-            ?.takeIf { it > 0 }
-            ?.toString()
-            ?: songId
-            ?: mediaInfo?.contentId
-            ?: return null
-
-        val durationHintMs = currentItem
-            ?.customData
-            ?.optLong("durationHintMs", -1L)
-            ?.takeIf { it > 0L }
-
-        val streamDurationMs = remoteClient.streamDuration.takeIf { it > 0L }
-        val effectiveDurationMs = (streamDurationMs ?: durationHintMs ?: 0L).coerceAtLeast(0L)
-        val imageUri = metadata
-                ?.images
-                ?.firstOrNull()
-                ?.url
-                ?.toString()
-                ?.takeIf { it.isNotBlank() }?.toUri()
-
-        val mappedRepeatMode = when (mediaStatus.queueRepeatMode) {
-            MediaStatus.REPEAT_MODE_REPEAT_SINGLE -> Player.REPEAT_MODE_ONE
-            MediaStatus.REPEAT_MODE_REPEAT_ALL,
-            MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE -> Player.REPEAT_MODE_ALL
-            else -> Player.REPEAT_MODE_OFF
-        }
-        val remotePlayback = CastRemotePlaybackState.project(
-            mediaStatus = mediaStatus,
-            previousPlayIntent = activeCastPlaybackIntent
-        )
-        activeCastPlaybackIntent = remotePlayback.playWhenReady
-
-        return RemotePlaybackSnapshot(
-            occurrenceId = occurrenceId,
-            songId = songId,
-            title = metadata?.getString(CastMediaMetadata.KEY_TITLE).orEmpty(),
-            artist = metadata?.getString(CastMediaMetadata.KEY_ARTIST).orEmpty(),
-            artworkUri = imageUri,
-            isPlaying = remotePlayback.isPlaying,
-            isActuallyPlaying = mediaStatus.playerState == MediaStatus.PLAYER_STATE_PLAYING,
-            currentPositionMs = remoteClient.approximateStreamPosition.coerceAtLeast(0L),
-            totalDurationMs = effectiveDurationMs,
-            repeatMode = mappedRepeatMode,
-            isShuffleEnabled = mediaStatus.queueRepeatMode == MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE,
-        )
-    }
 
     private suspend fun resolveCurrentMediaIdForWear(): String? {
-        val remoteSongId = resolveCastRemoteSnapshot()?.songId
+        val remoteSongId = castSyncCoordinator.resolveRemoteSnapshot()?.songId
         if (!remoteSongId.isNullOrBlank()) {
             return remoteSongId
         }
@@ -2234,60 +1804,12 @@ class MusicService : MediaLibraryService() {
         return withContext(Dispatchers.Main) { player.currentMediaItem?.mediaId }
     }
 
-    private var lastWidgetPlayerInfo: PlayerInfo? = null
-
-    private fun shouldUpdateWidget(old: PlayerInfo, new: PlayerInfo): Boolean {
-        if (old.songTitle != new.songTitle) return true
-        if (old.artistName != new.artistName) return true
-        if (old.isPlaying != new.isPlaying) return true
-        if (old.albumArtUri != new.albumArtUri) return true
-        // Detect when artwork bytes arrive (null → non-null) or are cleared
-        if ((old.albumArtBitmapData == null) != (new.albumArtBitmapData == null)) return true
-        if (old.isFavorite != new.isFavorite) return true
-        if (old.queue != new.queue) return true
-        if (old.themeColors != new.themeColors) return true
-        if (old.isShuffleEnabled != new.isShuffleEnabled) return true
-        if (old.repeatMode != new.repeatMode) return true
-        if (old.totalDurationMs != new.totalDurationMs) return true
-        if (old.wearThemePalette != new.wearThemePalette) return true
-
-        val drift = kotlin.math.abs(old.currentPositionMs - new.currentPositionMs)
-        return drift > 3000L
-    }
-
-    private fun shouldPublishWearState(old: PlayerInfo, new: PlayerInfo): Boolean {
-        return shouldUpdateWidget(old, new) || old.wearQueueRevision != new.wearQueueRevision
-    }
-
-    private suspend fun processWidgetUpdateInternal() {
-        val playerInfo = buildPlayerInfo()
-        val oldInfo = lastWidgetPlayerInfo
-
-        val shouldUpdateWidgets = oldInfo == null || shouldUpdateWidget(oldInfo, playerInfo)
-        val shouldPublishWear = oldInfo == null || shouldPublishWearState(oldInfo, playerInfo)
-
-        if (shouldUpdateWidgets || shouldPublishWear) {
-            lastWidgetPlayerInfo = playerInfo
-        }
-
-        if (shouldUpdateWidgets) {
-            updateGlanceWidgets(playerInfo)
-        }
-
-        if (shouldPublishWear) {
-            val currentMediaId = resolveCurrentMediaIdForWear()
-            // Publish state to Wear OS watch
-            wearStatePublisher.publishState(currentMediaId, playerInfo)
-        }
-    }
-
     private fun buildWearQueueRevision(
         timeline: Timeline,
         currentIndex: Int,
         currentMediaId: String?,
     ): String {
-        val remoteClient = observedCastSession?.remoteMediaClient
-            ?: castSessionManager?.currentCastSession?.remoteMediaClient
+        val remoteClient = castSyncCoordinator.currentRemoteMediaClient()
         val remoteStatus = remoteClient?.mediaStatus
         val remoteQueueItems = remoteStatus?.queueItems.orEmpty()
         if (remoteQueueItems.isNotEmpty()) {
@@ -2367,7 +1889,7 @@ class MusicService : MediaLibraryService() {
         var artworkUri = resolveWidgetArtworkUriCandidates(currentItem?.mediaMetadata).firstOrNull()
         var artworkData = currentItem?.mediaMetadata?.artworkData
 
-        resolveCastRemoteSnapshot()?.let { remote ->
+        castSyncCoordinator.resolveRemoteSnapshot()?.let { remote ->
             if (remote.title.isNotBlank()) {
                 title = remote.title
             }
@@ -2779,56 +2301,6 @@ class MusicService : MediaLibraryService() {
         return output.toByteArray().takeIf { it.isNotEmpty() }
     }
 
-    private suspend fun updateGlanceWidgets(playerInfo: PlayerInfo) = withContext(Dispatchers.IO) {
-        try {
-            val glanceManager = GlanceAppWidgetManager(applicationContext)
-            val widgetPlayerInfo = playerInfo.toWidgetTransportState()
-
-            val glanceIds = glanceManager.getGlanceIds(PixelPlayGlanceWidget::class.java)
-            glanceIds.forEach { id ->
-                updateAppWidgetState(applicationContext, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
-                PixelPlayGlanceWidget().update(applicationContext, id)
-            }
-
-            val barGlanceIds = glanceManager.getGlanceIds(BarWidget4x1::class.java)
-            barGlanceIds.forEach { id ->
-                updateAppWidgetState(applicationContext, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
-                BarWidget4x1().update(applicationContext, id)
-            }
-
-            val controlGlanceIds = glanceManager.getGlanceIds(ControlWidget4x2::class.java)
-            controlGlanceIds.forEach { id ->
-                updateAppWidgetState(applicationContext, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
-                ControlWidget4x2().update(applicationContext, id)
-            }
-
-            val gridGlanceIds = glanceManager.getGlanceIds(GridWidget2x2::class.java)
-            gridGlanceIds.forEach { id ->
-                updateAppWidgetState(applicationContext, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
-                GridWidget2x2().update(applicationContext, id)
-            }
-            
-            if (glanceIds.isNotEmpty() || barGlanceIds.isNotEmpty() || controlGlanceIds.isNotEmpty() || gridGlanceIds.isNotEmpty()) {
-                Timber.tag(TAG)
-                    .d("Widgets actualizados: ${playerInfo.songTitle} (Original: ${glanceIds.size}, Bar: ${barGlanceIds.size}, Control: ${controlGlanceIds.size})")
-            } else {
-                Timber.tag(TAG).w("No se encontraron widgets para actualizar")
-            }
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Error al actualizar el widget")
-        }
-    }
-
-    private fun PlayerInfo.toWidgetTransportState(): PlayerInfo {
-        return copy(
-            lyrics = null,
-            isLoadingLyrics = false,
-            queue = queue.take(WIDGET_QUEUE_PREVIEW_LIMIT),
-            wearThemePalette = null,
-            wearQueueRevision = "",
-        )
-    }
-
     fun isSongFavorite(songId: String?): Boolean {
         return songId != null && favoriteSongIds.contains(songId)
     }
@@ -2935,8 +2407,7 @@ class MusicService : MediaLibraryService() {
         isPlaybackUnloadInProgress = true
         followUpMediaSessionUiRefreshJob?.cancel()
         mediaSessionButtonRefreshJob?.cancel()
-        followUpWidgetUpdateJob?.cancel()
-        debouncedWidgetUpdateJob?.cancel()
+        widgetUpdateManager.cancel()
         playbackSnapshotPersistJob?.cancel()
 
         val sessionToRelease = mediaSession
@@ -2958,7 +2429,7 @@ class MusicService : MediaLibraryService() {
         player.stop()
         player.clearMediaItems()
 
-        requestWidgetFullUpdate(force = true)
+        widgetUpdateManager.requestFullUpdate(true)
         stopForeground(STOP_FOREGROUND_REMOVE)
 
         stopSelf()
@@ -3023,7 +2494,7 @@ class MusicService : MediaLibraryService() {
             )
         }
         refreshMediaSessionUi(session)
-        requestWidgetFullUpdate(force = true)
+        widgetUpdateManager.requestFullUpdate(true)
     }
 
     private fun setCurrentSongFavoriteState(
@@ -3036,7 +2507,7 @@ class MusicService : MediaLibraryService() {
         val isCurrentlyFavorite = favoriteSongIds.contains(songId)
         if (isCurrentlyFavorite == targetFavoriteState) {
             refreshMediaSessionUi(session)
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
             return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
         }
 
@@ -3047,14 +2518,14 @@ class MusicService : MediaLibraryService() {
         }
 
         refreshMediaSessionUi(session)
-        requestWidgetFullUpdate(force = true)
+        widgetUpdateManager.requestFullUpdate(true)
 
         serviceScope.launch {
             Timber.tag("MusicService")
                 .d("Applying favorite=$targetFavoriteState for songId: $songId")
             musicRepository.setFavoriteStatus(songId, targetFavoriteState)
             refreshMediaSessionUi(session)
-            requestWidgetFullUpdate(force = true)
+            widgetUpdateManager.requestFullUpdate(true)
         }
 
         return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/ReplayGainProcessor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/ReplayGainProcessor.kt
@@ -1,0 +1,274 @@
+package com.theveloper.pixelplay.data.service
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import com.theveloper.pixelplay.data.media.ReplayGainManager
+import com.theveloper.pixelplay.data.service.player.DualPlayerEngine
+import com.theveloper.pixelplay.utils.MediaItemBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import kotlin.math.abs
+
+/**
+ * Owns all ReplayGain volume-normalization state and logic, extracted from
+ * [MusicService] during the Pass 5 service decomposition.
+ *
+ * The processor encapsulates the RG enable/album-gain flags, the in-flight IO
+ * read job, the "expected vs. user-selected" volume bookkeeping that keeps a
+ * programmatic RG volume change from being mistaken for a user gesture, and the
+ * crossfade-aware application of the computed gain. It reaches the players only
+ * through the injected [DualPlayerEngine]; the service supplies the current
+ * session media item via [currentSessionMediaItem] so stale IO results can be
+ * discarded.
+ *
+ * All public methods are main-thread affine (the IO tag read is dispatched
+ * internally), matching the original in-service behaviour.
+ */
+class ReplayGainProcessor(
+    private val engine: DualPlayerEngine,
+    private val replayGainManager: ReplayGainManager,
+    private val scope: CoroutineScope,
+    private val currentSessionMediaItem: () -> MediaItem?,
+) {
+    private companion object {
+        private const val TAG = "MusicService_PixelPlay"
+    }
+
+    private var enabled = false
+    private var useAlbumGain = false
+    private var job: Job? = null
+    private var requestToken = 0L
+
+    // Volume the user last chose by hand; restored whenever RG is disabled.
+    private var userSelectedVolume = 1f
+    // Volume we just wrote programmatically — used to ignore the echoed onVolumeChanged.
+    private var expectedVolume: Float? = null
+    // RG volume computed mid-crossfade, applied once the transition finishes.
+    private var pendingVolume: Float? = null
+    // Last successfully applied RG volume — avoids a full-volume spike during the
+    // IO read for the next track (Repeat/Shuffle/Queue changes).
+    private var lastAppliedVolume: Float? = null
+    // MediaId for which lastAppliedVolume was computed.
+    private var lastMediaId: String? = null
+
+    fun setEnabled(value: Boolean) {
+        enabled = value
+    }
+
+    fun setUseAlbumGain(value: Boolean) {
+        useAlbumGain = value
+    }
+
+    /** Seeds the user-selected volume from the player's current volume on startup. */
+    fun captureUserVolume(volume: Float) {
+        userSelectedVolume = volume.coerceIn(0f, 1f)
+    }
+
+    fun cancel() {
+        job?.cancel()
+    }
+
+    /**
+     * Mirrors [Player.Listener.onVolumeChanged]: distinguishes a programmatic RG
+     * volume change (which we ignore) from a genuine user gesture (which updates
+     * [userSelectedVolume]).
+     */
+    fun onPlayerVolumeChanged(volume: Float) {
+        if (engine.isTransitionRunning()) return
+        val expected = expectedVolume
+        if (expected != null && abs(expected - volume) < 0.001f) {
+            expectedVolume = null
+            return
+        }
+        expectedVolume = null
+        userSelectedVolume = volume.coerceIn(0f, 1f)
+    }
+
+    private fun setPlayerVolume(player: Player, volume: Float) {
+        val clampedVolume = volume.coerceIn(0f, 1f)
+        expectedVolume = clampedVolume
+        player.volume = clampedVolume
+    }
+
+    /**
+     * Re-applies the last computed RG volume immediately (no IO) unless a
+     * crossfade is running, preventing a brief full-volume spike on resume,
+     * same-track seeks, and queue edits.
+     */
+    fun reapplyLastAppliedVolume(player: Player) {
+        if (engine.isTransitionRunning()) return
+        lastAppliedVolume?.let { setPlayerVolume(player, it) }
+    }
+
+    /**
+     * Pre-computes ReplayGain for the incoming crossfade track. Seeds
+     * [DualPlayerEngine.incomingTrackReplayGainVolume] from cache when available so
+     * the fade loop ends at the correct volume, then kicks off [apply] which (since
+     * the transition is running) stores the result as a pending volume.
+     */
+    fun prepareForTransition(player: Player) {
+        val incomingItem = player.currentMediaItem
+        cachedVolumeFor(incomingItem)?.let { engine.incomingTrackReplayGainVolume = it }
+        apply(incomingItem)
+    }
+
+    /**
+     * Applies ReplayGain volume normalization to [mediaItem]. Reads RG tags from
+     * the file on an IO thread and adjusts the master player's volume accordingly.
+     */
+    fun apply(mediaItem: MediaItem?) {
+        job?.cancel()
+        requestToken += 1
+        val currentRequestToken = requestToken
+
+        if (mediaItem == null) {
+            return
+        }
+
+        if (!enabled) {
+            pendingVolume = null
+            if (!engine.isTransitionRunning()) {
+                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
+            }
+            return
+        }
+
+        val mediaId = mediaItem.mediaId
+        val filePath = mediaItem.mediaMetadata.extras
+            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH)
+
+        if (filePath.isNullOrBlank()) {
+            Timber.tag(TAG).d("ReplayGain: No file path for track, keeping user-selected volume")
+            if (!engine.isTransitionRunning()) {
+                setPlayerVolume(engine.masterPlayer, userSelectedVolume)
+            }
+            return
+        }
+
+        val resolvedUseAlbumGain = useAlbumGain
+
+        // Apply the last known RG volume immediately so there is no full-volume spike
+        // while the IO coroutine reads the tags for the new track.
+        if (!engine.isTransitionRunning()) {
+            lastAppliedVolume?.let { setPlayerVolume(engine.masterPlayer, it) }
+        }
+
+        // Read ReplayGain tags on IO thread to avoid blocking main
+        job = scope.launch {
+            val rgValues = withContext(Dispatchers.IO) {
+                replayGainManager.readReplayGain(filePath)
+            }
+
+            if (currentRequestToken != requestToken) {
+                return@launch
+            }
+
+            val currentMediaId = currentSessionMediaItem()?.mediaId
+            if (currentMediaId != mediaId) {
+                Timber.tag(TAG).d("ReplayGain: Ignoring stale result for mediaId=%s", mediaId)
+                return@launch
+            }
+
+            val volume = replayGainManager.getVolumeMultiplier(
+                rgValues,
+                useAlbumGain = resolvedUseAlbumGain
+            )
+
+            if (engine.isTransitionRunning()) {
+                // Store for application after transition completes.
+                // Also pass to engine so the crossfade loop ends at the correct RG
+                // volume instead of hard-coding 1f, preventing the audible jump.
+                pendingVolume = volume
+                engine.incomingTrackReplayGainVolume = volume
+                Timber.tag(TAG).d("ReplayGain: Stored pending volume=%.2f for %s (transition running)",
+                    volume, mediaItem.mediaMetadata.title
+                )
+            } else {
+                pendingVolume = null
+                engine.incomingTrackReplayGainVolume = null
+                lastAppliedVolume = volume
+                lastMediaId = mediaId
+                setPlayerVolume(engine.masterPlayer, volume)
+                Timber.tag(TAG).d("ReplayGain: Applied volume=%.2f for %s",
+                    volume, mediaItem.mediaMetadata.title
+                )
+            }
+        }
+    }
+
+    /**
+     * Returns the cached ReplayGain volume for a media item if already computed, or null.
+     * Does NOT trigger an IO read — only reads from the in-memory cache.
+     */
+    private fun cachedVolumeFor(mediaItem: MediaItem?): Float? {
+        if (!enabled || mediaItem == null) return null
+        val filePath = mediaItem.mediaMetadata.extras
+            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return null
+        if (filePath.isBlank()) return null
+        val cached = replayGainManager.getCachedReplayGain(filePath) ?: return null
+        return replayGainManager.getVolumeMultiplier(cached, useAlbumGain = useAlbumGain)
+    }
+
+    /**
+     * Pre-fetches ReplayGain tags for a media item into the cache without applying the volume.
+     * Called on queue changes and track transitions so the cache is warm by the time
+     * [apply] runs, avoiding the 1-2s JNI read delay on playback start.
+     */
+    fun prefetch(mediaItem: MediaItem?) {
+        if (!enabled || mediaItem == null) return
+        val filePath = mediaItem.mediaMetadata.extras
+            ?.getString(MediaItemBuilder.EXTERNAL_EXTRA_FILE_PATH) ?: return
+        if (filePath.isBlank()) return
+        scope.launch(Dispatchers.IO) {
+            replayGainManager.readReplayGain(filePath)
+        }
+    }
+
+    /**
+     * Applies the volume that was held back while a crossfade was running, or
+     * triggers a fresh computation if none was pending.
+     */
+    fun onTransitionFinished() {
+        val player = engine.masterPlayer
+        val pending = pendingVolume
+        pendingVolume = null
+
+        if (!enabled) {
+            setPlayerVolume(player, userSelectedVolume)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, RG disabled — restored userSelectedVolume=%.2f", userSelectedVolume)
+            return
+        }
+
+        if (pending != null) {
+            // The crossfade loop ramps to this value; apply it now as the stable post-fade volume.
+            // Also update lastAppliedVolume so any subsequent onPositionDiscontinuity
+            // (REASON_AUTO_TRANSITION fires right after crossfade ends) uses this value
+            // immediately instead of launching a new IO coroutine and causing a spike.
+            lastAppliedVolume = pending
+            setPlayerVolume(player, pending)
+            Timber.tag(TAG).d("ReplayGain: Transition finished, applied pending volume=%.2f", pending)
+        } else {
+            // No pending volume was computed during transition, trigger full computation
+            apply(currentSessionMediaItem())
+            Timber.tag(TAG).d("ReplayGain: Transition finished, no pending volume — triggering full recomputation")
+        }
+    }
+
+    /**
+     * Recomputes RG only when the track actually changed; otherwise re-applies the
+     * last known volume. [onMediaMetadataChanged] also fires on queue edits without a
+     * track change, which would otherwise launch a redundant IO read and cause a spike.
+     */
+    fun onMediaMetadataChanged(currentItem: MediaItem?) {
+        val currentMediaId = currentItem?.mediaId ?: return
+        if (currentMediaId != lastMediaId) {
+            apply(currentItem)
+        } else {
+            reapplyLastAppliedVolume(engine.masterPlayer)
+        }
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/service/WidgetUpdateManager.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/service/WidgetUpdateManager.kt
@@ -1,0 +1,187 @@
+package com.theveloper.pixelplay.data.service
+
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import com.theveloper.pixelplay.data.model.PlayerInfo
+import com.theveloper.pixelplay.data.service.wear.WearStatePublisher
+import com.theveloper.pixelplay.ui.glancewidget.BarWidget4x1
+import com.theveloper.pixelplay.ui.glancewidget.ControlWidget4x2
+import com.theveloper.pixelplay.ui.glancewidget.GridWidget2x2
+import com.theveloper.pixelplay.ui.glancewidget.PixelPlayGlanceWidget
+import com.theveloper.pixelplay.ui.glancewidget.PlayerInfoStateDefinition
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import kotlin.math.abs
+
+/**
+ * Owns the Glance widget + Wear OS state-publishing pipeline, extracted from
+ * [MusicService] during the Pass 5 service decomposition.
+ *
+ * Responsibilities:
+ *  - Debouncing the many `requestFullUpdate` triggers fired by player/cast events.
+ *  - Diffing the freshly built [PlayerInfo] against the last published one so we
+ *    only re-render widgets / re-publish Wear state when something user-visible
+ *    actually changed.
+ *  - Rendering every Glance widget variant and publishing to the watch.
+ *
+ * State *assembly* stays in the service (it is intimately tied to the player,
+ * repositories, favorites and theme), supplied here through [buildPlayerInfo] and
+ * [resolveCurrentMediaIdForWear]. This manager only orchestrates the *update*.
+ */
+internal class WidgetUpdateManager(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val wearStatePublisher: WearStatePublisher,
+    private val buildPlayerInfo: suspend () -> PlayerInfo,
+    private val resolveCurrentMediaIdForWear: suspend () -> String?,
+) {
+    private companion object {
+        private const val TAG = "MusicService_PixelPlay"
+        // Shorter debounce for forced (user-visible) state changes so the watch can
+        // foreground PixelPlay quickly; longer one coalesces incidental updates.
+        private const val FORCED_DEBOUNCE_MS = 250L
+        private const val NORMAL_DEBOUNCE_MS = 300L
+        private const val FOLLOW_UP_DELAY_MS = 250L
+        private const val QUEUE_PREVIEW_LIMIT = 4
+    }
+
+    private var debouncedUpdateJob: Job? = null
+    private var followUpUpdateJob: Job? = null
+    private var lastWidgetPlayerInfo: PlayerInfo? = null
+
+    fun requestFullUpdate(force: Boolean = false) {
+        debouncedUpdateJob?.cancel()
+        debouncedUpdateJob = scope.launch {
+            val debounceMs = if (force) FORCED_DEBOUNCE_MS else NORMAL_DEBOUNCE_MS
+            if (debounceMs > 0L) {
+                delay(debounceMs)
+            }
+            processUpdateInternal()
+        }
+    }
+
+    /** Forces an immediate update plus a delayed follow-up so late-arriving
+     *  metadata/artwork (delivered after the first callback) is still published. */
+    fun requestWithFollowUp() {
+        requestFullUpdate(force = true)
+        followUpUpdateJob?.cancel()
+        followUpUpdateJob = scope.launch {
+            delay(FOLLOW_UP_DELAY_MS)
+            requestFullUpdate(force = true)
+        }
+    }
+
+    fun cancel() {
+        followUpUpdateJob?.cancel()
+        debouncedUpdateJob?.cancel()
+    }
+
+    /**
+     * Drops the cached [PlayerInfo] so its embedded artwork ByteArray becomes
+     * GC-eligible under memory pressure. The next update rebuilds it from scratch.
+     */
+    fun clearCachedState() {
+        lastWidgetPlayerInfo = null
+    }
+
+    private suspend fun processUpdateInternal() {
+        val playerInfo = buildPlayerInfo()
+        val oldInfo = lastWidgetPlayerInfo
+
+        val shouldUpdateWidgets = oldInfo == null || shouldUpdateWidget(oldInfo, playerInfo)
+        val shouldPublishWear = oldInfo == null || shouldPublishWearState(oldInfo, playerInfo)
+
+        if (shouldUpdateWidgets || shouldPublishWear) {
+            lastWidgetPlayerInfo = playerInfo
+        }
+
+        if (shouldUpdateWidgets) {
+            updateGlanceWidgets(playerInfo)
+        }
+
+        if (shouldPublishWear) {
+            val currentMediaId = resolveCurrentMediaIdForWear()
+            // Publish state to Wear OS watch
+            wearStatePublisher.publishState(currentMediaId, playerInfo)
+        }
+    }
+
+    private fun shouldUpdateWidget(old: PlayerInfo, new: PlayerInfo): Boolean {
+        if (old.songTitle != new.songTitle) return true
+        if (old.artistName != new.artistName) return true
+        if (old.isPlaying != new.isPlaying) return true
+        if (old.albumArtUri != new.albumArtUri) return true
+        // Detect when artwork bytes arrive (null → non-null) or are cleared
+        if ((old.albumArtBitmapData == null) != (new.albumArtBitmapData == null)) return true
+        if (old.isFavorite != new.isFavorite) return true
+        if (old.queue != new.queue) return true
+        if (old.themeColors != new.themeColors) return true
+        if (old.isShuffleEnabled != new.isShuffleEnabled) return true
+        if (old.repeatMode != new.repeatMode) return true
+        if (old.totalDurationMs != new.totalDurationMs) return true
+        if (old.wearThemePalette != new.wearThemePalette) return true
+
+        val drift = abs(old.currentPositionMs - new.currentPositionMs)
+        return drift > 3000L
+    }
+
+    private fun shouldPublishWearState(old: PlayerInfo, new: PlayerInfo): Boolean {
+        return shouldUpdateWidget(old, new) || old.wearQueueRevision != new.wearQueueRevision
+    }
+
+    private suspend fun updateGlanceWidgets(playerInfo: PlayerInfo) = withContext(Dispatchers.IO) {
+        try {
+            val glanceManager = GlanceAppWidgetManager(context)
+            val widgetPlayerInfo = playerInfo.toWidgetTransportState()
+
+            val glanceIds = glanceManager.getGlanceIds(PixelPlayGlanceWidget::class.java)
+            glanceIds.forEach { id ->
+                updateAppWidgetState(context, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
+                PixelPlayGlanceWidget().update(context, id)
+            }
+
+            val barGlanceIds = glanceManager.getGlanceIds(BarWidget4x1::class.java)
+            barGlanceIds.forEach { id ->
+                updateAppWidgetState(context, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
+                BarWidget4x1().update(context, id)
+            }
+
+            val controlGlanceIds = glanceManager.getGlanceIds(ControlWidget4x2::class.java)
+            controlGlanceIds.forEach { id ->
+                updateAppWidgetState(context, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
+                ControlWidget4x2().update(context, id)
+            }
+
+            val gridGlanceIds = glanceManager.getGlanceIds(GridWidget2x2::class.java)
+            gridGlanceIds.forEach { id ->
+                updateAppWidgetState(context, PlayerInfoStateDefinition, id) { widgetPlayerInfo }
+                GridWidget2x2().update(context, id)
+            }
+
+            if (glanceIds.isNotEmpty() || barGlanceIds.isNotEmpty() || controlGlanceIds.isNotEmpty() || gridGlanceIds.isNotEmpty()) {
+                Timber.tag(TAG)
+                    .d("Widgets actualizados: ${playerInfo.songTitle} (Original: ${glanceIds.size}, Bar: ${barGlanceIds.size}, Control: ${controlGlanceIds.size})")
+            } else {
+                Timber.tag(TAG).w("No se encontraron widgets para actualizar")
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Error al actualizar el widget")
+        }
+    }
+
+    private fun PlayerInfo.toWidgetTransportState(): PlayerInfo {
+        return copy(
+            lyrics = null,
+            isLoadingLyrics = false,
+            queue = queue.take(QUEUE_PREVIEW_LIMIT),
+            wearThemePalette = null,
+            wearQueueRevision = "",
+        )
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/PlayerViewModel.kt
@@ -1272,7 +1272,10 @@ class PlayerViewModel @Inject constructor(
     }
 
     private var mediaController: MediaController? = null
-    private var mediaControllerPlaybackListener: Player.Listener? = null
+    // All Player.Listener instances registered by the decomposed setup*Listeners()
+    // helpers. Tracked together so they can be removed in one pass on re-setup and
+    // in onCleared().
+    private val mediaControllerPlaybackListeners = mutableListOf<Player.Listener>()
     private val _isMediaControllerReady = MutableStateFlow(false)
     val isMediaControllerReady: StateFlow<Boolean> = _isMediaControllerReady.asStateFlow()
     // SessionToken injected via constructor
@@ -2835,9 +2838,44 @@ class PlayerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Wires the [MediaController] into the ViewModel. Decomposed from a single
+     * ~300-line block into a one-time state sync plus a set of focused, structured
+     * sub-listener registrations so each playback concern reads in isolation:
+     *  - [applyInitialControllerState]: snapshot the controller's current state on attach
+     *  - [setupVolumeListeners]: track volume changes
+     *  - [setupPlaybackListeners]: play/pause, playWhenReady, playback-state transitions
+     *  - [setupTransitionListeners]: media-item and timeline transitions
+     *  - [setupMetadataListeners]: tracks, metadata, shuffle and repeat mode
+     */
     private fun setupMediaControllerListeners() {
         Trace.beginSection("PlayerViewModel.setupMediaControllerListeners")
         val playerCtrl = mediaController ?: return Trace.endSection()
+        applyInitialControllerState(playerCtrl)
+        clearMediaControllerPlaybackListeners(playerCtrl)
+        setupVolumeListeners(playerCtrl)
+        setupPlaybackListeners(playerCtrl)
+        setupTransitionListeners(playerCtrl)
+        setupMetadataListeners(playerCtrl)
+        Trace.endSection()
+    }
+
+    /** Registers [listener] on [playerCtrl] and tracks it for later removal. */
+    private fun registerMediaControllerListener(playerCtrl: MediaController, listener: Player.Listener) {
+        mediaControllerPlaybackListeners.add(listener)
+        playerCtrl.addListener(listener)
+    }
+
+    /** Removes and forgets every listener registered via [registerMediaControllerListener]. */
+    private fun clearMediaControllerPlaybackListeners(controller: MediaController?) {
+        mediaControllerPlaybackListeners.forEach { listener ->
+            controller?.removeListener(listener)
+        }
+        mediaControllerPlaybackListeners.clear()
+    }
+
+    /** One-time snapshot of the controller's current state when it first attaches. */
+    private fun applyInitialControllerState(playerCtrl: MediaController) {
         _trackVolume.value = playerCtrl.volume
         playbackStateHolder.updateStablePlayerState {
             it.copy(
@@ -2893,13 +2931,20 @@ class PlayerViewModel @Inject constructor(
                 resetPlaybackAudioMetadata()
             }
         }
+    }
 
-        mediaControllerPlaybackListener?.let(playerCtrl::removeListener)
-        mediaControllerPlaybackListener = object : Player.Listener {
+    /** Volume changes coming back from the player/session. */
+    private fun setupVolumeListeners(playerCtrl: MediaController) {
+        registerMediaControllerListener(playerCtrl, object : Player.Listener {
             override fun onVolumeChanged(volume: Float) {
                 _trackVolume.value = volume
             }
+        })
+    }
 
+    /** Play/pause, playWhenReady and playback-state lifecycle. */
+    private fun setupPlaybackListeners(playerCtrl: MediaController) {
+        registerMediaControllerListener(playerCtrl, object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 if (isRemoteSessionControllingPlayback()) return
                 playbackStateHolder.updateStablePlayerState {
@@ -2936,6 +2981,66 @@ class PlayerViewModel @Inject constructor(
                 }
             }
 
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (isRemoteSessionControllingPlayback()) return
+                refreshPlaybackAudioMetadata(playerCtrl)
+                syncDisplayedMediaItemIfChanged(playerCtrl)
+
+                // Debounce buffering state to avoid flickering
+                bufferingDebounceJob?.cancel()
+                if (playbackState == Player.STATE_BUFFERING) {
+                    bufferingDebounceJob = viewModelScope.launch {
+                        delay(150) // Wait 150ms before showing buffering indicator
+                        playbackStateHolder.updateStablePlayerState { state ->
+                            state.copy(isBuffering = true)
+                        }
+                    }
+                } else {
+                    // Immediately hide buffering when not buffering
+                    playbackStateHolder.updateStablePlayerState { state ->
+                        state.copy(isBuffering = false)
+                    }
+                }
+
+                if (playbackState == Player.STATE_READY) {
+                    clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
+                    val readyPosition = playerCtrl.currentPosition.coerceAtLeast(0L)
+                    val songDurationHint = playbackStateHolder.stablePlayerState.value.currentSong?.duration ?: 0L
+                    val resolvedDuration = playbackStateHolder.resolveDurationForPlaybackState(
+                        reportedDurationMs = playerCtrl.duration,
+                        songDurationHintMs = songDurationHint,
+                        currentPositionMs = readyPosition
+                    )
+                    syncPlaybackPositionFromPlayer(playerCtrl.currentMediaItem?.mediaId, readyPosition)
+                    playbackStateHolder.updateStablePlayerState { it.copy(totalDuration = resolvedDuration) }
+                    startProgressUpdates()
+                }
+                if (playbackState == Player.STATE_IDLE && playerCtrl.mediaItemCount == 0) {
+                    clearPreparingSongIfMatching()
+                    if (!isCastConnecting.value && !isRemotePlaybackActive.value) {
+                        lyricsStateHolder.cancelLoading()
+                        playbackStateHolder.updateStablePlayerState {
+                            it.copy(
+                                currentSong = null,
+                                isPlaying = false,
+                                playWhenReady = false,
+                                lyrics = null,
+                                isLoadingLyrics = false,
+                                totalDuration = 0L
+                            )
+                        }
+                        playbackStateHolder.clearCurrentPositionHints()
+                        playbackStateHolder.setCurrentPosition(0L)
+                        resetPlaybackAudioMetadata()
+                    }
+                }
+            }
+        })
+    }
+
+    /** Media-item and timeline transitions (incl. EOT timer + Telegram offline guard). */
+    private fun setupTransitionListeners(playerCtrl: MediaController) {
+        registerMediaControllerListener(playerCtrl, object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 if (isRemoteSessionControllingPlayback()) return
                 playbackStateHolder.onPlaybackOccurrenceTransition(mediaItem?.mediaId)
@@ -2965,7 +3070,7 @@ class PlayerViewModel @Inject constructor(
 
                     mediaItem?.let { transitionedItem ->
                         val song = resolveSongFromMediaItem(transitionedItem)
-                        
+
                         // Offline check for Telegram songs
                         if (song?.contentUriString?.startsWith("telegram:") == true) {
                             ensureTelegramPlaybackObserversStarted()
@@ -3035,60 +3140,26 @@ class PlayerViewModel @Inject constructor(
                 }
             }
 
-            override fun onPlaybackStateChanged(playbackState: Int) {
+            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
                 if (isRemoteSessionControllingPlayback()) return
-                refreshPlaybackAudioMetadata(playerCtrl)
                 syncDisplayedMediaItemIfChanged(playerCtrl)
+                // Skip updates during crossfade transitions to prevent UI freeze and jumpy state.
+                if (dualPlayerEngine.isTransitionRunning()) return
 
-                // Debounce buffering state to avoid flickering
-                bufferingDebounceJob?.cancel()
-                if (playbackState == Player.STATE_BUFFERING) {
-                    bufferingDebounceJob = viewModelScope.launch {
-                        delay(150) // Wait 150ms before showing buffering indicator
-                        playbackStateHolder.updateStablePlayerState { state ->
-                            state.copy(isBuffering = true)
-                        }
-                    }
-                } else {
-                    // Immediately hide buffering when not buffering
-                    playbackStateHolder.updateStablePlayerState { state ->
-                        state.copy(isBuffering = false)
-                    }
-                }
+                transitionSchedulerJob?.cancel()
 
-                if (playbackState == Player.STATE_READY) {
-                    clearPreparingSongIfMatching(playerCtrl.currentMediaItem?.mediaId)
-                    val readyPosition = playerCtrl.currentPosition.coerceAtLeast(0L)
-                    val songDurationHint = playbackStateHolder.stablePlayerState.value.currentSong?.duration ?: 0L
-                    val resolvedDuration = playbackStateHolder.resolveDurationForPlaybackState(
-                        reportedDurationMs = playerCtrl.duration,
-                        songDurationHintMs = songDurationHint,
-                        currentPositionMs = readyPosition
-                    )
-                    syncPlaybackPositionFromPlayer(playerCtrl.currentMediaItem?.mediaId, readyPosition)
-                    playbackStateHolder.updateStablePlayerState { it.copy(totalDuration = resolvedDuration) }
-                    startProgressUpdates()
-                }
-                if (playbackState == Player.STATE_IDLE && playerCtrl.mediaItemCount == 0) {
-                    clearPreparingSongIfMatching()
-                    if (!isCastConnecting.value && !isRemotePlaybackActive.value) {
-                        lyricsStateHolder.cancelLoading()
-                        playbackStateHolder.updateStablePlayerState {
-                            it.copy(
-                                currentSong = null,
-                                isPlaying = false,
-                                playWhenReady = false,
-                                lyrics = null,
-                                isLoadingLyrics = false,
-                                totalDuration = 0L
-                            )
-                        }
-                        playbackStateHolder.clearCurrentPositionHints()
-                        playbackStateHolder.setCurrentPosition(0L)
-                        resetPlaybackAudioMetadata()
-                    }
+                // Only refresh full queue on structural changes or source updates (metadata)
+                if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED ||
+                    reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
+                    updateCurrentPlaybackQueueFromPlayer(mediaController)
                 }
             }
+        })
+    }
+
+    /** Track/metadata changes plus shuffle and repeat-mode reconciliation. */
+    private fun setupMetadataListeners(playerCtrl: MediaController) {
+        registerMediaControllerListener(playerCtrl, object : Player.Listener {
             override fun onTracksChanged(tracks: Tracks) {
                 if (isRemoteSessionControllingPlayback()) return
                 refreshPlaybackAudioMetadata(playerCtrl, tracks)
@@ -3112,23 +3183,7 @@ class PlayerViewModel @Inject constructor(
                 playbackStateHolder.updateStablePlayerState { it.copy(repeatMode = repeatMode) }
                 viewModelScope.launch { userPreferencesRepository.setRepeatMode(repeatMode) }
             }
-            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
-                if (isRemoteSessionControllingPlayback()) return
-                syncDisplayedMediaItemIfChanged(playerCtrl)
-                // Skip updates during crossfade transitions to prevent UI freeze and jumpy state.
-                if (dualPlayerEngine.isTransitionRunning()) return
-
-                transitionSchedulerJob?.cancel()
-                
-                // Only refresh full queue on structural changes or source updates (metadata)
-                if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED ||
-                    reason == Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE) {
-                    updateCurrentPlaybackQueueFromPlayer(mediaController)
-                }
-            }
-        }
-        playerCtrl.addListener(checkNotNull(mediaControllerPlaybackListener))
-        Trace.endSection()
+        })
     }
 
 
@@ -4385,10 +4440,7 @@ class PlayerViewModel @Inject constructor(
 
     override fun onCleared() {
         val controllerToRelease = mediaController
-        mediaControllerPlaybackListener?.let { listener ->
-            controllerToRelease?.removeListener(listener)
-            mediaControllerPlaybackListener = null
-        }
+        clearMediaControllerPlaybackListeners(controllerToRelease)
         playbackStateHolder.clearMediaController(controllerToRelease)
         controllerToRelease?.release()
         mediaController = null


### PR DESCRIPTION
…ners

Decomposes the monolithic `MusicService` into specialized components to improve maintainability and separates concerns for ReplayGain, Cast synchronization, and widget updates. Additionally, refactors `PlayerViewModel` to use structured, isolated listener registrations for `MediaController`.

- Created `ReplayGainProcessor` to encapsulate volume normalization logic, including IO-bound tag reading, crossfade-aware gain application, and user volume tracking.
- Created `CastSyncCoordinator` to manage Google Cast session lifecycles, remote playback state projection, and listening statistics synchronization.
- Created `WidgetUpdateManager` to own the Glance widget and Wear OS state-publishing pipeline, implementing debouncing and state diffing to optimize UI updates.
- Refactored `MusicService` to delegate logic to the new components, significantly reducing its complexity and surface area.
- Decomposed `PlayerViewModel.setupMediaControllerListeners` into focused helper methods (e.g., `setupVolumeListeners`, `setupPlaybackListeners`) and implemented a tracking mechanism to ensure all `Player.Listener` instances are properly cleared.