### PR TITLE
fix: resolve specific volume names for MediaStore URIs on Android 11+

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MetadataEditStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/MetadataEditStateHolder.kt
@@ -455,7 +455,7 @@ class MetadataEditStateHolder @Inject constructor(
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                 val uris = songs.mapNotNull { song ->
                     song.id.toLongOrNull()?.takeIf { it > 0 }?.let { id ->
-                        MediaStorePermissionHelper.getMediaStoreUri(id)
+                        MediaStorePermissionHelper.getMediaStoreUri(context, id)
                     }
                 }
                 if (uris.isNotEmpty()) {

--- a/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/MediaStorePermissionHelper.kt
@@ -26,13 +26,52 @@ object MediaStorePermissionHelper {
     )
 
     /**
-     * Returns the MediaStore content URI for a given audio song ID.
+     * Returns the MediaStore content URI for a given audio song ID, querying the correct volume name.
      * Returns null for cloud songs (negative IDs).
+     */
+    fun getMediaStoreUri(context: Context, songId: Long): Uri? {
+        if (songId <= 0) return null
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val volumeName = try {
+                val projection = arrayOf(MediaStore.Audio.Media.VOLUME_NAME)
+                val selection = "${MediaStore.Audio.Media._ID} = ?"
+                val selectionArgs = arrayOf(songId.toString())
+                context.contentResolver.query(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    null
+                )?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.VOLUME_NAME))
+                    } else {
+                        null
+                    }
+                }
+            } catch (e: Exception) {
+                null
+            }
+
+            val targetVolume = if (volumeName != null && volumeName != MediaStore.VOLUME_EXTERNAL) {
+                volumeName
+            } else {
+                MediaStore.VOLUME_EXTERNAL_PRIMARY
+            }
+            MediaStore.Audio.Media.getContentUri(targetVolume, songId)
+        } else {
+            ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId)
+        }
+    }
+
+    /**
+     * Legacy/fallback version of getMediaStoreUri when Context is not available.
+     * Returns the MediaStore content URI using the primary external volume to avoid Invalid Uri exception.
      */
     fun getMediaStoreUri(songId: Long): Uri? {
         if (songId <= 0) return null
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL, songId)
+            MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY, songId)
         } else {
             ContentUris.withAppendedId(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songId)
         }
@@ -55,7 +94,9 @@ object MediaStorePermissionHelper {
                 add(MediaStore.Audio.Media.getContentUri(volumeName, songId))
             }
             add(MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY, songId))
-            add(MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL, songId))
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                add(MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL, songId))
+            }
         }.distinctBy { it.toString() }
     }
 
@@ -113,7 +154,12 @@ object MediaStorePermissionHelper {
      * Useful for non-audio files like .lrc that are indexed by MediaStore.
      */
     fun getMediaStoreUri(context: Context, filePath: String): Uri? {
-        val projection = arrayOf(MediaStore.Files.FileColumns._ID)
+        val hasVolumeName = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        val projection = if (hasVolumeName) {
+            arrayOf(MediaStore.Files.FileColumns._ID, MediaStore.Files.FileColumns.VOLUME_NAME)
+        } else {
+            arrayOf(MediaStore.Files.FileColumns._ID)
+        }
         val selection = "${MediaStore.Files.FileColumns.DATA} = ?"
         val selectionArgs = arrayOf(filePath)
         val queryUri = MediaStore.Files.getContentUri("external")
@@ -121,7 +167,22 @@ object MediaStorePermissionHelper {
         return context.contentResolver.query(queryUri, projection, selection, selectionArgs, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
                 val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID))
-                ContentUris.withAppendedId(queryUri, id)
+                val volumeName = if (hasVolumeName) {
+                    cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns.VOLUME_NAME))
+                } else {
+                    null
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val targetVolume = if (volumeName != null && volumeName != MediaStore.VOLUME_EXTERNAL) {
+                        volumeName
+                    } else {
+                        MediaStore.VOLUME_EXTERNAL_PRIMARY
+                    }
+                    val baseVolumeUri = MediaStore.Files.getContentUri(targetVolume)
+                    ContentUris.withAppendedId(baseVolumeUri, id)
+                } else {
+                    ContentUris.withAppendedId(queryUri, id)
+                }
             } else {
                 null
             }
@@ -205,7 +266,7 @@ object MediaStorePermissionHelper {
      */
     @RequiresApi(Build.VERSION_CODES.R)
     fun createWriteRequestForSong(context: Context, songId: Long): IntentSender? {
-        val uri = getMediaStoreUri(songId) ?: return null
+        val uri = getMediaStoreUri(context, songId) ?: return null
         return createWriteRequestIntentSender(context, listOf(uri))
     }
 
@@ -215,7 +276,7 @@ object MediaStorePermissionHelper {
      */
     @RequiresApi(Build.VERSION_CODES.R)
     fun createDeleteRequestForSong(context: Context, songId: Long): IntentSender? {
-        val uri = getMediaStoreUri(songId) ?: return null
+        val uri = getMediaStoreUri(context, songId) ?: return null
         return createDeleteRequestIntentSender(context, listOf(uri))
     }
 }


### PR DESCRIPTION
Updates the URI resolution logic to correctly identify the specific storage volume (internal vs. removable) for media files. This prevents potential "Invalid Uri" errors when performing file operations on Android 11 (API 30) and above.

- Introduced a context-aware `getMediaStoreUri` that queries `VOLUME_NAME` to construct precise content URIs.
- Updated file-path-to-URI resolution to fetch and utilize `VOLUME_NAME` on API 29+.
- Changed the legacy fallback volume from `VOLUME_EXTERNAL` to `VOLUME_EXTERNAL_PRIMARY` for API 30+ to improve compatibility.
- Refactored `MetadataEditStateHolder` and permission request helpers to use the enhanced URI resolution.