### PR TITLE
fix(playlists): prevent lost playlist edits from concurrent song removals (#2391)

### DIFF
--- a/app/src/androidTest/java/com/theveloper/pixelplay/data/repository/PlaylistSongCountTest.kt
+++ b/app/src/androidTest/java/com/theveloper/pixelplay/data/repository/PlaylistSongCountTest.kt
@@ -1,0 +1,136 @@
+package com.theveloper.pixelplay.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.theveloper.pixelplay.data.database.LocalPlaylistDao
+import com.theveloper.pixelplay.data.database.PixelPlayDatabase
+import com.theveloper.pixelplay.data.preferences.PlaylistPreferencesRepository
+import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression test for issue #2391:
+ * "Playlist song count doesn't update when removing songs — only when adding."
+ *
+ * Exercises the real PlaylistPreferencesRepository against an in-memory Room DB to
+ * verify that the song count exposed by userPlaylistsFlow (used by the Playlists menu)
+ * reflects removals as well as additions.
+ */
+@RunWith(AndroidJUnit4::class)
+class PlaylistSongCountTest {
+
+    private lateinit var db: PixelPlayDatabase
+    private lateinit var dao: LocalPlaylistDao
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var repo: PlaylistPreferencesRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, PixelPlayDatabase::class.java)
+            .addCallback(PixelPlayDatabase.createRuntimeArtifactsCallback())
+            .allowMainThreadQueries()
+            .build()
+        dao = db.localPlaylistDao()
+        dataStore = PreferenceDataStoreFactory.create {
+            context.preferencesDataStoreFile("test_settings_${System.nanoTime()}")
+        }
+        val userPrefs = UserPreferencesRepository(dataStore, Json { ignoreUnknownKeys = true })
+        repo = PlaylistPreferencesRepository(dao, userPrefs)
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    private suspend fun countFor(playlistId: String): Int =
+        repo.userPlaylistsFlow.first().first { it.id == playlistId }.songIds.size
+
+    @Test
+    fun menuSongCount_reflectsAddAndRemove() = runTest {
+        val playlist = repo.createPlaylist(name = "J-Pop", songIds = listOf("10", "20", "30"))
+        assertEquals("initial count", 3, countFor(playlist.id))
+
+        // Remove a song — the bug report says this does NOT update the count.
+        repo.removeSongFromPlaylist(playlist.id, "20")
+        assertEquals("after removing one song", 2, countFor(playlist.id))
+
+        // Remove another.
+        repo.removeSongFromPlaylist(playlist.id, "30")
+        assertEquals("after removing a second song", 1, countFor(playlist.id))
+
+        // Adding works per the report — verify it still does.
+        repo.addSongsToPlaylist(playlist.id, listOf("40"))
+        assertEquals("after adding one song", 2, countFor(playlist.id))
+    }
+
+    /**
+     * Reproduces the real-world trigger for issue #2391: removing several songs in
+     * quick succession. Each edit does an unsynchronized read-modify-write
+     * (userPlaylistsFlow.first() -> modify -> updatePlaylist), so concurrent removals
+     * all read the same original list and the last writer wins, silently dropping the
+     * other removals. The Playlists-menu count (songIds.size) then stays stuck high.
+     */
+    @Test
+    fun concurrentRemovals_doNotLoseUpdates() = runBlocking {
+        val playlist = repo.createPlaylist(
+            name = "Race",
+            songIds = listOf("1", "2", "3", "4", "5")
+        )
+        assertEquals(5, countFor(playlist.id))
+
+        // Remove four songs concurrently — "remove one or two of them", fast.
+        coroutineScope {
+            listOf("1", "2", "3", "4").forEach { id ->
+                launch(Dispatchers.IO) { repo.removeSongFromPlaylist(playlist.id, id) }
+            }
+        }
+
+        assertEquals("All concurrent removals must persist", 1, countFor(playlist.id))
+    }
+
+    /**
+     * Walks the exact reproduction from issue #2391, asserting the fixed behaviour:
+     * the song count stays accurate after a quick removal of "one or two" songs, and
+     * a later addition does not preserve a phantom difference.
+     */
+    @Test
+    fun issue2391_quickRemoveThenAdd_keepsCountAccurate() = runBlocking {
+        // Steps 2-3: create a playlist and add a few songs.
+        val playlist = repo.createPlaylist(
+            name = "J-Pop",
+            songIds = listOf("1", "2", "3", "4", "5", "6")
+        )
+        assertEquals(6, countFor(playlist.id))
+
+        // Step 4: remove one or two of them — quickly, as fast taps do.
+        coroutineScope {
+            launch(Dispatchers.IO) { repo.removeSongFromPlaylist(playlist.id, "2") }
+            launch(Dispatchers.IO) { repo.removeSongFromPlaylist(playlist.id, "4") }
+        }
+        // Step 5: the menu count must reflect BOTH removals (the bug left it stuck high).
+        assertEquals("count after removing two songs", 4, countFor(playlist.id))
+
+        // Steps 6-7: adding more must not carry over a phantom difference.
+        repo.addSongsToPlaylist(playlist.id, listOf("7", "8"))
+        assertEquals("count after adding two songs", 6, countFor(playlist.id))
+    }
+}

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/PlaylistPreferencesRepository.kt
@@ -21,6 +21,11 @@ class PlaylistPreferencesRepository @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository
 ) {
     private val migrationMutex = Mutex()
+    // Serializes read-modify-write edits to playlists. Without this, concurrent edits
+    // (e.g. removing several songs in quick succession) each read the same snapshot via
+    // userPlaylistsFlow.first() and the last writer wins, silently dropping the other
+    // edits — which left the Playlists-menu song count stuck high. See issue #2391.
+    private val editMutex = Mutex()
     @Volatile
     private var migrationChecked = false
 
@@ -92,16 +97,26 @@ class PlaylistPreferencesRepository @Inject constructor(
     }
 
     suspend fun renamePlaylist(playlistId: String, newName: String) {
-        ensureMigratedIfNeeded()
-        val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
-        val updated = existing.copy(
-            name = newName,
-            lastModified = System.currentTimeMillis()
-        )
-        localPlaylistDao.upsertPlaylist(updated.toEntity())
+        editMutex.withLock {
+            ensureMigratedIfNeeded()
+            val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
+            val updated = existing.copy(
+                name = newName,
+                lastModified = System.currentTimeMillis()
+            )
+            localPlaylistDao.upsertPlaylist(updated.toEntity())
+        }
     }
 
     suspend fun updatePlaylist(playlist: Playlist) {
+        editMutex.withLock {
+            updatePlaylistLocked(playlist)
+        }
+    }
+
+    // Persists a playlist and its songs. Caller must hold [editMutex] so the
+    // surrounding read-modify-write stays atomic.
+    private suspend fun updatePlaylistLocked(playlist: Playlist) {
         ensureMigratedIfNeeded()
         val updated = playlist.copy(lastModified = System.currentTimeMillis())
         localPlaylistDao.upsertPlaylist(updated.toEntity())
@@ -109,10 +124,12 @@ class PlaylistPreferencesRepository @Inject constructor(
     }
 
     suspend fun addSongsToPlaylist(playlistId: String, songIdsToAdd: List<String>) {
-        ensureMigratedIfNeeded()
-        val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
-        val merged = (existing.songIds + songIdsToAdd).distinct()
-        updatePlaylist(existing.copy(songIds = merged))
+        editMutex.withLock {
+            ensureMigratedIfNeeded()
+            val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
+            val merged = (existing.songIds + songIdsToAdd).distinct()
+            updatePlaylistLocked(existing.copy(songIds = merged))
+        }
     }
 
     suspend fun addOrRemoveSongFromPlaylists(songId: String, playlistIds: List<String>): MutableList<String> {
@@ -137,15 +154,19 @@ class PlaylistPreferencesRepository @Inject constructor(
     }
 
     suspend fun removeSongFromPlaylist(playlistId: String, songIdToRemove: String) {
-        ensureMigratedIfNeeded()
-        val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
-        updatePlaylist(existing.copy(songIds = existing.songIds.filterNot { it == songIdToRemove }))
+        editMutex.withLock {
+            ensureMigratedIfNeeded()
+            val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
+            updatePlaylistLocked(existing.copy(songIds = existing.songIds.filterNot { it == songIdToRemove }))
+        }
     }
 
     suspend fun reorderSongsInPlaylist(playlistId: String, newSongOrderIds: List<String>) {
-        ensureMigratedIfNeeded()
-        val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
-        updatePlaylist(existing.copy(songIds = newSongOrderIds))
+        editMutex.withLock {
+            ensureMigratedIfNeeded()
+            val existing = userPlaylistsFlow.first().find { it.id == playlistId } ?: return
+            updatePlaylistLocked(existing.copy(songIds = newSongOrderIds))
+        }
     }
 
     suspend fun setPlaylistSongOrderMode(playlistId: String, modeValue: String) =
@@ -177,15 +198,17 @@ class PlaylistPreferencesRepository @Inject constructor(
     }
 
     suspend fun removeSongFromAllPlaylists(songId: String) {
-        ensureMigratedIfNeeded()
-        val playlists = userPlaylistsFlow.first()
-        playlists.forEach { playlist ->
-            if (songId in playlist.songIds) {
-                updatePlaylist(
-                    playlist.copy(
-                        songIds = playlist.songIds.filterNot { it == songId }
+        editMutex.withLock {
+            ensureMigratedIfNeeded()
+            val playlists = userPlaylistsFlow.first()
+            playlists.forEach { playlist ->
+                if (songId in playlist.songIds) {
+                    updatePlaylistLocked(
+                        playlist.copy(
+                            songIds = playlist.songIds.filterNot { it == songId }
+                        )
                     )
-                )
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Fixes #2391 — the per-playlist song count in the **Playlists** menu doesn't update when you *remove* songs, only when you *add* them, and the difference between the menu count and the in-playlist count persists.

## Root cause

The bug is **not** "count incremented on add but not decremented on remove" — a single removal works fine. The real cause is a **lost-update race**.

Every editor in `PlaylistPreferencesRepository` does an unsynchronized read-modify-write:

```
existing = userPlaylistsFlow.first()  ->  modify the list  ->  updatePlaylist(...)
```

Removing several songs in quick succession (the issue's "remove one or two") fires concurrent coroutines (one per tap, via `viewModelScope.launch`) that all read the **same** snapshot. The last writer wins and the other removals are silently dropped. The menu count (`songIds.size`, read straight from the DB) then stays stuck high, while the playlist detail screen still looks correct because it updates optimistically per tap. That's exactly the reported symptom — and why it only seemed to break on remove.

## Fix

Serialize the read-modify-write editors behind a coroutine `Mutex` so each edit reads and writes atomically: `addSongsToPlaylist`, `removeSongFromPlaylist`, `reorderSongsInPlaylist`, `renamePlaylist`, `removeSongFromAllPlaylists`, and `updatePlaylist`. A private `updatePlaylistLocked` avoids re-entrant locking, and `addOrRemoveSongFromPlaylists` stays unlocked and delegates to the now-atomic methods (no nesting / no deadlock).

It's a coroutine `Mutex` (suspends, never blocks a thread), and playlist edits are infrequent, so there's no perceptible cost.

## Tests

New instrumentation test `PlaylistSongCountTest` (in-memory Room + the real repository):

- `menuSongCount_reflectsAddAndRemove` — sequential add/remove stays correct.
- `concurrentRemovals_doNotLoseUpdates` — 4 concurrent removals all persist.
- `issue2391_quickRemoveThenAdd_keepsCountAccurate` — the issue's exact steps.

Verified on a physical device (Realme RMX2040, Android 11):

- **Before the fix:** `issue2391_quickRemoveThenAdd…` fails `expected:<4> but was:<5>` and `concurrentRemovals…` fails `expected:<1> but was:<4>`.
- **After the fix:** all three pass.

> Note: these are `androidTest` instrumentation tests, so they need a device/emulator and aren't executed by the current CI build job — they're for local/manual verification and to document the regression.
