### PR TITLE
Fix lyrics translation issues & more localization UI

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumMultiSelectionOptionSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/AlbumMultiSelectionOptionSheet.kt
@@ -145,10 +145,10 @@ fun AlbumMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.Rounded.PlayArrow,
-                            contentDescription = "Play selected albums"
+                            contentDescription = stringResource(R.string.song_info_cd_play_all)
                         )
                     },
-                    text = "Play"
+                    text = stringResource(R.string.song_info_action_play),
                 )
 
                 AlbumSelectionActionButton(
@@ -166,10 +166,10 @@ fun AlbumMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Rounded.PlaylistAdd,
-                            contentDescription = "Add selected albums to playlist"
+                            contentDescription = stringResource(R.string.song_info_cd_add_to_playlist)
                         )
                     },
-                    text = "Playlist"
+                    text = stringResource(R.string.common_playlist)
                 )
             }
 
@@ -197,10 +197,10 @@ fun AlbumMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                            contentDescription = "Play selected albums next"
+                            contentDescription = stringResource(R.string.song_info_cd_queue_next)
                         )
                     },
-                    text = "Next"
+                    text = stringResource(R.string.song_info_action_queue_next)
                 )
 
                 AlbumSelectionActionButton(
@@ -218,10 +218,10 @@ fun AlbumMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
-                            contentDescription = "Add selected albums to queue"
+                            contentDescription = stringResource(R.string.song_info_cd_add_to_queue)
                         )
                     },
-                    text = "Add to Queue"
+                    text = stringResource(R.string.song_info_action_add_to_queue)
                 )
             }
 
@@ -253,7 +253,6 @@ private fun AlbumSelectionActionButton(
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,
             lineHeight = 20.sp,
-            style = MaterialTheme.typography.titleMedium
         )
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/GenreMultiSelectionOptionSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/GenreMultiSelectionOptionSheet.kt
@@ -90,7 +90,7 @@ fun GenreMultiSelectionOptionSheet(
 
                 Column {
                     AutoSizingTextToFill(
-                        text = stringResource(R.string.library_selection_all) + " (${selectedGenres.size})",
+                        text = stringResource(R.string.multi_selection_genres_count_upper, selectedGenres.size),
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         fontFamily = GoogleSansRounded,
@@ -100,7 +100,7 @@ fun GenreMultiSelectionOptionSheet(
                     )
                     Spacer(Modifier.height(4.dp))
                     Text(
-                        text = "Genres Selected",
+                        text = stringResource(R.string.multi_selection_genres_selected),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontFamily = GoogleSansRounded,
@@ -113,7 +113,7 @@ fun GenreMultiSelectionOptionSheet(
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "Perform batch operations on all songs within these genres.",
+                text = stringResource(R.string.multi_selection_genres_queue_hint),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -142,10 +142,10 @@ fun GenreMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.Rounded.PlayArrow,
-                            contentDescription = "Play selected genres"
+                            contentDescription = stringResource(R.string.song_info_cd_play_all)
                         )
                     },
-                    text = "Play"
+                    text = stringResource(R.string.song_info_action_play)
                 )
 
                 GenreSelectionActionButton(
@@ -163,10 +163,10 @@ fun GenreMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Rounded.PlaylistAdd,
-                            contentDescription = "Add selected genres to playlist"
+                            contentDescription = stringResource(R.string.song_info_cd_add_to_playlist)
                         )
                     },
-                    text = "Playlist"
+                    text = stringResource(R.string.common_playlist)
                 )
             }
 
@@ -194,10 +194,10 @@ fun GenreMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                            contentDescription = "Play selected genres next"
+                            contentDescription = stringResource(R.string.song_info_cd_queue_next)
                         )
                     },
-                    text = "Next"
+                    text = stringResource(R.string.song_info_action_queue_next)
                 )
 
                 GenreSelectionActionButton(
@@ -215,10 +215,10 @@ fun GenreMultiSelectionOptionSheet(
                     icon = {
                         Icon(
                             imageVector = Icons.AutoMirrored.Rounded.QueueMusic,
-                            contentDescription = "Add selected genres to queue"
+                            contentDescription = stringResource(R.string.song_info_cd_add_to_queue)
                         )
                     },
-                    text = "Add to Queue"
+                    text = stringResource(R.string.song_info_action_add_to_queue)
                 )
             }
 
@@ -250,7 +250,6 @@ private fun GenreSelectionActionButton(
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,
             lineHeight = 20.sp,
-            style = MaterialTheme.typography.titleMedium
         )
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsFloatingToolbar.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsFloatingToolbar.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.util.lerp
+import androidx.compose.ui.text.style.TextOverflow
 
 import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
 
@@ -129,7 +130,9 @@ fun LyricsFloatingToolbar(
                 inactiveContentColor = onBackgroundColor,
                 activeCornerRadius = 50.dp,
                 onClick = { onShowSyncedLyricsChange(true) },
-                text = stringResource(R.string.lyrics_mode_synced)
+                text = stringResource(R.string.lyrics_mode_synced),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
 
             ToggleSegmentButton(
@@ -142,7 +145,9 @@ fun LyricsFloatingToolbar(
                 inactiveContentColor = onBackgroundColor,
                 activeCornerRadius = 50.dp,
                 onClick = { onShowSyncedLyricsChange(false) },
-                text = stringResource(R.string.lyrics_mode_static)
+                text = stringResource(R.string.lyrics_mode_static),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
         

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/MultiSelectionBottomSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/MultiSelectionBottomSheet.kt
@@ -270,16 +270,16 @@ fun MultiSelectionBottomSheet(
                             ) {
                                 Icon(
                                     Icons.Rounded.PlayArrow,
-                                    contentDescription = stringResource(R.string.song_info_action_play_all),
+                                    contentDescription = stringResource(R.string.song_info_cd_play_all),
                                 )
                                 Spacer(Modifier.width(6.dp))
                                 TightWrapText(
-                                    text = stringResource(R.string.song_info_cd_play_all),
+                                    text = stringResource(R.string.song_info_action_play_all),
                                     modifier = Modifier.padding(end = 4.dp),
                                     overflow = TextOverflow.Ellipsis,
                                     maxLines = 2,
                                     lineHeight = 22.sp,
-                                    style = MaterialTheme.typography.titleMediumEmphasized
+                                    style = MaterialTheme.typography.titleLarge
                                 )
                             }
                             // Like/Unlike toggle button

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/ToggleSegmentButton.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/ToggleSegmentButton.kt
@@ -28,9 +28,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.theveloper.pixelplay.presentation.components.LocalMaterialTheme
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 
 @Composable
 fun ToggleSegmentButton(
@@ -107,7 +110,10 @@ fun ToggleSegmentButton(
     inactiveContentColor: Color = LocalMaterialTheme.current.primary,
     activeCornerRadius: Dp = 8.dp,
     onClick: () -> Unit,
-    text: String
+    text: String,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
+    textAlign: TextAlign = TextAlign.Center
 ) {
     ToggleSegmentButtonContainer(
         modifier = modifier,
@@ -118,11 +124,14 @@ fun ToggleSegmentButton(
         activeCornerRadius = activeCornerRadius,
         onClick = onClick
     ) {
-        androidx.compose.material3.Text(
+        Text(
             text = text,
             color = if (active) activeContentColor else inactiveContentColor,
-            style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            maxLines = maxLines,
+            overflow = overflow,
+            textAlign = textAlign
         )
     }
 }
@@ -139,7 +148,10 @@ fun ToggleSegmentButton(
     activeCornerRadius: Dp = 8.dp,
     onClick: () -> Unit,
     text: String,
-    imageVector: ImageVector
+    imageVector: ImageVector,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
+    textAlign: TextAlign = TextAlign.Center
 ) {
     ToggleSegmentButtonContainer(
         modifier = modifier,
@@ -166,7 +178,10 @@ fun ToggleSegmentButton(
                 text = text,
                 color = if (active) activeContentColor else inactiveContentColor,
                 style = MaterialTheme.typography.bodyMedium,
-                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                fontWeight = FontWeight.Bold,
+                maxLines = maxLines,
+                overflow = overflow,
+                textAlign = textAlign
             )
         }
     }
@@ -204,7 +219,11 @@ private fun ToggleSegmentButtonContainer(
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
-        Box(modifier = Modifier.graphicsLayer(alpha = if (enabled) 1f else 0.38f)) {
+        Box(
+            modifier = Modifier
+                .graphicsLayer(alpha = if (enabled) 1f else 0.38f)
+                .padding(horizontal = 10.dp)
+        ) {
             content()
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/SearchScreen.kt
@@ -1705,10 +1705,18 @@ fun SearchFilterChip(
 ) {
     val selected = filterType == currentFilter
 
+    val labelResId = when (filterType) {
+        SearchFilterType.ALL -> R.string.common_all
+        SearchFilterType.SONGS -> R.string.library_tab_songs
+        SearchFilterType.ALBUMS -> R.string.library_tab_albums
+        SearchFilterType.ARTISTS -> R.string.library_tab_artists
+        SearchFilterType.PLAYLISTS -> R.string.library_tab_playlists
+    }
+
     FilterChip(
         selected = selected,
         onClick = { playerViewModel.updateSearchFilter(filterType) },
-        label = { Text(filterType.name.lowercase().replaceFirstChar { it.titlecase() }) },
+        label = { Text(stringResource(labelResId)) },
         modifier = modifier,
         shape = CircleShape,
         border = BorderStroke(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
@@ -343,12 +343,6 @@ class LyricsStateHolder @Inject constructor(
      */
     fun translateLyricsViaAi(currentSong: Song, lyricsObj: Lyrics?, cb: LyricsTranslationCallbacks) {
         val songId = currentSong.id.toLongOrNull() ?: return
-        val rawLyrics = currentSong.lyrics
-
-        if (rawLyrics.isNullOrBlank()) {
-            _messageEvents.tryEmit(cb.getString(R.string.lyrics_not_found))
-            return
-        }
 
         if (lyricsObj?.synced != null) {
             val hasValidTranslation = lyricsObj.synced.any { !it.translation.isNullOrBlank() }
@@ -360,6 +354,19 @@ class LyricsStateHolder @Inject constructor(
 
         scope?.launch {
             _messageEvents.emit(cb.getString(R.string.lyrics_translate_progress))
+
+            val rawLyrics = withContext(Dispatchers.IO) {
+                currentSong.lyrics?.takeIf { it.isNotBlank() }
+                    ?: readLocalLyricsFile(currentSong)
+                    ?: readEmbeddedLyricsFromFile(currentSong)
+                    ?: musicRepository.getStoredLyrics(currentSong)?.second
+            }
+
+            if (rawLyrics.isNullOrBlank()) {
+                _messageEvents.emit(cb.getString(R.string.lyrics_not_found))
+                return@launch
+            }
+
             val result = cb.translate(rawLyrics)
             result.onSuccess { translatedText ->
                 if (translatedText.trim() == "ALREADY_IN_TARGET_LANGUAGE") {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Fehler</string>
     <string name="common_search">Suchen</string>
     <string name="common_clear_search">Suche löschen</string>
+    <string name="common_all">Alle</string>
     <string name="common_confirm">Bestätigen</string>
     <string name="common_saved">Gespeichert!</string>
     <string name="common_selected">Ausgewählt</string>

--- a/app/src/main/res/values-de/strings_library.xml
+++ b/app/src/main/res/values-de/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">ausgewählt</string>
     <string name="multi_selection_albums_selected_limit">Limit: %1$d Alben pro Auswahl.</string>
     <string name="multi_selection_albums_queue_hint">Queue + Abspielen beachtet die Auswahlreihenfolge.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GENRES</string>
+    <string name="multi_selection_genres_selected">ausgewählt</string>
+    <string name="multi_selection_genres_queue_hint">Führe Stapelaktionen für alle Songs in diesen Genres aus.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Standardreihenfolge</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Error</string>
     <string name="common_search">Buscar</string>
     <string name="common_clear_search">Borrar búsqueda</string>
+    <string name="common_all">Todos</string>
     <string name="common_confirm">Confirmar</string>
     <string name="common_saved">¡Guardado!</string>
     <string name="common_selected">Seleccionado</string>

--- a/app/src/main/res/values-es/strings_library.xml
+++ b/app/src/main/res/values-es/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">seleccionados</string>
     <string name="multi_selection_albums_selected_limit">Límite: %1$d álbumes por selección.</string>
     <string name="multi_selection_albums_queue_hint">La cola y reproducción respetan el orden de selección.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GÉNEROS</string>
+    <string name="multi_selection_genres_selected">seleccionados</string>
+    <string name="multi_selection_genres_queue_hint">Realizar operaciones por lotes en todas las canciones de estos géneros.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Orden predeterminado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Erreur</string>
     <string name="common_search">Rechercher</string>
     <string name="common_clear_search">Effacer la recherche</string>
+    <string name="common_all">Tout</string>
     <string name="common_confirm">Confirmer</string>
     <string name="common_saved">Enregistré !</string>
     <string name="common_selected">Sélectionné</string>

--- a/app/src/main/res/values-fr/strings_library.xml
+++ b/app/src/main/res/values-fr/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">sélectionné(s)</string>
     <string name="multi_selection_albums_selected_limit">Limite : %1$d albums par sélection.</string>
     <string name="multi_selection_albums_queue_hint">La file d\'attente + lecture respecte l\'ordre de votre sélection.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GENRES</string>
+    <string name="multi_selection_genres_selected">sélectionnés</string>
+    <string name="multi_selection_genres_queue_hint">Effectuer des opérations par lots sur toutes les chansons de ces genres.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Ordre par défaut</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Kesalahan</string>
     <string name="common_search">Cari</string>
     <string name="common_clear_search">Bersihkan pencarian</string>
+    <string name="common_all">Semua</string>
     <string name="common_confirm">Konfirmasi</string>
     <string name="common_saved">Disimpan!</string>
     <string name="common_selected">Terpilih</string>

--- a/app/src/main/res/values-in/strings_library.xml
+++ b/app/src/main/res/values-in/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">terpilih</string>
     <string name="multi_selection_albums_selected_limit">Batas: %1$d album per pilihan.</string>
     <string name="multi_selection_albums_queue_hint">Antrekan + putar menghormati urutan pilihan Anda.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GENRE</string>
+    <string name="multi_selection_genres_selected">terpilih</string>
+    <string name="multi_selection_genres_queue_hint">Lakukan operasi batch pada semua lagu dalam genre ini.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Urutan Default</string>

--- a/app/src/main/res/values-in/strings_player.xml
+++ b/app/src/main/res/values-in/strings_player.xml
@@ -130,7 +130,7 @@
     <string name="lyrics_title">Lirik</string>
     <string name="lyrics_loading">Memuat lirik…</string>
     <string name="lyrics_mode_synced">Synced</string>
-    <string name="lyrics_mode_static">Biasa</string>
+    <string name="lyrics_mode_static">Statis</string>
     <string name="lyrics_options">Opsi lirik</string>
     <string name="lyrics_offset_minus_half">−.5</string>
     <string name="lyrics_offset_minus_point_one">−.1</string>
@@ -153,7 +153,7 @@
 
     <!-- LyricsMoreBottomSheet -->
     <string name="lyrics_save_title">Simpan Lirik</string>
-    <string name="lyrics_translate_via_ai">Terjemahkan lewat AI</string>
+    <string name="lyrics_translate_via_ai">Terjemahkan via AI</string>
     <string name="lyrics_translate_already_translated">Lirik ini sudah memiliki terjemahan</string>
     <string name="lyrics_translate_already_in_target_language">Lirik ini sudah dalam bahasa tersebut</string>
     <string name="lyrics_translate_api_not_configured">API belum dikonfigurasi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Errore</string>
     <string name="common_search">Cerca</string>
     <string name="common_clear_search">Cancella ricerca</string>
+    <string name="common_all">Tutti</string>
     <string name="common_confirm">Conferma</string>
     <string name="common_saved">Salvato!</string>
     <string name="common_selected">Selezionato</string>

--- a/app/src/main/res/values-it/strings_library.xml
+++ b/app/src/main/res/values-it/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">selezionati</string>
     <string name="multi_selection_albums_selected_limit">Limite: %1$d album per selezione.</string>
     <string name="multi_selection_albums_queue_hint">Coda + riproduzione rispetta l\'ordine della tua selezione.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GENERI</string>
+    <string name="multi_selection_genres_selected">selezionati</string>
+    <string name="multi_selection_genres_queue_hint">Esegui operazioni batch su tutti i brani all\'interno di questi generi.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Ordine predefinito</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">오류</string>
     <string name="common_search">검색</string>
     <string name="common_clear_search">검색 지우기</string>
+    <string name="common_all">전체</string>
     <string name="common_confirm">확인</string>
     <string name="common_saved">저장됨!</string>
     <string name="common_selected">선택됨</string>

--- a/app/src/main/res/values-ko/strings_library.xml
+++ b/app/src/main/res/values-ko/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">선택됨</string>
     <string name="multi_selection_albums_selected_limit">제한: 선택당 앨범 최대 %1$d개.</string>
     <string name="multi_selection_albums_queue_hint">대기열 추가 및 재생은 선택한 순서를 존중합니다.</string>
+    <string name="multi_selection_genres_count_upper">장르 %1$d개</string>
+    <string name="multi_selection_genres_selected">선택됨</string>
+    <string name="multi_selection_genres_queue_hint">이 장르에 속한 모든 곡에 대해 일괄 작업을 수행합니다.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">기본 정렬</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Feil</string>
     <string name="common_search">Søk</string>
     <string name="common_clear_search">Tøm søk</string>
+    <string name="common_all">Alle</string>
     <string name="common_confirm">Bekreft</string>
     <string name="common_saved">Lagret!</string>
     <string name="common_selected">Valgt</string>

--- a/app/src/main/res/values-nb/strings_library.xml
+++ b/app/src/main/res/values-nb/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">valgt</string>
     <string name="multi_selection_albums_selected_limit">Grense: %1$d album per valg.</string>
     <string name="multi_selection_albums_queue_hint">Kø og avspilling følger valgrekkefølgen din.</string>
+    <string name="multi_selection_genres_count_upper">%1$d SJANGERE</string>
+    <string name="multi_selection_genres_selected">valgt</string>
+    <string name="multi_selection_genres_queue_hint">Utfør gruppehandlinger på alle sanger i disse sjangerne.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Standardrekkefølge</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Ошибка</string>
     <string name="common_search">Поиск</string>
     <string name="common_clear_search">Очистить поиск</string>
+    <string name="common_all">Все</string>
     <string name="common_confirm">Подтвердить</string>
     <string name="common_saved">Сохранено!</string>
     <string name="common_selected">Выбрано</string>

--- a/app/src/main/res/values-ru/strings_library.xml
+++ b/app/src/main/res/values-ru/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">выбрано</string>
     <string name="multi_selection_albums_selected_limit">Лимит: %1$d альбомов за одно выделение.</string>
     <string name="multi_selection_albums_queue_hint">Очередь + воспроизведение сохраняют порядок вашего выбора.</string>
+    <string name="multi_selection_genres_count_upper">%1$d ЖАНРОВ</string>
+    <string name="multi_selection_genres_selected">выбрано</string>
+    <string name="multi_selection_genres_queue_hint">Выполняйте пакетные операции для всех треков в этих жанрах.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Порядок по умолчанию</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Hata</string>
     <string name="common_search">Ara</string>
     <string name="common_clear_search">Aramayı temizle</string>
+    <string name="common_all">Tümü</string>
     <string name="common_confirm">Onayla</string>
     <string name="common_saved">Kaydedildi!</string>
     <string name="common_selected">Seçildi</string>

--- a/app/src/main/res/values-tr/strings_library.xml
+++ b/app/src/main/res/values-tr/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">seçildi</string>
     <string name="multi_selection_albums_selected_limit">Sınır: seçim başına %1$d albüm.</string>
     <string name="multi_selection_albums_queue_hint">Kuyruğa ekle ve oynat, seçim sıranıza göre davranır.</string>
+    <string name="multi_selection_genres_count_upper">%1$d TÜR</string>
+    <string name="multi_selection_genres_selected">seçildi</string>
+    <string name="multi_selection_genres_queue_hint">Bu türlerdeki tüm şarkılarda toplu işlemler gerçekleştirin.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Varsayılan Sıralama</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">错误</string>
     <string name="common_search">搜索</string>
     <string name="common_clear_search">清除搜索</string>
+    <string name="common_all">全部</string>
     <string name="common_confirm">确认</string>
     <string name="common_saved">已保存！</string>
     <string name="common_selected">已选择</string>

--- a/app/src/main/res/values-zh-rCN/strings_library.xml
+++ b/app/src/main/res/values-zh-rCN/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">已选择</string>
     <string name="multi_selection_albums_selected_limit">限制：每次选择最多 %1$d 张专辑。</string>
     <string name="multi_selection_albums_queue_hint">加入队列及播放将遵循您的选择顺序。</string>
+    <string name="multi_selection_genres_count_upper">%1$d 个流派</string>
+    <string name="multi_selection_genres_selected">已选择</string>
+    <string name="multi_selection_genres_queue_hint">对这些流派中的所有歌曲进行批量操作。</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">默认顺序</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="common_error">Error</string>
     <string name="common_search">Search</string>
     <string name="common_clear_search">Clear search</string>
+    <string name="common_all">All</string>
     <string name="common_confirm">Confirm</string>
     <string name="common_saved">Saved!</string>
     <string name="common_selected">Selected</string>

--- a/app/src/main/res/values/strings_library.xml
+++ b/app/src/main/res/values/strings_library.xml
@@ -193,6 +193,9 @@
     <string name="multi_selection_albums_selected">selected</string>
     <string name="multi_selection_albums_selected_limit">Limit: %1$d albums per selection.</string>
     <string name="multi_selection_albums_queue_hint">Queue + play respects your selection order.</string>
+    <string name="multi_selection_genres_count_upper">%1$d GENRES</string>
+    <string name="multi_selection_genres_selected">selected</string>
+    <string name="multi_selection_genres_queue_hint">Perform batch operations on all songs within these genres.</string>
 
     <!-- Sort Option Display Names -->
     <string name="sort_display_default_order">Default Order</string>


### PR DESCRIPTION
## Summary
- Fix bug where translate lyrics via AI only works for online source lyrics. Fixed by introduced fallback checks in `LyricsStateHolder` to search for local files, embedded metadata, or database backups when the primary lyrics field is empty.
- Replaced hardcoded text in album and genre multi-selection bottom sheets, and the search screen filters with resource strings for localization.
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/39b41cde-a8f6-40d6-b5b7-21be7a74b220" />

- Redesign genre multi-selection bottom sheets to have same design as album mutli-selection for consistency.
<img width="190" height="200" alt="image" src="https://github.com/user-attachments/assets/e519bae2-e844-49e2-a850-ab109f31b5b2" />
<img width="190" height="200" alt="image" src="https://github.com/user-attachments/assets/971d2319-805d-4c2f-a7ad-f1508b4b7114" />

- Added corresponding translations across supported locales.

- Enhanced `ToggleSegmentButton` with `maxLines`, `overflow`, and `textAlign`, and `padding`properties to prevent text issues in `LyricsFloatingToolbar`.

Before
<img width="350" height="150" alt="image" src="https://github.com/user-attachments/assets/cd43b0ef-2b18-465f-a728-0b10dc6ad771" />

After
<img width="350" height="150" alt="image" src="https://github.com/user-attachments/assets/a79d34dd-4568-4e16-9972-c9787a799189" />
