### PR TITLE
fix(debug): add missing locale overrides for the [D] app name suffix

### DIFF
--- a/app/src/debug/res/values-ar/strings.xml
+++ b/app/src/debug/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>

--- a/app/src/debug/res/values-es/strings.xml
+++ b/app/src/debug/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>

--- a/app/src/debug/res/values-in/strings.xml
+++ b/app/src/debug/res/values-in/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>

--- a/app/src/debug/res/values-it/strings.xml
+++ b/app/src/debug/res/values-it/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>

--- a/app/src/debug/res/values-tr/strings.xml
+++ b/app/src/debug/res/values-tr/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>

--- a/app/src/debug/res/values-zh-rCN/strings.xml
+++ b/app/src/debug/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">PixelPlayer [D]</string>
+</resources>


### PR DESCRIPTION
The debug build type overrides `app_name` to "PixelPlayer [D]" so it's visually distinguishable from the release build once installed side by side. That override only exists for the `de`, `fr`, `ko`, `nb`, `ru` locales (plus the default bucket) under `app/src/debug/res/`.

However, `app/src/main/res/values-<locale>/strings.xml` also defines `app_name` (untranslated, same "PixelPlayer" value) for 11 locales: `ar, de, es, fr, in, it, ko, nb, ru, tr, zh-rCN`. Android resource resolution picks the most locale-specific match for the device's configuration — a locale-qualified resource always wins over a less-specific one, **regardless of which source set (main vs debug) contributed it**. So for the 6 locales debug never overrode (`ar, es, in, it, tr, zh-rCN`), a debug build silently falls back to `main`'s plain "PixelPlayer", losing the "[D]" indicator entirely.

Concretely: a debug build installed on a device set to Spanish (or Arabic, Indonesian, Italian, Turkish, Chinese) looks identical to the release build in the launcher — defeating the whole point of the override.

## Fix

Add the missing `app/src/debug/res/values-{ar,es,in,it,tr,zh-rCN}/strings.xml`, each overriding only `app_name` (mirroring the existing `de/fr/ko/nb/ru` files — no other strings touched).

## Testing

Verified on a real device set to `es-MX`: before the fix, the debug build showed "PixelPlayer" (no suffix); after, "PixelPlayer [D]". Also confirmed via `aapt2 dump badging` on the rebuilt debug APK that all 6 previously-broken locale labels now resolve to "PixelPlayer [D]".