### PR TITLE
Align artist parsing with conservative default delimiters

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="wear">
         <option name="selectionMode" value="DROPDOWN" />
         <DropdownSelection timestamp="2026-03-26T13:52:07.598927Z">
           <Target type="DEFAULT_BOOT">
@@ -13,7 +13,7 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="wear">
+      <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
         <DropdownSelection timestamp="2026-03-26T13:52:07.598927Z">
           <Target type="DEFAULT_BOOT">

--- a/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/database/MusicDao.kt
@@ -1653,6 +1653,7 @@ interface MusicDao {
             artist_id = :artistId,
             artists_json = :artistsJson,
             album_name = :album,
+            album_artist = :albumArtist,
             genre = :genre,
             track_number = :trackNumber,
             disc_number = :discNumber
@@ -1665,6 +1666,7 @@ interface MusicDao {
         artistId: Long,
         artistsJson: String?,
         album: String,
+        albumArtist: String?,
         genre: String?,
         trackNumber: Int,
         discNumber: Int?
@@ -1678,6 +1680,7 @@ interface MusicDao {
         artistId: Long,
         artistsJson: String?,
         album: String,
+        albumArtist: String?,
         genre: String?,
         trackNumber: Int,
         discNumber: Int?,
@@ -1695,6 +1698,7 @@ interface MusicDao {
             artistId = artistId,
             artistsJson = artistsJson,
             album = album,
+            albumArtist = albumArtist,
             genre = genre,
             trackNumber = trackNumber,
             discNumber = discNumber

--- a/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/gdrive/GDriveRepository.kt
@@ -16,6 +16,7 @@ import com.theveloper.pixelplay.data.database.SongEntity
 import com.theveloper.pixelplay.data.database.SourceType
 import com.theveloper.pixelplay.data.database.toSong
 import com.theveloper.pixelplay.data.model.Song
+import com.theveloper.pixelplay.data.stream.CloudMusicUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -526,14 +527,8 @@ class GDriveRepository @Inject constructor(
         )
     }
 
-    private fun parseArtistNames(rawArtist: String): List<String> {
-        if (rawArtist.isBlank()) return listOf("Unknown Artist")
-        val parsed = rawArtist.split(Regex("\\s*[,/&;+]\\s*"))
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .distinct()
-        return if (parsed.isEmpty()) listOf("Unknown Artist") else parsed
-    }
+    private fun parseArtistNames(rawArtist: String): List<String> =
+        CloudMusicUtils.parseArtistNames(rawArtist)
 
     private fun toUnifiedSongId(driveFileId: String): Long {
         return -(GDRIVE_SONG_ID_OFFSET + driveFileId.hashCode().toLong().absoluteValue)

--- a/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/media/SongMetadataEditor.kt
@@ -152,6 +152,7 @@ class SongMetadataEditor(
         title: String,
         artist: String,
         album: String,
+        albumArtist: String?,
         genre: String?,
         trackNumber: Int,
         discNumber: Int?
@@ -222,6 +223,7 @@ class SongMetadataEditor(
             artistId = primaryArtistId,
             artistsJson = artistsJson,
             album = album,
+            albumArtist = albumArtist,
             genre = genre,
             trackNumber = trackNumber,
             discNumber = discNumber,
@@ -525,6 +527,7 @@ class SongMetadataEditor(
                 title = newTitle,
                 artist = newArtist,
                 album = newAlbum,
+                albumArtist = newAlbumArtist,
                 genre = normalizedGenre,
                 trackNumber = newTrackNumber,
                 discNumber = newDiscNumber

--- a/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepository.kt
@@ -995,7 +995,11 @@ suspend fun markDirectoryRulesVersionApplied(version: Int) {
     // ─── Multi-artist settings ────────────────────────────────────────────────
 
     val artistDelimitersFlow: Flow<List<String>> =
-        pref { decodeJsonPref(it, PreferencesKeys.ARTIST_DELIMITERS, DEFAULT_ARTIST_DELIMITERS) }
+        pref {
+            normalizeLegacyDefaultArtistDelimiters(
+                decodeJsonPref(it, PreferencesKeys.ARTIST_DELIMITERS, DEFAULT_ARTIST_DELIMITERS)
+            )
+        }
 
     suspend fun setArtistDelimiters(delimiters: List<String>) {
         if (delimiters.isEmpty()) return
@@ -1347,7 +1351,9 @@ suspend fun markDirectoryRulesVersionApplied(version: Int) {
 
     companion object {
         /** Default character delimiters for splitting multi-artist tags. */
-        val DEFAULT_ARTIST_DELIMITERS = listOf("/", ";", ",", "+", "&")
+        val DEFAULT_ARTIST_DELIMITERS = listOf(";")
+
+        private val LEGACY_DEFAULT_ARTIST_DELIMITERS = listOf("/", ";", ",", "+", "&")
 
         /** Default word-based delimiters matched case-insensitively with whitespace boundaries. */
         val DEFAULT_ARTIST_WORD_DELIMITERS = listOf(
@@ -1359,6 +1365,9 @@ suspend fun markDirectoryRulesVersionApplied(version: Int) {
     }
 
     // ─── Private utilities ────────────────────────────────────────────────────
+
+    private fun normalizeLegacyDefaultArtistDelimiters(delimiters: List<String>): List<String> =
+        if (delimiters == LEGACY_DEFAULT_ARTIST_DELIMITERS) DEFAULT_ARTIST_DELIMITERS else delimiters
 
     /** Increments [value] by 1, wrapping back to 0 on overflow. */
     private fun incrementWrapped(value: Int?) =

--- a/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudMusicUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/stream/CloudMusicUtils.kt
@@ -1,5 +1,7 @@
 package com.theveloper.pixelplay.data.stream
 
+import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
+import com.theveloper.pixelplay.utils.splitArtistsByDelimiters
 import org.json.JSONObject
 
 /**
@@ -26,13 +28,13 @@ object CloudMusicUtils {
         return result
     }
 
-    /** Split a raw artist string like "A, B & C" into individual names. */
+    /** Split a raw artist string using the same conservative defaults as local library sync. */
     fun parseArtistNames(rawArtist: String): List<String> {
         if (rawArtist.isBlank()) return listOf("Unknown Artist")
-        val parsed = rawArtist.split(Regex("\\s*[,/&;+、]\\s*"))
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .distinct()
+        val parsed = rawArtist.splitArtistsByDelimiters(
+            delimiters = UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+            wordDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_WORD_DELIMITERS
+        )
         return if (parsed.isEmpty()) listOf("Unknown Artist") else parsed
     }
 }

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtils.kt
@@ -67,7 +67,9 @@ internal fun buildAlbumGroupingKeys(album: AlbumEntity): List<AlbumGroupingKey> 
 
 internal fun chooseAlbumDisplayArtist(
     songs: List<SongEntity>,
-    preferAlbumArtist: Boolean
+    preferAlbumArtist: Boolean,
+    artistDelimiters: List<String> = emptyList(),
+    wordDelimiters: List<String> = emptyList()
 ): String {
     if (songs.isEmpty()) return "Unknown Artist"
 
@@ -78,7 +80,13 @@ internal fun chooseAlbumDisplayArtist(
     )
     val trackArtist = mostCommonValue(
         songs.map { song ->
-            song.artistName.normalizeMetadataTextOrEmpty()
+            collectArtistNames(
+                rawArtistName = song.artistName,
+                title = song.title,
+                artistDelimiters = artistDelimiters,
+                wordDelimiters = wordDelimiters,
+                extractFromTitle = true
+            ).firstOrNull().normalizeMetadataTextOrEmpty()
         }
     )
 

--- a/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/worker/SyncWorker.kt
@@ -620,7 +620,9 @@ constructor(
              val representativeAlbumArt = songsInAlbum.firstNotNullOfOrNull { it.albumArtUriString }
              val determinedAlbumArtist = chooseAlbumDisplayArtist(
                  songs = songsInAlbum,
-                 preferAlbumArtist = groupByAlbumArtist
+                 preferAlbumArtist = groupByAlbumArtist,
+                 artistDelimiters = artistDelimiters,
+                 wordDelimiters = wordDelimiters
              )
              val determinedAlbumArtistId = resolveAlbumDisplayArtistId(
                  displayArtist = determinedAlbumArtist,

--- a/app/src/test/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepositoryTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/preferences/UserPreferencesRepositoryTest.kt
@@ -12,6 +12,34 @@ import java.nio.file.Files
 class UserPreferencesRepositoryTest {
 
     @Test
+    fun `default artist delimiters avoid common characters inside artist names`() {
+        assertEquals(listOf(";"), UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS)
+    }
+
+    @Test
+    fun `artistDelimitersFlow normalizes stored legacy defaults`() = runTest {
+        val tempDir = Files.createTempDirectory("user-preferences-repository-test")
+        try {
+            val repository = UserPreferencesRepository(
+                dataStore = PreferenceDataStoreFactory.create(
+                    scope = backgroundScope,
+                    produceFile = { tempDir.resolve("settings.preferences_pb").toFile() }
+                ),
+                json = Json
+            )
+
+            repository.setArtistDelimiters(listOf("/", ";", ",", "+", "&"))
+
+            assertEquals(
+                UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+                repository.artistDelimitersFlow.first()
+            )
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `clearPreferencesExceptKeys preserves initial setup completion`() = runTest {
         val tempDir = Files.createTempDirectory("user-preferences-repository-test")
         try {

--- a/app/src/test/java/com/theveloper/pixelplay/data/stream/CloudMusicUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/stream/CloudMusicUtilsTest.kt
@@ -1,0 +1,23 @@
+package com.theveloper.pixelplay.data.stream
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CloudMusicUtilsTest {
+
+    @Test
+    fun `parseArtistNames preserves common punctuation in artist names by default`() {
+        assertEquals(listOf("W&W"), CloudMusicUtils.parseArtistNames("W&W"))
+        assertEquals(listOf("AC/DC"), CloudMusicUtils.parseArtistNames("AC/DC"))
+        assertEquals(listOf("Lost & Found"), CloudMusicUtils.parseArtistNames("Lost & Found"))
+        assertEquals(listOf("Black Country, New Road"), CloudMusicUtils.parseArtistNames("Black Country, New Road"))
+    }
+
+    @Test
+    fun `parseArtistNames still splits explicit semicolon artists`() {
+        assertEquals(
+            listOf("Artist One", "Artist Two"),
+            CloudMusicUtils.parseArtistNames("Artist One; Artist Two")
+        )
+    }
+}

--- a/app/src/test/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/worker/AlbumGroupingUtilsTest.kt
@@ -114,6 +114,24 @@ class AlbumGroupingUtilsTest {
     }
 
     @Test
+    fun `chooseAlbumDisplayArtist uses primary parsed artist for feature-heavy albums`() {
+        val songs = listOf(
+            testSong(artistName = "Gorillaz feat. Stevie Nicks", albumArtist = null),
+            testSong(artistName = "Gorillaz feat. Thundercat", albumArtist = null),
+            testSong(artistName = "Gorillaz feat. Tame Impala", albumArtist = null)
+        )
+
+        val displayArtist = chooseAlbumDisplayArtist(
+            songs = songs,
+            preferAlbumArtist = false,
+            artistDelimiters = listOf(";"),
+            wordDelimiters = listOf("feat.")
+        )
+
+        assertThat(displayArtist).isEqualTo("Gorillaz")
+    }
+
+    @Test
     fun `chooseAlbumDisplayArtist prefers album artist when grouping is on`() {
         val songs = listOf(
             testSong(artistName = "The Weeknd", albumArtist = "The Weeknd & Justice"),

--- a/app/src/test/java/com/theveloper/pixelplay/data/worker/ArtistParsingUtilsTest.kt
+++ b/app/src/test/java/com/theveloper/pixelplay/data/worker/ArtistParsingUtilsTest.kt
@@ -2,8 +2,49 @@ package com.theveloper.pixelplay.data.worker
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import com.theveloper.pixelplay.data.preferences.UserPreferencesRepository
 
 class ArtistParsingUtilsTest {
+
+    @Test
+    fun `default delimiters preserve ampersand slash comma and plus inside artist names`() {
+        assertEquals(
+            listOf("W&W"),
+            collectArtistNames(
+                rawArtistName = "W&W",
+                title = "Rave Culture",
+                artistDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+                wordDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_WORD_DELIMITERS
+            )
+        )
+        assertEquals(
+            listOf("AC/DC"),
+            collectArtistNames(
+                rawArtistName = "AC/DC",
+                title = "Back In Black",
+                artistDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+                wordDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_WORD_DELIMITERS
+            )
+        )
+        assertEquals(
+            listOf("Lost & Found"),
+            collectArtistNames(
+                rawArtistName = "Lost & Found",
+                title = "Found",
+                artistDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+                wordDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_WORD_DELIMITERS
+            )
+        )
+        assertEquals(
+            listOf("Black Country, New Road"),
+            collectArtistNames(
+                rawArtistName = "Black Country, New Road",
+                title = "Track X",
+                artistDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_DELIMITERS,
+                wordDelimiters = UserPreferencesRepository.DEFAULT_ARTIST_WORD_DELIMITERS
+            )
+        )
+    }
 
     @Test
     fun `choosePreferredArtistName prefers media store when it contains more artists`() {


### PR DESCRIPTION
## Summary
- Narrow the default artist delimiter set to avoid splitting common punctuation inside artist names.
- Normalize stored legacy delimiter preferences to the new default on read.
- Reuse the same delimiter logic across cloud imports, album grouping, and metadata updates so display artist selection stays consistent.
- Add tests covering preserved artist names, legacy preference migration, and feature-heavy album display selection.

## Fixed Issues
- Fixes #2408
- Fixes #2409
- Fixes #2365
- Fixes #2366

## Related Reports
- Related to #1823, #1024, #974, #1057, #1468, #668

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :app:testDebugUnitTest --tests 'com.theveloper.pixelplay.data.worker.ArtistParsingUtilsTest' --tests 'com.theveloper.pixelplay.data.worker.AlbumGroupingUtilsTest' --tests 'com.theveloper.pixelplay.data.preferences.UserPreferencesRepositoryTest' --tests 'com.theveloper.pixelplay.data.stream.CloudMusicUtilsTest'`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk PATH=/usr/lib/jvm/java-21-openjdk/bin:$PATH ./gradlew :app:assembleDebug :app:installDebug`
- Launched `com.theveloper.pixelplay.debug` on attached SM-S928B via adb; process stayed running and logcat showed no `FATAL EXCEPTION` / `AndroidRuntime` crash.