### PR TITLE
fix: NetEase source tagging + lossless quality, and lyrics-card extended Unicode glyphs

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/netease/NeteaseRepository.kt
@@ -13,7 +13,10 @@ import com.theveloper.pixelplay.data.database.NeteasePlaylistEntity
 import com.theveloper.pixelplay.data.database.NeteaseSongEntity
 import com.theveloper.pixelplay.data.database.SongArtistCrossRef
 import com.theveloper.pixelplay.data.database.SongEntity
+import com.theveloper.pixelplay.data.database.SourceType
+import com.theveloper.pixelplay.data.database.serializeArtistRefs
 import com.theveloper.pixelplay.data.database.toSong
+import com.theveloper.pixelplay.data.model.ArtistRef
 import com.theveloper.pixelplay.data.model.Song
 import com.theveloper.pixelplay.data.network.netease.NeteaseApiService
 import com.theveloper.pixelplay.data.preferences.PlaylistPreferencesRepository
@@ -486,7 +489,7 @@ class NeteaseRepository @Inject constructor(
 
     // ─── Song URL Resolution ───────────────────────────────────────────
 
-    suspend fun getSongUrl(songId: Long, quality: String = "exhigh"): Result<String> {
+    suspend fun getSongUrl(songId: Long, quality: String = "lossless"): Result<String> {
         val now = System.currentTimeMillis()
         val lastAttempt = lastSongUrlAttemptAtMs[songId]
         if (lastAttempt != null && now - lastAttempt < songUrlRequestCooldownMs) {
@@ -507,7 +510,9 @@ class NeteaseRepository @Inject constructor(
 
         val result = withContext(Dispatchers.IO) {
             runCatching {
-                val qualityFallbacks = linkedSetOf(quality, "higher", "standard")
+                // Try the requested level first (e.g. "lossless" for SVIP accounts),
+                // then degrade gracefully so non-privileged accounts still resolve a URL.
+                val qualityFallbacks = linkedSetOf(quality, "exhigh", "higher", "standard")
                 var lastFailure: String? = null
 
                 for (level in qualityFallbacks) {
@@ -685,6 +690,14 @@ class NeteaseRepository @Inject constructor(
                 )
             }
 
+            val neteaseArtistRefs = artistNames.mapIndexed { index, artistName ->
+                ArtistRef(
+                    id = toUnifiedArtistId(artistName),
+                    name = artistName,
+                    isPrimary = index == 0
+                )
+            }
+
             val albumId = toUnifiedAlbumId(neteaseSong.albumId, neteaseSong.album)
             val albumName = neteaseSong.album.ifBlank { "Unknown Album" }
             albums.putIfAbsent(
@@ -725,7 +738,9 @@ class NeteaseRepository @Inject constructor(
                     bitrate = neteaseSong.bitrate,
                     sampleRate = null,
                     telegramChatId = null,
-                    telegramFileId = null
+                    telegramFileId = null,
+                    artistsJson = serializeArtistRefs(neteaseArtistRefs),
+                    sourceType = SourceType.NETEASE
                 )
             )
         }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -956,7 +956,10 @@ fun FullPlayerContent(
             onDismissLyricsSearch = { playerViewModel.resetLyricsSearchState() },
             lyricsSyncOffset = lyricsSyncOffset,
             onLyricsSyncOffsetChange = { currentSong?.id?.let { songId -> playerViewModel.setLyricsSyncOffset(songId, it) } },
-            lyricsTextStyle = MaterialTheme.typography.titleLarge,
+            // Use the platform default font (fontFamily = null) for lyrics so extended
+            // Unicode glyphs (e.g. Icelandic æ ð þ) render instead of tofu. The bundled
+            // Google Sans Rounded variable font drops these codepoints at runtime. (#2427)
+            lyricsTextStyle = MaterialTheme.typography.titleLarge.copy(fontFamily = null),
             colorScheme = LocalMaterialTheme.current,
             onBackClick = { showLyricsSheet = false },
             onSaveLyricsToFile = playerViewModel::saveLyricsToFile,


### PR DESCRIPTION
Combined fix for two unrelated bugs.

## #2431 — NetEase Cloud Music sync

**Songs miscategorized as local + broken playlist/cleanup sync.** `NeteaseRepository.syncUnifiedLibrarySongsFromNetease()` built its `SongEntity` rows without `sourceType`, so they defaulted to `SourceType.LOCAL` (0). Consequences:

- NetEase tracks surfaced in the **local** media library (the local/cloud split keys on `source_type`).
- The incremental-sync deletion diff was a permanent no-op, because `getAllNeteaseSongIds()` filters `source_type = 2` and the repo rows were `0` — so playlists never reconciled.
- Logout cleanup (`clearAllNeteaseSongs()`) deleted nothing for the same reason.

Every other source repo (Navidrome / GDrive / QQ / Jellyfin) sets `sourceType`, and the `SyncWorker` NetEase path already set both `sourceType` and `artistsJson`; only this repository copy omitted them. Now fixed to match.

**Quality capped despite SVIP.** `getSongUrl()` defaulted to `"exhigh"` with a fallback set of `higher/standard` — no lossless tier was ever requested, so SVIP accounts could not get FLAC. The API already maps `level=lossless` → `encodeType=flac`. Default is now `"lossless"` with a graceful fallback chain `lossless → exhigh → higher → standard`, so non-privileged accounts still resolve a URL.

## #2427 — Extended Unicode glyphs missing in Lyrics Card

Glyphs like Icelandic `æ`, `ð`, `þ` rendered as tofu (□) in the lyrics card. The lyrics text used the bundled Google Sans Rounded variable font, which drops those codepoints at runtime. The lyrics text style now uses the platform default font (`fontFamily = null`), which has full Latin Extended coverage.

> Trade-off: lyrics now render in the system font rather than Google Sans Rounded. A multi-entry `FontFamily` does **not** fix this — Compose resolves one font per weight and has no per-glyph fall-through within a family; platform-level fallback is the reliable path.

## Verification

- `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL.
- NetEase lossless delivery and the on-device glyph rendering still want a real SVIP account / affected device to confirm end-to-end; the code paths and the `level=lossless → flac` API mapping are verified statically.

## Follow-up (not in this PR)

`NeteaseRepository.syncUnifiedLibrarySongsFromNetease()` and the NetEase block in `SyncWorker` duplicate the song→entity mapping and had drifted — that drift is what caused the #2431 miscategorization. Worth consolidating into one shared mapper so they cannot diverge again.

Closes #2431
Closes #2427