### PR TITLE
Add MIT attribution compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 This project is licensed under a Proprietary License - see the [LICENSE](LICENSE) file for details.
 
+Portions contributed before 2026-05-12 remain available under the MIT License; see [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+
 ---
 
 <p align="center">

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,75 @@
+# Third-Party Notices
+
+Portions of this software were originally contributed under the MIT License prior to 2026-05-12. Those contributions remain licensed under the MIT License, and the notice below is preserved as required.
+
+## MIT License
+
+Copyright (c) 2024-2026 Theo Vilardo and PixelPlayer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Contributors
+
+The following contributor names were generated from the Git history through `ceec1bb9^`, with obvious aliases consolidated and automated accounts omitted:
+
+- Theo Vilardo
+- lostf1sh
+- Dhruv Varia
+- serein-213
+- adlifarizi
+- rebornloki-dev
+- Amonoman
+- Dae Euhwa
+- BeanVortex
+- Colby Cabrera
+- VoidX3D
+- Ayaan Hussain
+- imoyy
+- starry-shivam
+- Sjoerd Vermeulen
+- Clyde Ho
+- Claudio Gratton
+- Mazen Natour
+- Dexter Reed
+- Kainoa Kanter
+- Ravishanker
+- Silke pilon
+- lijinkang
+- raplivx
+- Luis Vervaet
+- Sincere-Bhattarai
+- faraz152
+- mirkiv
+- AJ
+- Héctor Luis
+- Jakob Moen Bekken
+- Jared Stemper
+- Jean-Baptiste
+- Linus
+- OpenSource Guy
+- Rahul Sharma
+- Rishit
+- Ryan
+- T. Stark
+- Zeus-990
+- chen
+- danZiKr1
+- jair1c
+- ori
+- Неважно

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,14 +1,42 @@
 import java.io.File
 import java.util.Properties
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.aboutlibraries)
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.dagger.hilt.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.baselineprofile)
     id("kotlin-parcelize")
+}
+
+abstract class CopyThirdPartyNotices : DefaultTask() {
+    @get:InputFile
+    abstract val sourceFile: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    @get:Inject
+    abstract val fileSystemOperations: FileSystemOperations
+
+    @TaskAction
+    fun copyNotice() {
+        fileSystemOperations.copy {
+            from(sourceFile)
+            into(outputDirectory)
+        }
+    }
 }
 
 // Load keystore properties early to avoid unresolved references inside the android block
@@ -33,6 +61,12 @@ val enableAbiSplits = providers.gradleProperty("pixelplay.enableAbiSplits")
 val enableComposeCompilerReports = providers.gradleProperty("pixelplay.enableComposeCompilerReports")
     .getOrElse("false")
     .toBoolean()
+
+val generatedNoticesAssets = layout.buildDirectory.dir("generated/assets/thirdPartyNotices")
+val copyThirdPartyNotices = tasks.register<CopyThirdPartyNotices>("copyThirdPartyNotices") {
+    sourceFile.set(rootProject.layout.projectDirectory.file("THIRD_PARTY_NOTICES.md"))
+    outputDirectory.set(generatedNoticesAssets)
+}
 
 @Suppress("DEPRECATION")
 android {
@@ -157,6 +191,15 @@ android {
     }
 }
 
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.sources.assets?.addGeneratedSourceDirectory(
+            copyThirdPartyNotices,
+            CopyThirdPartyNotices::outputDirectory,
+        )
+    }
+}
+
 composeCompiler {
     // StrongSkipping is now enabled by default.
 }
@@ -220,6 +263,8 @@ dependencies {
     implementation(libs.androidx.ui.text.google.fonts)
     implementation(libs.material)
     implementation(libs.androidx.appcompat)
+    implementation(libs.aboutlibraries.core)
+    implementation(libs.aboutlibraries.compose.m3)
 
     // DI & Navigation
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/MainActivity.kt
@@ -632,6 +632,7 @@ class MainActivity : ComponentActivity() {
                 Screen.DJSpace.route,
                 Screen.NavBarCrRad.route,
                 Screen.About.route,
+                Screen.OpenSourceLicenses.route,
                 Screen.Stats.route,
                 Screen.EditTransition.route,
                 Screen.Experimental.route,

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/AppNavigation.kt
@@ -51,6 +51,7 @@ import com.theveloper.pixelplay.presentation.screens.PlaylistDetailScreen
 import com.theveloper.pixelplay.presentation.screens.RecentlyPlayedScreen
 
 import com.theveloper.pixelplay.presentation.screens.AboutScreen
+import com.theveloper.pixelplay.presentation.screens.OpenSourceLicensesScreen
 import com.theveloper.pixelplay.presentation.screens.SearchScreen
 import com.theveloper.pixelplay.presentation.screens.StatsScreen
 import com.theveloper.pixelplay.presentation.screens.SettingsScreen
@@ -404,6 +405,15 @@ fun AppNavigation(
                         navController = navController,
                         viewModel = playerViewModel,
                         onNavigationIconClick = { navController.popBackStack() }
+                    )
+                }
+            }
+            composable(
+                Screen.OpenSourceLicenses.route,
+            ) {
+                ScreenWrapper(navController = navController, playerViewModel = playerViewModel, animatedVisibilityScope = this) {
+                    OpenSourceLicensesScreen(
+                        onBackClick = { navController.popBackStack() },
                     )
                 }
             }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/navigation/Screen.kt
@@ -43,6 +43,7 @@ sealed class Screen(val route: String) {
     }
 
     object About : Screen("about")
+    object OpenSourceLicenses : Screen("open_source_licenses")
     object EasterEgg : Screen("easter_egg")
 
     object ArtistSettings : Screen("artist_settings")

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/AboutScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Gavel
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material3.CircularProgressIndicator
@@ -420,6 +422,25 @@ fun AboutScreen(
                 )
             }
 
+            item(key = "licenses_title") {
+                AboutSectionHeader(
+                    title = stringResource(R.string.about_licenses_title),
+                    subtitle = stringResource(R.string.about_licenses_subtitle),
+                    modifier = Modifier.padding(top = 24.dp),
+                )
+            }
+
+            item(key = "open_source_licenses") {
+                OpenSourceLicensesCard(
+                    onClick = {
+                        navController.navigateSafely(Screen.OpenSourceLicenses.route)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                )
+            }
+
             item(key = "contributors_title") {
                 AboutSectionHeader(
                     title = stringResource(R.string.about_contributors_section_title),
@@ -488,6 +509,55 @@ fun AboutScreen(
             expandedTitleStartPadding = 20.dp,
             collapsedTitleStartPadding = 68.dp
         )
+    }
+}
+
+@Composable
+private fun OpenSourceLicensesCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        onClick = onClick,
+        modifier = modifier,
+        shape = expressiveListShape(index = 0, count = 1),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 2.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Gavel,
+                    contentDescription = null,
+                    modifier = Modifier.padding(10.dp).size(22.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+            Spacer(modifier = Modifier.width(14.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.about_open_source_licenses),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringResource(R.string.about_open_source_licenses_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.Rounded.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/screens/OpenSourceLicensesScreen.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/screens/OpenSourceLicensesScreen.kt
@@ -1,0 +1,142 @@
+package com.theveloper.pixelplay.presentation.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
+import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
+import com.theveloper.pixelplay.R
+import com.theveloper.pixelplay.presentation.components.MiniPlayerHeight
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OpenSourceLicensesScreen(
+    onBackClick: () -> Unit,
+) {
+    val libraries by produceLibraries(R.raw.aboutlibraries)
+    var showThirdPartyNotices by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.open_source_licenses_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                            contentDescription = stringResource(R.string.common_back),
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { showThirdPartyNotices = true }) {
+                        Text(stringResource(R.string.third_party_notices_action))
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        LibrariesContainer(
+            libraries = libraries,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                top = contentPadding.calculateTopPadding(),
+                bottom = contentPadding.calculateBottomPadding() + MiniPlayerHeight,
+            ),
+        )
+    }
+
+    if (showThirdPartyNotices) {
+        ThirdPartyNoticesDialog(
+            onDismissRequest = { showThirdPartyNotices = false },
+        )
+    }
+}
+
+@Composable
+private fun ThirdPartyNoticesDialog(
+    onDismissRequest: () -> Unit,
+) {
+    val context = LocalContext.current
+    val loadError = stringResource(R.string.third_party_notices_load_error)
+    val noticeText = remember(context, loadError) {
+        runCatching {
+            context.assets.open("THIRD_PARTY_NOTICES.md")
+                .bufferedReader()
+                .use { it.readText() }
+        }.getOrElse { loadError }
+    }
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(20.dp),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp,
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 20.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.third_party_notices_title),
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                    TextButton(onClick = onDismissRequest) {
+                        Text(stringResource(R.string.third_party_notices_close))
+                    }
+                }
+                HorizontalDivider()
+                SelectionContainer {
+                    Text(
+                        text = noticeText,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(20.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@raw/aboutlibraries" />

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -630,6 +630,15 @@
     <string name="about_maintainer_subtitle">The person behind PixelPlayer.</string>
     <string name="about_spotlight_title">Community spotlight</string>
     <string name="about_spotlight_subtitle">Recognition for collaborators with major impact.</string>
+    <string name="about_licenses_title">Licenses and notices</string>
+    <string name="about_licenses_subtitle">Attribution for dependencies and earlier contributions.</string>
+    <string name="about_open_source_licenses">Open source licenses</string>
+    <string name="about_open_source_licenses_subtitle">Dependency licenses and third-party notices</string>
+    <string name="open_source_licenses_screen_title">Open source licenses</string>
+    <string name="third_party_notices_action">MIT-era notice</string>
+    <string name="third_party_notices_title">Third-party notices</string>
+    <string name="third_party_notices_close">Close</string>
+    <string name="third_party_notices_load_error">The bundled third-party notice could not be loaded.</string>
     <string name="about_contributors_section_title">Open source contributors</string>
     <string name="about_contributors_section_subtitle">Live contributor list from GitHub.</string>
     <string name="about_contributions_format">%1$d contrib.</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.aboutlibraries) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp) apply false
@@ -18,4 +19,3 @@ allprojects {
         }
     }
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 accompanistDrawablepainter = "0.37.3"
+aboutLibraries = "15.0.3"
 agp = "9.2.1"
 app = "1.7.0"
 googleGenai = "1.58.0"
@@ -111,6 +112,8 @@ playServicesWearable = "20.0.1"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
+aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "aboutLibraries" }
+aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
 
 lifecycleprocess = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 junitplatformlauncher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitJupiter" }
@@ -273,6 +276,7 @@ apache-httpclient = { module = "org.apache.httpcomponents:httpclient", version.r
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin.android", version.ref = "aboutLibraries" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin"}
 


### PR DESCRIPTION
## Summary

- preserve the MIT-era copyright and permission notice with a deduplicated historical contributor list
- bundle THIRD_PARTY_NOTICES.md into APK assets through a generated Gradle source directory
- add AboutLibraries dependency-license metadata and an in-app licenses/notices screen
- clarify the pre-2026-05-12 MIT status in README without changing LICENSE

## Verification

- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:assembleDebug
- verified the built APK contains assets/THIRD_PARTY_NOTICES.md and res/raw/aboutlibraries.json
- installed the arm64 debug APK successfully on a physical SM-S928B