### PR TITLE
fix: prevent home gesture from opening queue

### DIFF
--- a/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
+++ b/app/src/main/java/com/theveloper/pixelplay/presentation/components/player/FullPlayerContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.mandatorySystemGestures
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -261,7 +262,10 @@ fun FullPlayerContent(
     val isBluetoothEnabled = fullPlayerSlice.isBluetoothEnabled
     val bluetoothName = fullPlayerSlice.bluetoothName
     val navigationBarBottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-    val queueGestureBottomExclusion = maxOf(20.dp, navigationBarBottomInset + 8.dp)
+    val mandatoryGestureBottomInset =
+        WindowInsets.mandatorySystemGestures.asPaddingValues().calculateBottomPadding()
+    val queueGestureBottomExclusion =
+        maxOf(20.dp, navigationBarBottomInset, mandatoryGestureBottomInset) + 8.dp
     val queueGestureBottomExclusionPx = with(LocalDensity.current) {
         queueGestureBottomExclusion.toPx()
     }


### PR DESCRIPTION
## Summary

- include the mandatory system gesture inset in the queue swipe exclusion area
- prevent the Android Home swipe from also opening the Next Up sheet on gesture-navigation devices
- preserve queue swipe behavior above the system gesture area

## Context

This is a regression/follow-up to #1539. The issue is reproducible on PixelPlayer 0.7.5-beta with a Galaxy S24 running One UI 8 / Android 16. The existing exclusion only considers `WindowInsets.navigationBars`, which can be smaller than the mandatory Home gesture area on this configuration.

## Testing

- [x] Galaxy S24, One UI 8, Android 16: Home gesture no longer opens Next Up
- [x] Queue swipe still works above the system gesture area
- [ ] Automated Gradle verification (local Android SDK was unavailable in the terminal environment)