### PR TITLE
Allow http URLs for all local-network Navidrome and Jellyfin hosts

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentials.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentials.kt
@@ -54,15 +54,8 @@ data class JellyfinCredentials(
         }
 
         // Warn about cleartext HTTP on public hosts
-        if (!parsed.isHttps) {
-            val host = parsed.host
-            val isPrivate = host == "localhost" ||
-                    host == "127.0.0.1" ||
-                    host.endsWith(".local") ||
-                    CloudStreamSecurity.isPrivateIpv4Literal(host)
-            if (!isPrivate) {
-                return "Use https:// for remote Jellyfin servers. HTTP is only allowed for local network addresses."
-            }
+        if (!parsed.isHttps && !CloudStreamSecurity.isLocalOrPrivateHost(parsed.host)) {
+            return "Use https:// for remote Jellyfin servers. HTTP is only allowed for local network addresses."
         }
 
         return null

--- a/app/src/main/java/com/theveloper/pixelplay/data/navidrome/model/NavidromeCredentials.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/navidrome/model/NavidromeCredentials.kt
@@ -76,15 +76,10 @@ data class NavidromeCredentials(
         if (httpUrl.username.isNotEmpty() || httpUrl.password.isNotEmpty()) {
             return "Server URL must not include embedded credentials."
         }
-        if (requireHttps && !httpUrl.isHttps) {
-            val host = httpUrl.host
-            val isPrivate = host == "localhost" ||
-                    host == "127.0.0.1" ||
-                    host.endsWith(".local") ||
-                    CloudStreamSecurity.isPrivateIpv4Literal(host)
-            if (!isPrivate) {
-                return "Use an https:// server URL for remote Navidrome/Subsonic servers. HTTP is only allowed for local network addresses."
-            }
+        if (requireHttps && !httpUrl.isHttps &&
+            !CloudStreamSecurity.isLocalOrPrivateHost(httpUrl.host)
+        ) {
+            return "Use an https:// server URL for remote Navidrome/Subsonic servers. HTTP is only allowed for local network addresses."
         }
         return null
     }

--- a/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurity.kt
@@ -20,6 +20,11 @@ object CloudStreamSecurity {
     private val NAVIDROME_SONG_ID_REGEX = Regex("^[A-Za-z0-9_-]{1,100}$")
     private val JELLYFIN_ITEM_ID_REGEX = Regex("^[A-Za-z0-9]{1,100}$")
     private val FORBIDDEN_HOSTS = setOf("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")
+
+    // DNS suffixes that only resolve on a local network: mDNS (.local), common
+    // router defaults (.lan, .home), ICANN private-use (.internal), and the
+    // RFC 8375 home network domain (.home.arpa).
+    private val LOCAL_DNS_SUFFIXES = listOf(".local", ".lan", ".home", ".internal", ".home.arpa")
     private val EXTRA_ALLOWED_AUDIO_TYPES = setOf(
         "application/octet-stream",
         "binary/octet-stream",
@@ -171,6 +176,28 @@ object CloudStreamSecurity {
         }
     }
 
+    /**
+     * Returns true when [host] points at a local network or private address,
+     * where cleartext HTTP is acceptable for self-hosted media servers
+     * (Navidrome/Subsonic, Jellyfin).
+     *
+     * Covers loopback names, local-only DNS suffixes, single-label LAN
+     * hostnames, private and carrier-grade-NAT IPv4 ranges (the latter used by
+     * Tailscale-style VPNs), and loopback/link-local/unique-local IPv6 literals.
+     */
+    internal fun isLocalOrPrivateHost(host: String): Boolean {
+        val normalized = host.lowercase().removePrefix("[").removeSuffix("]")
+        if (normalized.isEmpty()) return false
+        if (normalized == "localhost") return true
+        if (LOCAL_DNS_SUFFIXES.any { normalized.endsWith(it) }) return true
+        if (isPrivateIpv4Literal(normalized)) return true
+        if (isCgnatIpv4Literal(normalized)) return true
+        if (normalized.contains(':')) return isPrivateIpv6Literal(normalized)
+        // Single-label hostnames have no public DNS meaning; they only resolve
+        // via the local resolver (router DNS, hosts file, NetBIOS).
+        return !normalized.contains('.')
+    }
+
     internal fun isPrivateIpv4Literal(host: String): Boolean {
         val parts = host.split('.')
         if (parts.size != 4) return false
@@ -187,5 +214,28 @@ object CloudStreamSecurity {
             (first == 169 && second == 254) ||
             (first == 172 && second in 16..31) ||
             (first == 192 && second == 168)
+    }
+
+    // 100.64.0.0/10 — carrier-grade NAT space (RFC 6598), assigned to clients
+    // by Tailscale and similar overlay VPNs.
+    private fun isCgnatIpv4Literal(host: String): Boolean {
+        val parts = host.split('.')
+        if (parts.size != 4) return false
+
+        val octets = parts.map { it.toIntOrNull() ?: return false }
+        if (octets.any { it !in 0..255 }) return false
+
+        return octets[0] == 100 && octets[1] in 64..127
+    }
+
+    // ::1 loopback, fe80::/10 link-local, fc00::/7 unique-local.
+    private fun isPrivateIpv6Literal(host: String): Boolean {
+        if (host == "::1" || host == "0:0:0:0:0:0:0:1") return true
+        if (host.startsWith("fe8") || host.startsWith("fe9") ||
+            host.startsWith("fea") || host.startsWith("feb")
+        ) {
+            return true
+        }
+        return host.startsWith("fc") || host.startsWith("fd")
     }
 }

--- a/app/src/test/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentialsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/jellyfin/model/JellyfinCredentialsTest.kt
@@ -1,37 +1,36 @@
-package com.theveloper.pixelplay.data.navidrome.model
+package com.theveloper.pixelplay.data.jellyfin.model
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
-class NavidromeCredentialsTest {
+class JellyfinCredentialsTest {
 
     @Test
     fun `connectionValidationError accepts normalized https urls`() {
-        val credentials = NavidromeCredentials(
-            serverUrl = " https://music.example.com/subsonic/ ",
+        val credentials = JellyfinCredentials(
+            serverUrl = " https://media.example.com/jellyfin/ ",
             username = "user",
             password = "pass"
         )
 
         assertNull(credentials.connectionValidationError())
-        assertEquals("https://music.example.com/subsonic", credentials.normalizedServerUrl)
+        assertEquals("https://media.example.com/jellyfin", credentials.normalizedServerUrl)
     }
 
     @Test
     fun `connectionValidationError accepts local http urls`() {
         val localUrls = listOf(
-            "http://192.168.1.20:4533",
-            "http://mynas:4533",
-            "http://nas.lan:4533",
-            "http://navidrome.home.arpa:4533",
-            "http://[::1]:4533",
-            "http://[fd00::1]:4533",
-            "http://100.101.102.103:4533"
+            "http://192.168.1.20:8096",
+            "http://mynas:8096",
+            "http://nas.lan:8096",
+            "http://jellyfin.home.arpa:8096",
+            "http://[::1]:8096",
+            "http://100.101.102.103:8096"
         )
 
         localUrls.forEach { url ->
-            val credentials = NavidromeCredentials(
+            val credentials = JellyfinCredentials(
                 serverUrl = url,
                 username = "user",
                 password = "pass"
@@ -43,28 +42,28 @@ class NavidromeCredentialsTest {
 
     @Test
     fun `connectionValidationError rejects remote http urls`() {
-        val credentials = NavidromeCredentials(
-            serverUrl = "http://music.example.com",
+        val credentials = JellyfinCredentials(
+            serverUrl = "http://media.example.com",
             username = "user",
             password = "pass"
         )
 
         assertEquals(
-            "Use an https:// server URL for remote Navidrome/Subsonic servers. HTTP is only allowed for local network addresses.",
+            "Use https:// for remote Jellyfin servers. HTTP is only allowed for local network addresses.",
             credentials.connectionValidationError()
         )
     }
 
     @Test
     fun `connectionValidationError rejects embedded credentials`() {
-        val credentials = NavidromeCredentials(
-            serverUrl = "https://user:secret@music.example.com",
+        val credentials = JellyfinCredentials(
+            serverUrl = "https://user:secret@media.example.com",
             username = "user",
             password = "pass"
         )
 
         assertEquals(
-            "Server URL must not include embedded credentials.",
+            "Server URL must not contain embedded credentials",
             credentials.connectionValidationError()
         )
     }

--- a/app/src/test/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurityTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/stream/CloudStreamSecurityTest.kt
@@ -70,6 +70,40 @@ class CloudStreamSecurityTest {
     }
 
     @Test
+    fun `isLocalOrPrivateHost accepts local network hosts`() {
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("localhost"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("127.0.0.1"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("192.168.1.20"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("10.0.0.5"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("172.20.0.3"))
+        // Carrier-grade NAT (Tailscale and similar VPNs)
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("100.101.102.103"))
+        // Single-label LAN hostnames
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("mynas"))
+        // Local-only DNS suffixes
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("nas.local"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("nas.lan"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("nas.home"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("nas.internal"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("nas.home.arpa"))
+        // IPv6 loopback, unique-local, link-local
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("::1"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("[::1]"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("fd00::1"))
+        assertTrue(CloudStreamSecurity.isLocalOrPrivateHost("fe80::abcd"))
+    }
+
+    @Test
+    fun `isLocalOrPrivateHost rejects public hosts`() {
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost("music.example.com"))
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost("8.8.8.8"))
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost("100.32.1.2"))
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost("2001:db8::1"))
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost("notlocal.example.org"))
+        assertFalse(CloudStreamSecurity.isLocalOrPrivateHost(""))
+    }
+
+    @Test
     fun `isSupportedAudioContentType only accepts audio-safe types`() {
         assertTrue(CloudStreamSecurity.isSupportedAudioContentType("audio/mpeg"))
         assertTrue(CloudStreamSecurity.isSupportedAudioContentType("application/octet-stream"))


### PR DESCRIPTION
Fixes #2327

## Problem

#2329 relaxed the Navidrome server URL validation to accept http for `localhost`, `127.0.0.1`, `*.local`, and private IPv4 literals, matching Jellyfin. However, many common local setups are still rejected over http by both integrations:

- Single-label LAN hostnames (`http://mynas:4533`) resolved by router DNS
- Local-only DNS suffixes: `.lan`, `.home`, `.internal`, `.home.arpa` (RFC 8375)
- IPv6 loopback / link-local / unique-local literals (`http://[::1]:4533`, `http://[fd00::1]:4533`)
- Carrier-grade NAT addresses, `100.64.0.0/10` (RFC 6598) — what Tailscale assigns, a very common way to reach a self-hosted Navidrome

## Changes

- Add `CloudStreamSecurity.isLocalOrPrivateHost(host)` covering all of the above host forms in one place.
- Use it from `NavidromeCredentials.connectionValidationError` and `JellyfinCredentials.connectionValidationError`, replacing the duplicated inline checks so the two integrations stay in sync.
- Remote (public) http URLs are still rejected with the same error message as before.

No changes were needed downstream: `NavidromeApiService`, the stream proxies, and the Coil image loader all use cleartext-capable OkHttp clients, and the network security config already permits cleartext, so http works end-to-end once validation passes.

## Tests

- `CloudStreamSecurityTest`: new coverage for `isLocalOrPrivateHost` (accepts local/private forms, rejects public hosts including `100.32.x.x` outside the CGNAT range).
- `NavidromeCredentialsTest`: local http acceptance extended to hostname/IPv6/CGNAT forms.
- `JellyfinCredentialsTest` (new): parity coverage for the Jellyfin validation.

All 16 tests in the three classes pass via `:app:testDebugUnitTest`.