### PR TITLE
fix: lyrics translation cutoff, CJK matching, and UI

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/data/repository/LyricsRepositoryImpl.kt
@@ -527,6 +527,15 @@ class LyricsRepositoryImpl @Inject constructor(
                         })
                     }
                 }
+                // Romanized search strategy for non-Latin artists
+                if (MultiLangRomanizer.isScriptThatNeedsRomanization(cleanArtist)) {
+                    val romanArtist = romanizeForMatch(cleanArtist)
+                    if (romanArtist != cleanArtist) {
+                        add(RemoteSearchStrategy("romanized_artist") {
+                            lrcLibApiService.searchLyrics(trackName = cleanTitle, artistName = romanArtist)
+                        })
+                    }
+                }
                 
                 // Smart title cleanup strategy (removes leading digits/spaces and truncates at -, (, ))
                 val smartTitle = cleanTitleSmart(cleanTitle)
@@ -581,14 +590,19 @@ class LyricsRepositoryImpl @Inject constructor(
                         
                         // Save to database
                         try {
-                            lyricsDao.insert(
-                                com.theveloper.pixelplay.data.database.LyricsEntity(
-                                    songId = song.id.toLong(),
-                                    content = rawLyrics,
-                                    isSynced = !bestMatch.syncedLyrics.isNullOrBlank(),
-                                    source = "remote"
+                            val songIdLong = song.id.toLongOrNull()
+                            if (songIdLong == null) {
+                                Log.w(TAG, "Cannot persist lyrics to DB: non-numeric Song.id '${song.id}'")
+                            } else {
+                                lyricsDao.insert(
+                                    com.theveloper.pixelplay.data.database.LyricsEntity(
+                                        songId = songIdLong,
+                                        content = rawLyrics,
+                                        isSynced = !bestMatch.syncedLyrics.isNullOrBlank(),
+                                        source = "remote"
+                                    )
                                 )
-                            )
+                            }
                         } catch (e: NumberFormatException) {
                             Log.w(TAG, "Skipping database save for non-numeric song ID: ${song.id} (possible streaming or external source). Lyrics will be cached in JSON.")
                         }
@@ -1014,8 +1028,8 @@ class LyricsRepositoryImpl @Inject constructor(
                     }
                 }
 
-                val cleanArtist = song.displayArtist.replace(Regex("[^a-zA-Z0-9]"), "_")
-                val cleanTitle = song.title.replace(Regex("[^a-zA-Z0-9]"), "_")
+                val cleanArtist = song.displayArtist.replace(Regex("[^\\p{L}\\p{N}]"), "_")
+                val cleanTitle = song.title.replace(Regex("[^\\p{L}\\p{N}]"), "_")
 
                 for (extension in LyricsImportSecurity.supportedFileExtensions()) {
                     val alternativeLyricsFile = File(directory, "${cleanArtist}_${cleanTitle}.$extension")
@@ -1056,7 +1070,14 @@ class LyricsRepositoryImpl @Inject constructor(
 
             val lyricsData = LyricsData(
                 plainLyrics = lyrics.plain?.joinToString("\n"),
-                syncedLyrics = lyrics.synced?.joinToString("\n") { "[${formatTimestamp(it.time)}]${it.line}" },
+                syncedLyrics = lyrics.synced?.joinToString("\n") { line ->
+                    buildString {
+                        append("[${formatTimestamp(line.time)}]${line.line}")
+                        if (!line.translation.isNullOrBlank()) {
+                            append("\n[${formatTimestamp(line.time)}]${line.translation}")
+                        }
+                    }
+                },
                 wordByWordLyrics = wordByWordLyrics
             )
 
@@ -1247,7 +1268,12 @@ class LyricsRepositoryImpl @Inject constructor(
                 toWordByWordLrc(syncedLyrics)
             } else {
                 syncedLyrics.joinToString("\n") { line ->
-                    "[${formatTimestamp(line.time)}]${line.line}"
+                    buildString {
+                        append("[${formatTimestamp(line.time)}]${line.line}")
+                        if (!line.translation.isNullOrBlank()) {
+                            append("\n[${formatTimestamp(line.time)}]${line.translation}")
+                        }
+                    }
                 }
             }
         }
@@ -1293,14 +1319,19 @@ class LyricsRepositoryImpl @Inject constructor(
                     val rawLyricsToSave = best.rawLyrics
 
                     try {
-                        lyricsDao.insert(
-                             com.theveloper.pixelplay.data.database.LyricsEntity(
-                                 songId = song.id.toLong(),
-                                 content = rawLyricsToSave,
-                                 isSynced = !best.lyrics.synced.isNullOrEmpty(),
-                                 source = "remote"
-                             )
-                        )
+                        val songIdLong = song.id.toLongOrNull()
+                        if (songIdLong == null) {
+                            Log.w(TAG, "Cannot persist lyrics to DB: non-numeric Song.id '${song.id}'")
+                        } else {
+                            lyricsDao.insert(
+                                 com.theveloper.pixelplay.data.database.LyricsEntity(
+                                     songId = songIdLong,
+                                     content = rawLyricsToSave,
+                                     isSynced = !best.lyrics.synced.isNullOrEmpty(),
+                                     source = "remote"
+                                 )
+                            )
+                        }
                     } catch (e: NumberFormatException) {
                         Log.w(TAG, "Skipping DB update for non-numeric ID: ${song.id}")
                     }
@@ -1336,9 +1367,14 @@ class LyricsRepositoryImpl @Inject constructor(
                 }
 
                 try {
+                    val songIdLong = song.id.toLongOrNull()
+                    if (songIdLong == null) {
+                        Log.w(TAG, "Cannot persist lyrics to DB: non-numeric Song.id '${song.id}'")
+                        return@withContext Result.failure(LyricsException("Non-numeric Song.id"))
+                    }
                     lyricsDao.insert(
                         com.theveloper.pixelplay.data.database.LyricsEntity(
-                            songId = song.id.toLong(),
+                            songId = songIdLong,
                             content = rawLyricsToSave,
                             isSynced = !parsedLyrics.synced.isNullOrEmpty(),
                             source = "remote"
@@ -1352,7 +1388,7 @@ class LyricsRepositoryImpl @Inject constructor(
                 saveLocalLyricsJson(song, parsedLyrics)
                 LogUtils.d(this@LyricsRepositoryImpl, "Fetched and cached remote lyrics (exact match) for: ${song.title}")
 
-                Result.success(Pair(parsedLyrics, rawLyricsToSave))
+                return@withContext Result.success(Pair(parsedLyrics, rawLyricsToSave))
             } else {
                 LogUtils.d(this@LyricsRepositoryImpl, "No lyrics found remotely for: ${song.title}")
                 Result.failure(NoLyricsFoundException())
@@ -1388,6 +1424,24 @@ class LyricsRepositoryImpl @Inject constructor(
                     lrcLibApiService.searchLyrics(trackName = cleanTitle, artistName = cleanArtist)
                 })
                 
+                // Romanized search strategy for non-Latin titles
+                if (MultiLangRomanizer.isScriptThatNeedsRomanization(cleanTitle)) {
+                    val romanTitle = romanizeForMatch(cleanTitle)
+                    if (romanTitle != cleanTitle) {
+                        add(RemoteSearchStrategy("romanized_track") {
+                            lrcLibApiService.searchLyrics(trackName = romanTitle, artistName = cleanArtist)
+                        })
+                    }
+                }
+                if (MultiLangRomanizer.isScriptThatNeedsRomanization(cleanArtist)) {
+                    val romanArtist = romanizeForMatch(cleanArtist)
+                    if (romanArtist != cleanArtist) {
+                        add(RemoteSearchStrategy("romanized_artist") {
+                            lrcLibApiService.searchLyrics(trackName = cleanTitle, artistName = romanArtist)
+                        })
+                    }
+                }
+
                 // Smart title cleanup strategy
                 val smartTitle = cleanTitleSmart(cleanTitle)
                 if (smartTitle != cleanTitle && smartTitle.isNotBlank()) {
@@ -1535,7 +1589,9 @@ class LyricsRepositoryImpl @Inject constructor(
         // Also remove JSON cache
         try {
             val file = File(context.filesDir, "lyrics/${songId}.json")
-            if (file.exists()) file.delete()
+            if (file.exists() && !file.delete()) {
+                Log.w(TAG, "Failed to delete JSON cache for songId: $songId")
+            }
         } catch (e: Exception) {
             Log.w(TAG, "Error deleting JSON cache: ${e.message}")
         }
@@ -1613,8 +1669,8 @@ class LyricsRepositoryImpl @Inject constructor(
                                 
                                 // Strategy 2: Artist - Title
                                 if (foundFile == null) {
-                                    val cleanArtist = song.displayArtist.replace(Regex("[^a-zA-Z0-9]"), "_")
-                                    val cleanTitle = song.title.replace(Regex("[^a-zA-Z0-9]"), "_")
+                                    val cleanArtist = song.displayArtist.replace(Regex("[^\\p{L}\\p{N}]"), "_")
+                                    val cleanTitle = song.title.replace(Regex("[^\\p{L}\\p{N}]"), "_")
                                     for (extension in LyricsImportSecurity.supportedFileExtensions()) {
                                         val altMatch = File(directory, "${cleanArtist}_${cleanTitle}.$extension")
                                         if (altMatch.exists() && altMatch.canRead()) {
@@ -1628,14 +1684,19 @@ class LyricsRepositoryImpl @Inject constructor(
                                     val validated = readValidatedLocalLyrics(foundFile)
                                     if (validated != null) {
                                         try {
-                                            lyricsDao.insert(
-                                                 com.theveloper.pixelplay.data.database.LyricsEntity(
-                                                     songId = song.id.toLong(),
-                                                     content = validated.sanitizedContent,
-                                                     isSynced = validated.parsedLyrics.synced?.isNotEmpty() == true,
-                                                     source = "local_file"
-                                                 )
-                                            )
+                                            val songIdLong = song.id.toLongOrNull()
+                                            if (songIdLong == null) {
+                                                Log.w(TAG, "Cannot persist lyrics to DB: non-numeric Song.id '${song.id}'")
+                                            } else {
+                                                lyricsDao.insert(
+                                                     com.theveloper.pixelplay.data.database.LyricsEntity(
+                                                         songId = songIdLong,
+                                                         content = validated.sanitizedContent,
+                                                         isSynced = validated.parsedLyrics.synced?.isNotEmpty() == true,
+                                                         source = "local_file"
+                                                     )
+                                                )
+                                            }
                                             updatedCount.incrementAndGet()
                                             LogUtils.d(this@LyricsRepositoryImpl, "Auto-assigned lyrics from ${foundFile.name}")
                                         } catch (e: Exception) {
@@ -1710,6 +1771,8 @@ class LyricsRepositoryImpl @Inject constructor(
             MultiLangRomanizer.isJapanese(text) -> MultiLangRomanizer.romanizeJapanese(text) ?: text
             MultiLangRomanizer.isChinese(text) -> MultiLangRomanizer.romanizeChinese(text) ?: text
             MultiLangRomanizer.isKorean(text) -> MultiLangRomanizer.romanizeKorean(text)
+            MultiLangRomanizer.isCyrillic(text) -> MultiLangRomanizer.romanizeCyrillic(text) ?: text
+            MultiLangRomanizer.isVietnamese(text) -> MultiLangRomanizer.romanizeVietnamese(text)
             else -> text
         }
     }

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/LyricsSheet.kt
@@ -513,8 +513,11 @@ fun LyricsSheet(
         immersiveMode = false
     }
 
-    LaunchedEffect(currentSong, lyrics, isLoadingLyrics) {
-        if (currentSong != null && lyrics == null && !isLoadingLyrics) {
+    LaunchedEffect(currentSong, lyrics, isLoadingLyrics, lyricsSearchUiState) {
+        if (lyricsSearchUiState is LyricsSearchUiState.Success) {
+            // Search completed successfully — close the dialog
+            showFetchLyricsDialog = false
+        } else if (currentSong != null && lyrics == null && !isLoadingLyrics) {
             // Only show dialog if reset was not just triggered
             if (!wasResetTriggered) {
                 showFetchLyricsDialog = true

--- a/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/viewmodel/LyricsStateHolder.kt
@@ -344,22 +344,16 @@ class LyricsStateHolder @Inject constructor(
     fun translateLyricsViaAi(currentSong: Song, lyricsObj: Lyrics?, cb: LyricsTranslationCallbacks) {
         val songId = currentSong.id.toLongOrNull() ?: return
 
-        if (lyricsObj?.synced != null) {
-            val hasValidTranslation = lyricsObj.synced.any { !it.translation.isNullOrBlank() }
-            if (hasValidTranslation) {
-                _messageEvents.tryEmit(cb.getString(R.string.lyrics_translate_already_translated))
-                return
-            }
-        }
-
         scope?.launch {
             _messageEvents.emit(cb.getString(R.string.lyrics_translate_progress))
 
+            // Always read fresh lyrics from source — never rely on the potentially
+            // stale Lyrics object from UI state which may contain old translations.
             val rawLyrics = withContext(Dispatchers.IO) {
-                currentSong.lyrics?.takeIf { it.isNotBlank() }
-                    ?: readLocalLyricsFile(currentSong)
+                readLocalLyricsFile(currentSong)
                     ?: readEmbeddedLyricsFromFile(currentSong)
                     ?: musicRepository.getStoredLyrics(currentSong)?.second
+                    ?: currentSong.lyrics?.takeIf { it.isNotBlank() }
             }
 
             if (rawLyrics.isNullOrBlank()) {
@@ -428,17 +422,18 @@ class LyricsStateHolder @Inject constructor(
     }
 
     private fun readEmbeddedLyricsFromFile(song: Song): String? {
-        song.lyrics
-            ?.trim()
-            ?.takeIf { it.isNotBlank() }
-            ?.let { return it }
-
-        return runCatching {
+        val fileLyrics = runCatching {
             AudioMetadataReader.read(File(song.path))
                 ?.lyrics
                 ?.trim()
                 ?.takeIf { it.isNotBlank() }
         }.getOrNull()
+
+        if (fileLyrics != null) return fileLyrics
+
+        return song.lyrics
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
     }
 
     private fun readLocalLyricsFile(song: Song): String? {

--- a/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/utils/LyricsUtils.kt
@@ -48,6 +48,7 @@ import com.theveloper.pixelplay.data.model.SyncedLine
 import com.theveloper.pixelplay.data.model.SyncedWord
 import kotlinx.coroutines.flow.Flow
 
+import java.text.Normalizer
 import java.util.Locale
 import java.util.regex.Pattern
 import kotlin.math.PI
@@ -119,8 +120,17 @@ object MultiLangRomanizer {
     fun isPunjabi(text: String) = text.any { it in '\u0A00'..'\u0A7F' }
     fun isCyrillic(text: String) = text.any { it in '\u0400'..'\u04FF' }
     fun isChinese(text: String) = text.any { it in '\u4E00'..'\u9FFF' }
+    fun isThai(text: String) = text.any { it in '\u0E00'..'\u0E7F' }
+    fun isArabic(text: String) = text.any { it in '\u0600'..'\u06FF' }
+    fun isGreek(text: String) = text.any { it in '\u0370'..'\u03FF' }
+    fun isHebrew(text: String) = text.any { it in '\u0590'..'\u05FF' }
+    fun isVietnamese(text: String): Boolean {
+        return text.any { it in '\u1EA0'..'\u1EF9' } ||
+                text.any { it in "\u0102\u0103\u0110\u0111\u01A0\u01A1\u01AF\u01B0" }
+    }
 
     fun isScriptThatNeedsRomanization(text: String): Boolean {
+        if (isVietnamese(text) || isThai(text) || isArabic(text) || isGreek(text) || isHebrew(text)) return true
         return text.any { char ->
             val code = char.code
             code in 0x3040..0x309F || // Hiragana
@@ -133,8 +143,8 @@ object MultiLangRomanizer {
         }
     }
 
-    private fun isRussian(text: String) = text.any { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
-    private fun isUkrainian(text: String) = text.any { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
+    internal fun isRussian(text: String) = text.any { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { RUSSIAN_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
+    internal fun isUkrainian(text: String) = text.any { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { UKRAINIAN_CYRILLIC_LETTERS.contains(it.toString()) || UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
     private fun isSerbian(text: String) = text.any { SERBIAN_CYRILLIC_LETTERS.contains(it.toString()) || SERBIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { SERBIAN_CYRILLIC_LETTERS.contains(it.toString()) || SERBIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
     private fun isBulgarian(text: String) = text.any { BULGARIAN_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { BULGARIAN_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
     private fun isBelarusian(text: String) = text.any { BELARUSIAN_CYRILLIC_LETTERS.contains(it.toString()) || BELARUSIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) } && text.all { BELARUSIAN_CYRILLIC_LETTERS.contains(it.toString()) || BELARUSIAN_SPECIFIC_CYRILLIC_LETTERS.contains(it.toString()) || !it.toString().matches("[\\u0400-\\u04FF]".toRegex()) }
@@ -545,6 +555,22 @@ object MultiLangRomanizer {
             isMacedonian(text) -> processCyrillicWordByWord(text, MACEDONIAN_ROMAJI_MAP)
             else -> processCyrillicWordByWord(text, emptyMap())
         }
+    }
+
+    fun romanizeVietnamese(text: String): String {
+        if (text.isEmpty()) return text
+        val normalized = Normalizer.normalize(text, Normalizer.Form.NFKD)
+        val sb = StringBuilder(text.length)
+        for (char in normalized) {
+            when {
+                char == '\u0111' -> sb.append('d')
+                char == '\u0110' -> sb.append('D')
+                char in '\u0300'..'\u036F' || char in '\uFE20'..'\uFE2F' -> {}
+                char.code > 0x7E && char in '\u00C0'..'\u024F' -> {}
+                else -> sb.append(char)
+            }
+        }
+        return sb.toString()
     }
 
     private fun processCyrillicWordByWord(text: String, specificMap: Map<String, String>, isRussian: Boolean = false): String {


### PR DESCRIPTION
Fixes lyrics translation cutoff, false already-translated detection, search dialog stuck, non-Latin search handling, CJK token scaling, embedded lyrics reading, local .lrc Unicode matching, romanization detection, LyricsSheet UI improvements