### PR TITLE
ui: handle FULL_WIDTH navigation bar style in SheetVisualState

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetVisualState.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/scoped/SheetVisualState.kt
@@ -189,7 +189,9 @@ internal fun rememberSheetVisualState(
                 showPlayerContentArea &&
                 playerContentExpansionFraction.value < 0.01f
             ) {
-                if (navBarStyle == NavBarStyle.DEFAULT) {
+                if (navBarStyle == NavBarStyle.FULL_WIDTH) {
+                    calculatedNormally
+                } else if (navBarStyle == NavBarStyle.DEFAULT) {
                     lerp(10.dp, navBarCornerRadiusDp, swipeDismissProgress)
                 } else {
                     val baseCollapsedRadius = if (isNavBarHidden) 32.dp else navBarCornerRadiusDp


### PR DESCRIPTION
Updates the corner radius logic in `SheetVisualState` to use default calculations when the `FULL_WIDTH` navigation bar style is active.

- Added a condition to use `calculatedNormally` for `NavBarStyle.FULL_WIDTH` within the player content area radius calculation.
- Ensures consistent UI behavior when transitioning between collapsed and expanded states across different navigation configurations.