### PR TITLE
fix: preserve scroll position when returning to library tabs

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryMediaTabs.kt
@@ -92,7 +92,9 @@ fun LibraryAlbumsTab(
     onAlbumLongPress: (Album) -> Unit = {},
     onAlbumSelectionToggle: (Album) -> Unit = {},
     getSelectionIndex: (Long) -> Int? = { null },
-    storageFilter: StorageFilter = StorageFilter.ALL
+    storageFilter: StorageFilter = StorageFilter.ALL,
+    listState: androidx.compose.foundation.lazy.LazyListState = androidx.compose.foundation.lazy.rememberLazyListState(),
+    gridState: androidx.compose.foundation.lazy.grid.LazyGridState = androidx.compose.foundation.lazy.grid.rememberLazyGridState()
 ) {
     val hasCurrentSong by remember(playerViewModel) {
         playerViewModel.stablePlayerState
@@ -100,10 +102,8 @@ fun LibraryAlbumsTab(
             .distinctUntilChanged()
     }.collectAsStateWithLifecycle(initialValue = false)
 
-    val gridState = rememberLazyGridState()
-    val listState = rememberLazyListState()
-    val dummyListState = rememberLazyListState()
-    val dummyGridState = rememberLazyGridState()
+    val dummyListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val dummyGridState = androidx.compose.foundation.lazy.grid.rememberLazyGridState()
     val context = LocalContext.current
     val imageLoader = context.imageLoader
 
@@ -481,7 +481,8 @@ fun LibraryArtistsTab(
     onArtistClick: (Long) -> Unit,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
-    storageFilter: StorageFilter = StorageFilter.ALL
+    storageFilter: StorageFilter = StorageFilter.ALL,
+    listState: androidx.compose.foundation.lazy.LazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
 ) {
     val hasCurrentSong by remember(playerViewModel) {
         playerViewModel.stablePlayerState
@@ -489,8 +490,7 @@ fun LibraryArtistsTab(
             .distinctUntilChanged()
     }.collectAsStateWithLifecycle(initialValue = false)
 
-    val listState = rememberLazyListState()
-    val dummyListState = rememberLazyListState()
+    val dummyListState = androidx.compose.foundation.lazy.rememberLazyListState()
     val artistFastScrollLabelProvider = remember(artists, currentArtistSortOption) {
         { index: Int ->
             artistFastScrollLabel(

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibraryScreen.kt
@@ -438,6 +438,10 @@ fun LibraryScreen(
     songInfoBottomSheetViewModel: SongInfoBottomSheetViewModel = hiltViewModel()
 ) {
     // La recolección de estados de alto nivel se mantiene mínima.
+    val albumsListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val albumsGridState = androidx.compose.foundation.lazy.grid.rememberLazyGridState()
+    val songsListState = androidx.compose.foundation.lazy.rememberLazyListState()
+    val artistsListState = androidx.compose.foundation.lazy.rememberLazyListState()
     val context = LocalContext.current // Added context
     val haptic = LocalHapticFeedback.current
     val lastTabIndex by playerViewModel.lastLibraryTabIndexFlow.collectAsStateWithLifecycle()
@@ -1533,7 +1537,8 @@ fun LibraryScreen(
                                             onRegisterLocateCurrentSongAction = { songsLocateAction = it },
                                             sortOption = playerUiState.currentSongSortOption,
                                             storageFilter = playerUiState.currentStorageFilter,
-                                            hasCurrentSong = hasCurrentSong
+                                            hasCurrentSong = hasCurrentSong,
+                                            listState = songsListState
                                         )
                                     }
                                     LibraryTabId.ALBUMS -> {
@@ -1563,7 +1568,9 @@ fun LibraryScreen(
                                             onAlbumLongPress = onAlbumLongPress,
                                             onAlbumSelectionToggle = onAlbumSelectionToggle,
                                             getSelectionIndex = getAlbumSelectionIndex,
-                                            storageFilter = playerUiState.currentStorageFilter
+                                            storageFilter = playerUiState.currentStorageFilter,
+                                            listState = albumsListState,
+                                            gridState = albumsGridState
                                         )
                                     }
 
@@ -1585,7 +1592,8 @@ fun LibraryScreen(
                                             },
                                             isRefreshing = isRefreshing,
                                             onRefresh = onRefresh,
-                                            storageFilter = playerUiState.currentStorageFilter
+                                            storageFilter = playerUiState.currentStorageFilter,
+                                            listState = artistsListState
                                         )
                                     }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/LibrarySongsTab.kt
@@ -79,10 +79,10 @@ fun LibrarySongsTab(
     onLocateCurrentSongVisibilityChanged: (Boolean) -> Unit = {},
     onRegisterLocateCurrentSongAction: ((() -> Unit)?) -> Unit = {},
     storageFilter: StorageFilter = StorageFilter.ALL,
-    hasCurrentSong: Boolean = false
+    hasCurrentSong: Boolean = false,
+    listState: androidx.compose.foundation.lazy.LazyListState = androidx.compose.foundation.lazy.rememberLazyListState()
 ) {
-    val listState = rememberLazyListState()
-    val dummyListState = rememberLazyListState()
+    val dummyListState = androidx.compose.foundation.lazy.rememberLazyListState()
     val pullToRefreshState = rememberPullToRefreshState()
     val coroutineScope = rememberCoroutineScope()
     val visibilityCallback by rememberUpdatedState(onLocateCurrentSongVisibilityChanged)


### PR DESCRIPTION
## Overview
This fixes an annoying UX issue where navigating away from a library tab (like clicking on an album in the Albums tab) and then pressing back would jump you all the way back to the top of the list.
  
## What changed
I moved the scroll states (`LazyListState` and `LazyGridState`) out of the individual tabs (Albums, Artists, Songs) and hoisted them up to the parent `LibraryScreen`.

Previously, because the scroll states lived inside the tab composables themselves, they were getting wiped out whenever the Navigation system or the HorizontalPager had to recreate the view upon returning. By holding the states at the `LibraryScreen` level, the screen's saveable state registry can properly hold onto them while we navigate back and forth.

## How to test
1. Open the app and go to the Albums tab.
2. Scroll down a bit and click on any album to open its details.
3. Press back. You should be exactly where you left off instead of at the top.