### PR TITLE
Simplify image cropping layout and redesign generate report button

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/EditSongSheet.kt
@@ -937,80 +937,65 @@ fun CoverArtCropperDialog(
                             .size(cropSide)
                             .align(Alignment.Center)
                             .clip(RoundedCornerShape(32.dp))
-                            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                            .padding(12.dp)
+                            .background(MaterialTheme.colorScheme.surfaceDim)
+                            .clipToBounds()
+                            .capturable(controller = captureController)
+                            .transformable(transformableState)
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .clip(RoundedCornerShape(28.dp))
-                                .background(MaterialTheme.colorScheme.surfaceDim)
-                                .clipToBounds()
-                        ) {
-                            when {
-                                isLoading -> {
-                                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                                }
+                        when {
+                            isLoading -> {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.align(Alignment.Center)
+                                )
+                            }
 
-                                loadError != null -> {
-                                    Text(
-                                        text = loadError!!,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        modifier = Modifier
-                                            .align(Alignment.Center)
-                                            .padding(16.dp),
-                                        textAlign = TextAlign.Center
-                                    )
-                                }
+                            loadError != null -> {
+                                Text(
+                                    text = loadError!!,
+                                    modifier = Modifier
+                                        .align(Alignment.Center)
+                                        .padding(16.dp)
+                                )
+                            }
 
-                                 loadedBitmap != null -> {
-                                    val bitmap = loadedBitmap!!
-                                    val baseScale = maxOf(containerSize / bitmap.width, containerSize / bitmap.height)
-                                    val displayWidth = with(LocalDensity.current) { (bitmap.width * baseScale).toDp() }
-                                    val displayHeight = with(LocalDensity.current) { (bitmap.height * baseScale).toDp() }
+                            loadedBitmap != null -> {
+                                val bitmap = loadedBitmap!!
+                                val baseScale = maxOf(containerSize / bitmap.width, containerSize / bitmap.height)
+                                val displayWidth = with(LocalDensity.current) { (bitmap.width * baseScale).toDp() }
+                                val displayHeight = with(LocalDensity.current) { (bitmap.height * baseScale).toDp() }
+                                
+                                Image(
+                                    bitmap = loadedBitmap!!,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .align(Alignment.Center)
+                                        .requiredSize(displayWidth, displayHeight)
+                                        .graphicsLayer {
+                                            scaleX = scale
+                                            scaleY = scale
+                                            translationX = offset.x
+                                            translationY = offset.y
+                                        }
+                                )
 
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxSize()
-                                            .clip(RoundedCornerShape(28.dp))
-                                            .background(MaterialTheme.colorScheme.surface)
-                                            .clipToBounds()
-                                            .capturable(controller = captureController)
-                                            .transformable(transformableState)
-                                    ) {
-                                        Image(
-                                            bitmap = bitmap,
-                                            contentDescription = null,
-                                            modifier = Modifier
-                                                .requiredSize(displayWidth, displayHeight)
-                                                .graphicsLayer {
-                                                    scaleX = scale
-                                                    scaleY = scale
-                                                    translationX = offset.x
-                                                    translationY = offset.y
-                                                }
+                                Canvas(modifier = Modifier.matchParentSize()) {
+                                    val step = size.width / 3f
+                                    for (index in 1 until 3) {
+                                        val lineOffset = step * index
+                                        drawLine(
+                                            color = gridColor,
+                                            start = Offset(lineOffset, 0f),
+                                            end = Offset(lineOffset, size.height),
+                                            strokeWidth = 2f
+                                        )
+                                        drawLine(
+                                            color = gridColor,
+                                            start = Offset(0f, lineOffset),
+                                            end = Offset(size.width, lineOffset),
+                                            strokeWidth = 2f
                                         )
                                     }
-
-                                    Canvas(modifier = Modifier.matchParentSize()) {
-                                        val step = size.width / 3f
-                                        for (index in 1 until 3) {
-                                            val lineOffset = step * index
-                                            drawLine(
-                                                color = gridColor,
-                                                start = Offset(lineOffset, 0f),
-                                                end = Offset(lineOffset, size.height),
-                                                strokeWidth = 2f
-                                            )
-                                            drawLine(
-                                                color = gridColor,
-                                                start = Offset(0f, lineOffset),
-                                                end = Offset(size.width, lineOffset),
-                                                strokeWidth = 2f
-                                            )
-                                        }
-                                        drawRect(color = gridColor, style = Stroke(width = 3f))
-                                    }
+                                    drawRect(color = gridColor, style = Stroke(width = 3f))
                                 }
                             }
                         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DeviceCapabilitiesScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/DeviceCapabilitiesScreen.kt
@@ -303,32 +303,35 @@ private fun PerformanceReportCard(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
+        Button(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = onGenerate,
+            enabled = !isGenerating
+        ) {
+            if (isGenerating) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            } else {
+                Text(
+                    text = stringResource(
+                        if (report == null) R.string.device_capabilities_report_generate
+                        else R.string.device_capabilities_report_regenerate
+                    )
+                )
+            }
+        }
+
         Row(
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Button(
-                onClick = onGenerate,
-                enabled = !isGenerating
-            ) {
-                if (isGenerating) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                } else {
-                    Text(
-                        text = stringResource(
-                            if (report == null) R.string.device_capabilities_report_generate
-                            else R.string.device_capabilities_report_regenerate
-                        )
-                    )
-                }
-            }
-
             if (report != null) {
                 OutlinedButton(
+                    modifier = Modifier.weight(1f),
                     onClick = {
                         clipboardManager.setText(AnnotatedString(report))
                         Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
@@ -344,6 +347,7 @@ private fun PerformanceReportCard(
                 }
 
                 OutlinedButton(
+                    modifier = Modifier.weight(1f),
                     onClick = {
                         val sendIntent = Intent(Intent.ACTION_SEND).apply {
                             type = "text/plain"


### PR DESCRIPTION
- Simplify the image cropping UI in `EditSongSheet.kt` by removing internal padding and an unnecessary nested Box, fixing the image zoom issue.
- Redesign the Generate Report action layout for better usability. See the screenshot below.

**Before**
<img width="350" height="600" alt="Screenshot_20260606-065511_1" src="https://github.com/user-attachments/assets/ad655d88-7d36-4320-8c71-fc0bb3948f77" />

**After**
<img width="350" height="600" alt="Screenshot_20260606-064634_1" src="https://github.com/user-attachments/assets/ddb7f569-98fb-4727-b575-121783487168" />
